### PR TITLE
feat: add the `DraftValidation` class

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -29,7 +29,7 @@ jobs:
           pip install -e '.[dev]'
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-cov pytest-snapshot pandas polars ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0
+          pip install pytest pytest-cov pytest-snapshot pandas polars ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0 chatlas
       - name: pytest unit tests
         run: |
           make test

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -53,6 +53,8 @@ quartodoc:
         - name: Thresholds
         - name: Schema
           members: []
+        - name: DraftValidation
+          members: []
     - title: Validation Steps
       desc: >
         Validation steps can be thought of as sequential validations on the target data. We call

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -32,6 +32,7 @@ from pointblank.validate import (
 from pointblank.schema import Schema
 from pointblank.thresholds import Thresholds
 from pointblank.datascan import DataScan
+from pointblank.draft import DraftValidation
 
 __all__ = [
     "TF",
@@ -39,6 +40,7 @@ __all__ = [
     "Thresholds",
     "Schema",
     "DataScan",
+    "DraftValidation",
     "col",
     "starts_with",
     "ends_with",

--- a/pointblank/_constants.py
+++ b/pointblank/_constants.py
@@ -111,6 +111,11 @@ VALIDATION_REPORT_FIELDS = [
     "proc_duration_s",
 ]
 
+MODEL_PROVIDERS = [
+    "openai",
+    "anthropic",
+]
+
 TABLE_TYPE_STYLES = {
     "pandas": {"background": "#150458", "text": "#FFFFFF", "label": "Pandas"},
     "polars": {"background": "#0075FF", "text": "#FFFFFF", "label": "Polars"},

--- a/pointblank/_utils.py
+++ b/pointblank/_utils.py
@@ -509,11 +509,13 @@ def _get_api_text() -> str:
         "Validate.notify",
     ]
 
-    utilities_exported = [
-        "load_dataset",
+    inspect_exported = [
+        "DataScan",
         "preview",
+        "missing_vals_tbl",
         "get_column_count",
         "get_row_count",
+        "load_dataset",
         "config",
     ]
 
@@ -540,9 +542,12 @@ validation steps, (3) `interrogate()`. After interrogation of the data, we can v
 report table (by printing the object or using `get_tabular_report()`), extract key metrics, or we
 can split the data based on the validation results (with `get_sundered_data()`)."""
 
-    utilities_desc = """The utilities group contains functions that are helpful for the validation
-process. We can load datasets with `load_dataset()`, preview a table with `preview()`, and set
-global configuration parameters with `config()`."""
+    inspect_desc = """The *Inspect* group contains functions that are helpful for getting to grips
+on a new data table. Use the `DataScan` class to get a quick overview of the data, `preview()` to
+see the first and last few rows of a table, `missing_vals_tbl()` to see where there are missing
+values in a table, and `get_column_count()`/`get_row_count()` to get the number of columns and rows
+in a table. Several datasets included in the package can be accessed via the `load_dataset()`
+function. Finally, the `config()` utility lets us set global configuration parameters."""
 
     #
     # Add headings (`*_desc` text) and API details for each family of functions/methods
@@ -560,8 +565,8 @@ global configuration parameters with `config()`."""
     api_text += f"""\n## The Interrogation and Reporting family\n\n{interrogation_desc}\n\n"""
     api_text += get_api_details(module=pointblank, exported_list=interrogation_exported)
 
-    api_text += f"""\n## The Utilities family\n\n{utilities_desc}\n\n"""
-    api_text += get_api_details(module=pointblank, exported_list=utilities_exported)
+    api_text += f"""\n## The Utilities family\n\n{inspect_desc}\n\n"""
+    api_text += get_api_details(module=pointblank, exported_list=inspect_exported)
 
     # Modify language syntax in all code cells
     api_text = api_text.replace("{python}", "python")

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -39,8 +39,8 @@ class DataScan:
     text to a file, the `save_to_json()` method could be used.
 
     :::{.callout-warning}
-    The `DataScan()` class (along with its methods) is still experimental. Please report any issues
-    you encounter in the [Pointblank issue tracker](https://github.com/posit-dev/pointblank/issues).
+    The `DataScan()` class is still experimental. Please report any issues you encounter in the
+    [Pointblank issue tracker](https://github.com/posit-dev/pointblank/issues).
     :::
 
     Parameters

--- a/pointblank/draft.py
+++ b/pointblank/draft.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from narwhals.typing import FrameT
+from typing import Any
+
+from pointblank._constants import MODEL_PROVIDERS
+from pointblank.datascan import DataScan
+from pointblank._utils import _get_api_and_examples_text
+
+__all__ = [
+    "DraftValidation",
+]
+
+
+@dataclass
+class DraftValidation:
+    """
+    Draft a validation plan for a given table using an LLM.
+
+    By using a large language model (LLM) to draft a validation plan, you can quickly generate a
+    starting point for validating a table. This can be useful when you have a new table and you
+    want to get a sense of how to validate it (and adjustments could always be made later). The
+    `DraftValidation` class uses the `chatlas` package to draft a validation plan for a given table
+    using an LLM from either the `"anthropic"` or `"openai"` provider. You can install all
+    requirements for the class by using the optional install of Pointblank with `pip install
+    pointblank[generate]`.
+
+    :::{.callout-warning}
+    The `DraftValidation()` class is still experimental. Please report any issues you encounter in
+    the [Pointblank issue tracker](https://github.com/posit-dev/pointblank/issues).
+    :::
+
+    Parameters
+    ----------
+    data
+        The data to be used for drafting a validation plan.
+    model
+        The model to be used. This should be in the form of `provider:model` (e.g.,
+        `"anthropic:claude-3-5-sonnet-latest"`). Supported providers are `"anthropic"` and
+        `"openai"`.
+    api_key
+        The API key to be used for the model.
+
+    Returns
+    -------
+    str
+        The drafted validation plan.
+    """
+
+    data: FrameT | Any
+    model: str
+    api_key: str | None = None
+    response: str = field(init=False)
+
+    def __post_init__(self):
+
+        # Check that the chatlas package is installed
+        try:
+            import chatlas  # noqa
+        except ImportError:
+            raise ImportError(
+                "The `chatlas` package is required to use the `DraftValidation` class. "
+                "Please install it using `pip install chatlas`."
+            )
+
+        # Generate a table summary in JSON format using the `DataScan` class
+        tbl_json = DataScan(data=self.data).to_json()
+
+        # Get the LLM provider from the `model` value
+        provider = self.model.split(":")[0]
+
+        # Validate that the provider is supported
+        if provider not in MODEL_PROVIDERS:
+            raise ValueError(
+                f"Unsupported provider: {provider}. Supported providers are {MODEL_PROVIDERS}."
+            )
+
+        # Generate the API and examples text
+        api_and_examples_text = _get_api_and_examples_text()
+
+        # Get the model name from the `model` value
+        model_name = self.model.split(":")[1]
+
+        prompt = (
+            f"{api_and_examples_text}"
+            "--------------------------"
+            "Knowing what you now know about the pointblank package in Python, can you write a "
+            "thorough validation plan for the following table?"
+            "Here is the JSON summary for the table:"
+            " "
+            "```json"
+            f"{tbl_json}"
+            "```"
+            " "
+            "Provide a single piece of Python code for a validation plan that is contained in "
+            "```python + ``` code fences. Don't provide any text before or after this block. Use "
+            "the same style as in the provided examples."
+            " "
+            "Additional notes for this task:"
+            " "
+            "  - structure the code with the following parts: (1) `import pointblank as pb` at the "
+            "    top; (2) assign the schema to the variable `schema`, comment above should read "
+            "    # Define schema based on column names and dtypes; (3) provide the validation "
+            "    plan, comment above should read # The validation plan; (4) end with a single call "
+            "    of `validation`"
+            "  - the name of the dataset won't be known to you. Simply use the text your_data in "
+            "    the `data=` arg of the `Validate` class."
+            "  - use the text `Draft Validation` in the `label=` argument of `Validate`"
+            "  - don't use an invocation of the `load_dataset()` function anywhere, that is just "
+            "    for loading example datasets."
+            "  - avoid using the validation method `col_vals_regex()` since you are only provided "
+            "    with a very small set of strings."
+            "  - do use the `col_schema_match()` validation step along with a `Schema` invocation "
+            "    that gets the column names (`column_name` field) and the column types "
+            "    (`column_type` field) from the JSON summary for the table."
+            "  - when providing column types to `Schema` make sure it is taken *exactly* from the "
+            "    JSON summary; so don't use 'Datetime' when the `column_type` is"
+            "    'Datetime(time_unit='us', time_zone='UTC')'"
+            "  - note that the `col_vals_*()` validation methods do not work with anything other "
+            "    than numeric values (except `col_vals_regex()`, which is meant for text)"
+            "  - always use the `row_count_match()` and `column_count_match()` validation methods"
+            "  - if the number of `missing_values` for a column is `0` (provided in the JSON "
+            "    summary) then use the `col_vals_not_null()` validation method (and include all "
+            "    such columns) in the `columns=` arg"
+            "  - use the `rows_distinct()` validation method but don't supply anything to the "
+            "    `columns_subset=` arg"
+            "  - use a `col_vals_*()` validation method for a column only once; in other words "
+            "    don't have two validation steps where `col_vals_between()` is used for a "
+            "    particular column"
+            "  - when using the `col_vals_*()` methods that have the `na_pass=` argument, use "
+            "    `na_pass=True` when the JSON summary indicates that a column has a non-zero "
+            "    number of `missing_values`"
+            "  - when providing long lists of columns, use line breaks at `[` and `]`, this is so "
+            "    that the generated code isn't too wide (try to adhere to a 80 character limit "
+            "    per line)"
+        )
+
+        if provider == "anthropic":
+
+            # Check that the anthropic package is installed
+            try:
+                import anthropic  # noqa
+            except ImportError:
+                raise ImportError(
+                    "The `anthropic` package is required to use the `DraftValidation` class with "
+                    "the `anthropic` provider. Please install it using `pip install anthropic`."
+                )
+
+            from chatlas import ChatAnthropic
+
+            chat = ChatAnthropic(
+                model=model_name,
+                system_prompt="You are a terse assistant and a Python expert.",
+                api_key=self.api_key,
+            )
+
+        if provider == "openai":
+
+            # Check that the openai package is installed
+            try:
+                import openai  # noqa
+            except ImportError:
+                raise ImportError(
+                    "The `openai` package is required to use the `DraftValidation` class with the "
+                    "`openai` provider. Please install it using `pip install openai`."
+                )
+
+            from chatlas import ChatOpenAI
+
+            chat = ChatOpenAI(
+                model=model_name,
+                system_prompt="You are a terse assistant and a Python expert.",
+                api_key=self.api_key,
+            )
+
+        self.response = str(chat.chat(prompt, stream=False, echo="none"))
+
+    def __str__(self) -> str:
+        return self.response
+
+    def __repr__(self) -> str:
+        return self.response

--- a/pointblank/draft.py
+++ b/pointblank/draft.py
@@ -208,12 +208,12 @@ class DraftValidation:
             )
 
         # Generate the API and examples text
-        api_and_examples_text = _get_api_and_examples_text()
+        api_and_examples_text = _get_api_and_examples_text()  # pragma: no cover
 
         # Get the model name from the `model` value
-        model_name = self.model.split(":")[1]
+        model_name = self.model.split(":")[1]  # pragma: no cover
 
-        prompt = (
+        prompt = (  # pragma: no cover
             f"{api_and_examples_text}"
             "--------------------------"
             "Knowing what you now know about the pointblank package in Python, can you write a "
@@ -267,13 +267,13 @@ class DraftValidation:
             "    per line)"
         )
 
-        if provider == "anthropic":
+        if provider == "anthropic":  # pragma: no cover
 
             # Check that the anthropic package is installed
             try:
                 import anthropic  # noqa
-            except ImportError:
-                raise ImportError(
+            except ImportError:  # pragma: no cover
+                raise ImportError(  # pragma: no cover
                     "The `anthropic` package is required to use the `DraftValidation` class with "
                     "the `anthropic` provider. Please install it using `pip install anthropic`."
                 )
@@ -286,26 +286,26 @@ class DraftValidation:
                 api_key=self.api_key,
             )
 
-        if provider == "openai":
+        if provider == "openai":  # pragma: no cover
 
             # Check that the openai package is installed
             try:
                 import openai  # noqa
-            except ImportError:
-                raise ImportError(
+            except ImportError:  # pragma: no cover
+                raise ImportError(  # pragma: no cover
                     "The `openai` package is required to use the `DraftValidation` class with the "
                     "`openai` provider. Please install it using `pip install openai`."
                 )
 
-            from chatlas import ChatOpenAI
+            from chatlas import ChatOpenAI  # pragma: no cover
 
-            chat = ChatOpenAI(
+            chat = ChatOpenAI(  # pragma: no cover
                 model=model_name,
                 system_prompt="You are a terse assistant and a Python expert.",
                 api_key=self.api_key,
             )
 
-        self.response = str(chat.chat(prompt, stream=False, echo="none"))
+        self.response = str(chat.chat(prompt, stream=False, echo="none"))  # pragma: no cover
 
     def __str__(self) -> str:
         return self.response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ pd = [
 pl = [
     "polars>=1.17.1",
 ]
+generate = [
+    "chatlas>=0.3.0",
+    "anthropic>=0.45.2",
+    "openai>=1.63.0",
+]
 duckdb = [
     "ibis-framework[duckdb]>=9.5.0",
 ]

--- a/tests/test_draft.py
+++ b/tests/test_draft.py
@@ -1,0 +1,21 @@
+import sys
+
+import pytest
+from unittest.mock import patch
+
+from pointblank.validate import load_dataset
+from pointblank.draft import DraftValidation
+
+
+def test_draft_fail_no_chatlas():
+    with patch.dict(sys.modules, {"chatlas": None}):
+        with pytest.raises(ImportError):
+            DraftValidation(data="data", model="model")
+
+
+def test_draft_fail_invalid_provider():
+
+    small_table = load_dataset(dataset="small_table")
+
+    with pytest.raises(ValueError):
+        DraftValidation(data=small_table, model="invalid:model")


### PR DESCRIPTION
This adds `DraftValidation`, a class that can generate a validation plan based on any table that Pointblank supports. Example usage:

```python
import pointblank as pb

nycflights = pb.load_dataset("nycflights", tbl_type="duckdb")

pb.DraftValidation(data=nycflights, model="anthropic:claude-3-5-sonnet-latest")
```

This generates:

```python
import pointblank as pb

# Define schema based on column names and dtypes
schema = pb.Schema(columns=[
    ("year", "int64"), ("month", "int64"), ("day", "int64"),
    ("dep_time", "int64"), ("sched_dep_time", "int64"), ("dep_delay", "int64"),
    ("arr_time", "int64"), ("sched_arr_time", "int64"), ("arr_delay", "int64"),
    ("carrier", "string"), ("flight", "int64"), ("tailnum", "string"),
    ("origin", "string"), ("dest", "string"), ("air_time", "int64"),
    ("distance", "int64"), ("hour", "int64"), ("minute", "int64")
])

# The validation plan
validation = (
    pb.Validate(
        data=your_data,
        label="Draft Validation",
        thresholds=pb.Thresholds(warn_at=0.10, stop_at=0.25, notify_at=0.35)
    )
    .col_schema_match(schema=schema)
    .row_count_match(count=336776)
    .col_count_match(count=18)
    .rows_distinct()
    .col_vals_not_null(columns=[
        "year", "month", "day", "sched_dep_time", "sched_arr_time", 
        "carrier", "flight", "origin", "dest", "distance", "hour", "minute"
    ])
    .col_vals_eq(columns="year", value=2013)
    .col_vals_between(columns="month", left=1, right=12)
    .col_vals_between(columns="day", left=1, right=31) 
    .col_vals_between(columns="dep_time", left=1, right=2400, na_pass=True)
    .col_vals_between(columns="dep_delay", left=-43, right=1301, na_pass=True)
    .col_vals_between(columns="arr_time", left=1, right=2400, na_pass=True)
    .col_vals_between(columns="air_time", left=20, right=695, na_pass=True)
    .col_vals_between(columns="hour", left=1, right=23)
    .col_vals_between(columns="minute", left=0, right=59)
    .col_vals_gt(columns="distance", value=16)
    .col_vals_in_set(columns="origin", set=["EWR", "LGA", "JFK"])
    .interrogate()
)

validation
```

which, when run, is fully working and produces no failing test units:

<img width="643" alt="image" src="https://github.com/user-attachments/assets/64997f71-85c4-4f80-9f71-7dc65bdb3e90" />

Currently, this is lean on support for model providers (only Anthropic and OpenAI for now).