### PR TITLE
Add Explicit Assertion Method to `Validate` for Test Suites

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -127,6 +127,7 @@ quartodoc:
         - name: Validate.get_sundered_data
         - name: Validate.get_data_extracts
         - name: Validate.all_passed
+        - name: Validate.assert_passing
         - name: Validate.n
         - name: Validate.n_passed
         - name: Validate.n_failed

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5016,9 +5016,9 @@ class Validate:
         """
         Raise an `AssertionError` if all tests are not passing.
 
-        The `assert_passing()` method will raise an `AssertionError` if a test does not pass.
-        This method simply wraps `all_passed` for more ready use in test suites. The method
-        does not preserve information or the object itself, and must be further investigated.
+        The `assert_passing()` method will raise an `AssertionError` if a test does not pass. This
+        method simply wraps `all_passed` for more ready use in test suites. The method does not
+        preserve information or the object itself, and must be further investigated.
 
         Raises
         -------

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5012,6 +5012,51 @@ class Validate:
         """
         return all(validation.all_passed for validation in self.validation_info)
 
+    def assert_passing(self) -> None:
+        """
+        Raise an `AssertionError` if all tests are not passing.
+
+        The `assert_passing()` method will raise an `AssertionError` if a test does not pass.
+        This method simply wraps `all_passed` for more ready use in test suites. The method
+        does not preserve information or the object itself, and must be further investigated.
+
+        Raises
+        -------
+        AssertionError
+            If any validation step has failing test units.
+
+        Examples
+        --------
+        In the example below, we'll use a simple Polars DataFrame with three columns (`a`, `b`, and
+        `c`). There will be three validation steps, and the second step will have a failing test
+        unit (the value `10` isn't less than `9`). After interrogation, the `assert_passing()`
+        method is used to assert that all validation steps passed perfectly.
+
+        ```{python}
+
+        tbl = pl.DataFrame(
+            {
+            "a": [1, 2, 9, 5],
+            "b": [5, 6, 10, 3],
+            "c": ["a", "b", "a", "a"],
+            }
+        )
+
+        validation = (
+            pb.Validate(data=tbl)
+            .col_vals_gt(columns="a", value=0)
+            .col_vals_lt(columns="b", value=9)
+            .col_vals_in_set(columns="c", set=["a", "b"])
+            .interrogate()
+        )
+
+        validation.assert_passing()
+        ```
+        """
+        if not self.all_passed():
+            msg = "All tests did not pass."
+            raise AssertionError(msg)
+
     def n(self, i: int | list[int] | None = None, scalar: bool = False) -> dict[int, int] | int:
         """
         Provides a dictionary of the number of test units for each validation step.


### PR DESCRIPTION
I'm using this package in my professional life and find myself (and my teammates) frequently writing boilerplate to wrap the `all_passing` method to check if tests pass. I think a `assert_passing` method would be beneficial for 2 reasons:

1. It's simply less code than `assert v.all_passing(), msg`, especially when the message is standard and contains no special information to be surfaced. I'll admit it's nearly identical but I personally find it nice.
2. In the case where the message is more involved, having the message be generated by by the instance could save quite a bit of code. For example, if I need to surface what tests actually failed via the AssertionError's message, it would be nice to have it built in. However, I did not implement this, as it's only an idea, but I'd be happy to if you think it's worth pursuing. As a simple user I think it would be nice.

Let me know if you need any changes!