### PR TITLE
feat: Add ability to execute actions based on entering threshold levels

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -66,6 +66,7 @@ quartodoc:
         - name: Validate
           members: []
         - name: Thresholds
+        - name: Actions
         - name: Schema
           members: []
         - name: DraftValidation

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -30,7 +30,7 @@ from pointblank.validate import (
     get_row_count,
 )
 from pointblank.schema import Schema
-from pointblank.thresholds import Thresholds
+from pointblank.thresholds import Thresholds, Actions
 from pointblank.datascan import DataScan
 from pointblank.draft import DraftValidation
 
@@ -38,6 +38,7 @@ __all__ = [
     "TF",
     "Validate",
     "Thresholds",
+    "Actions",
     "Schema",
     "DataScan",
     "DraftValidation",

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -319,14 +319,14 @@ class Actions:
     Parameters
     ----------
     warn
-        A string, `Callable`, or list of `Callable` values for the 'warn' level. Using `None` means
-        no action should be performed at the 'warn' level.
-    stop
-        A string, `Callable`, or list of `Callable` values for the 'stop' level. Using `None` means
-        no action should be performed at the 'warn' level.
-    notify
-        A string, `Callable`, or list of `Callable` values for the 'notify' level. Using `None`
+        A string, `Callable`, or list of `Callable`/string values for the 'warn' level. Using `None`
         means no action should be performed at the 'warn' level.
+    stop
+        A string, `Callable`, or list of `Callable`/string values for the 'stop' level. Using `None`
+        means no action should be performed at the 'warn' level.
+    notify
+        A string, `Callable`, or list of `Callable`/string values for the 'notify' level. Using
+        `None` means no action should be performed at the 'warn' level.
 
     Returns
     -------
@@ -337,9 +337,23 @@ class Actions:
         are scoped to individual validation steps, overriding any globally set actions).
     """
 
-    warn: str | Callable | None = None
-    stop: str | Callable | None = None
-    notify: str | Callable | None = None
+    warn: str | Callable | list[str | Callable] | None = None
+    stop: str | Callable | list[str | Callable] | None = None
+    notify: str | Callable | list[str | Callable] | None = None
+
+    def __post_init__(self):
+        self.warn = self._ensure_list(self.warn)
+        self.stop = self._ensure_list(self.stop)
+        self.notify = self._ensure_list(self.notify)
+
+    def _ensure_list(
+        self, value: str | Callable | list[str | Callable] | None
+    ) -> list[str | Callable]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            return [value]
+        return value
 
     def __repr__(self) -> str:
         return f"Actions(warn={self.warn}, stop={self.stop}, notify={self.notify})"
@@ -347,5 +361,5 @@ class Actions:
     def __str__(self) -> str:
         return self.__repr__()
 
-    def _get_action(self, level: str) -> str | Callable | None:
+    def _get_action(self, level: str) -> list[str | Callable]:
         return getattr(self, level)

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -337,9 +337,9 @@ class Actions:
         are scoped to individual validation steps, overriding any globally set actions).
     """
 
-    warn: Callable | None = None
-    stop: Callable | None = None
-    notify: Callable | None = None
+    warn: str | Callable | None = None
+    stop: str | Callable | None = None
+    notify: str | Callable | None = None
 
     def __repr__(self) -> str:
         return f"Actions(warn={self.warn}, stop={self.stop}, notify={self.notify})"
@@ -347,5 +347,5 @@ class Actions:
     def __str__(self) -> str:
         return self.__repr__()
 
-    def _get_action(self, level: str) -> Callable | None:
+    def _get_action(self, level: str) -> str | Callable | None:
         return getattr(self, level)

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -350,7 +350,7 @@ class Actions:
         self, value: str | Callable | list[str | Callable] | None
     ) -> list[str | Callable]:
         if value is None:
-            return []
+            return None
         if not isinstance(value, list):
             return [value]
         return value

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -11,24 +11,32 @@ class Thresholds:
     """
     Definition of threshold values.
 
+    Thresholds are used to set limits on the number of failing test units at different levels. The
+    levels are 'warn', 'stop', and 'notify'. These levels correspond to different levels of
+    severity when a threshold is reached. The threshold values can be set as absolute counts or as
+    fractions of the total number of test units. When a threshold is reached, an action can be taken
+    (e.g., displaying a message or calling a function) if there is an associated action defined for
+    that level (defined through the [`Actions`](`pointblank.Actions`) class).
+
     Parameters
     ----------
     warn_at
         The threshold for the 'warn' level. This can be an absolute count or a fraction of the
-        total. Using `True` will set this threshold to 1.
+        total. Using `True` will set this threshold to `1`.
     stop_at
         The threshold for the 'stop' level. This can be an absolute count or a fraction of the
-        total. Using `True` will set this threshold to 1.
+        total. Using `True` will set this threshold to `1`.
     notify_at
         The threshold for the 'notify' level. This can be an absolute count or a fraction of the
-        total. Using `True` will set this threshold to 1.
+        total. Using `True` will set this threshold to `1`.
 
     Returns
     -------
     Thresholds
-        A Thresholds object. This can be used when using the `Validate` class (to set thresholds
-        globally) or when defining validation steps through `Validate`'s methods (so that threshold
-        values are scoped to individual validation steps, overriding any global thresholds).
+        A `Thresholds` object. This can be used when using the [`Validate`](`pointblank.Validate`)
+        class (to set thresholds globally) or when defining validation steps like
+        [`col_vals_gt()`](`pointblank.Validate.col_vals_gt`) (so that threshold values are scoped to
+        individual validation steps, overriding any global thresholds).
 
     Examples
     --------
@@ -65,7 +73,7 @@ class Thresholds:
     thresholds
     ```
 
-    The `Thresholds` object can be used to set global thresholds for all validation steps. Or, you
+    The `thresholds` object can be used to set global thresholds for all validation steps. Or, you
     can set thresholds for individual validation steps, which will override the global thresholds.
     Here's a data validation workflow example where we set global thresholds and then override with
     different thresholds at the [`col_vals_gt()`](`pointblank.Validate.col_vals_gt`) step:
@@ -87,7 +95,7 @@ class Thresholds:
 
     As can be seen, the last step ([`col_vals_gt()`](`pointblank.Validate.col_vals_gt`)) has its own
     thresholds, which override the global thresholds set at the beginning of the validation workflow
-    (in the `Validate` class).
+    (in the [`Validate`](`pointblank.Validate`) class).
     """
 
     warn_at: int | float | bool | None = None
@@ -297,25 +305,36 @@ class Actions:
     """
     Definition of action values.
 
+    Actions complement threshold values by defining what action should be taken when a threshold
+    level is reached. The action can be a string or a `Callable`. When a string is used, it is
+    interpreted as a message to be displayed. When a `Callable` is used, it will be invoked at
+    interrogation time if the threshold level is met or exceeded.
+
+    There are three threshold levels: 'warn', 'stop', and 'notify'. These levels correspond to
+    different levels of severity when a threshold is reached. Those thresholds can be defined using
+    the [`Thresholds`](`pointblank.Thresholds`) class or various shorthand forms. Actions don't have
+    to be defined for all threshold levels; if an action is not defined for a level in exceedence,
+    no action will be taken.
+
     Parameters
     ----------
     warn
-        A Callable (or list of Callable values) for the 'warn' level. Using `None` means that no
-        action is taken at the 'warn' level.
+        A string, `Callable`, or list of `Callable` values for the 'warn' level. Using `None` means
+        no action should be performed at the 'warn' level.
     stop
-        A Callable (or list thereof) for the 'stop' level. Using `None` means that no action is
-        taken at the 'stop' level.
+        A string, `Callable`, or list of `Callable` values for the 'stop' level. Using `None` means
+        no action should be performed at the 'warn' level.
     notify
-        A Callable (or list thereof)  for the 'notify' level. Using `None` means that no action is
-        taken at the 'notify' level.
+        A string, `Callable`, or list of `Callable` values for the 'notify' level. Using `None`
+        means no action should be performed at the 'warn' level.
 
     Returns
     -------
     Actions
-        An Actions object. This can be used when using the `Validate` class (to set actions for
-        meeting different threshold levels globally) or when defining validation steps through
-        `Validate`'s methods (so that action values are scoped to individual validation steps,
-        overriding any global actions).
+        An `Actions` object. This can be used when using the [`Validate`](`pointblank.Validate`)
+        class (to set actions for meeting different threshold levels globally) or when defining
+        validation steps like [`col_vals_gt()`](`pointblank.Validate.col_vals_gt`) (so that actions
+        are scoped to individual validation steps, overriding any globally set actions).
     """
 
     warn: Callable | None = None

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from typing import Callable
 from dataclasses import dataclass, field
 
-__all__ = ["Thresholds"]
+__all__ = ["Thresholds", "Actions"]
 
 
 @dataclass
@@ -289,3 +290,43 @@ def _threshold_check(failing_test_units: int, threshold: int | None) -> bool:
         return False
 
     return failing_test_units < threshold
+
+
+@dataclass
+class Actions:
+    """
+    Definition of action values.
+
+    Parameters
+    ----------
+    warn
+        A Callable (or list of Callable values) for the 'warn' level. Using `None` means that no
+        action is taken at the 'warn' level.
+    stop
+        A Callable (or list thereof) for the 'stop' level. Using `None` means that no action is
+        taken at the 'stop' level.
+    notify
+        A Callable (or list thereof)  for the 'notify' level. Using `None` means that no action is
+        taken at the 'notify' level.
+
+    Returns
+    -------
+    Actions
+        An Actions object. This can be used when using the `Validate` class (to set actions for
+        meeting different threshold levels globally) or when defining validation steps through
+        `Validate`'s methods (so that action values are scoped to individual validation steps,
+        overriding any global actions).
+    """
+
+    warn: Callable | None = None
+    stop: Callable | None = None
+    notify: Callable | None = None
+
+    def __repr__(self) -> str:
+        return f"Actions(warn={self.warn}, stop={self.stop}, notify={self.notify})"
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def _get_action(self, level: str) -> Callable | None:
+        return getattr(self, level)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -34,6 +34,7 @@ from pointblank.column import Column, col, ColumnSelector, ColumnSelectorNarwhal
 from pointblank.schema import Schema, _get_schema_validation_info
 from pointblank.thresholds import (
     Thresholds,
+    Actions,
     _normalize_thresholds_creation,
     _convert_abs_count_to_fraction,
 )
@@ -1536,6 +1537,8 @@ class _ValidationInfo:
         A pre-processing function or lambda to apply to the data table for the validation step.
     thresholds
         The threshold values for the validation.
+    actions
+        The actions to take if the validation fails.
     label
         A label for the validation step. Unused.
     brief
@@ -1584,6 +1587,7 @@ class _ValidationInfo:
     na_pass: bool | None = None
     pre: Callable | None = None
     thresholds: Thresholds | None = None
+    actions: Actions | None = None
     label: str | None = None
     brief: str | None = None
     active: bool | None = None
@@ -1656,6 +1660,10 @@ class Validate:
         input schemes: (1) single integer/float denoting absolute number or fraction of failing test
         units for the 'warn' level, (2) a tuple of 1-3 values, (3) a dictionary of 1-3 entries, or a
         [`Thresholds`](`pointblank.Thresholds`) object.
+    actions
+        The actions to take when validation steps meet or exceed any set threshold levels. This
+        should be provided in the form of an `Actions` object. If `None` then no default actions
+        will be set.
 
     Returns
     -------
@@ -1758,6 +1766,7 @@ class Validate:
     tbl_name: str | None = None
     label: str | None = None
     thresholds: int | float | bool | tuple | dict | Thresholds | None = None
+    actions: Actions | None = None
 
     def __post_init__(self):
 
@@ -1787,6 +1796,7 @@ class Validate:
         na_pass: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -1814,13 +1824,19 @@ class Validate:
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -1929,6 +1945,7 @@ class Validate:
                 na_pass=na_pass,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -1943,6 +1960,7 @@ class Validate:
         na_pass: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -1970,13 +1988,19 @@ class Validate:
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2084,6 +2108,7 @@ class Validate:
                 na_pass=na_pass,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -2098,6 +2123,7 @@ class Validate:
         na_pass: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -2125,13 +2151,19 @@ class Validate:
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2238,6 +2270,7 @@ class Validate:
                 na_pass=na_pass,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -2252,6 +2285,7 @@ class Validate:
         na_pass: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -2279,13 +2313,19 @@ class Validate:
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2390,6 +2430,7 @@ class Validate:
                 na_pass=na_pass,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -2404,6 +2445,7 @@ class Validate:
         na_pass: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -2431,13 +2473,19 @@ class Validate:
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2546,6 +2594,7 @@ class Validate:
                 na_pass=na_pass,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -2560,6 +2609,7 @@ class Validate:
         na_pass: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -2587,13 +2637,19 @@ class Validate:
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2702,6 +2758,7 @@ class Validate:
                 na_pass=na_pass,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -2718,6 +2775,7 @@ class Validate:
         na_pass: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -2754,13 +2812,19 @@ class Validate:
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2882,6 +2946,7 @@ class Validate:
                 na_pass=na_pass,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -2898,6 +2963,7 @@ class Validate:
         na_pass: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -2934,13 +3000,19 @@ class Validate:
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3065,6 +3137,7 @@ class Validate:
                 na_pass=na_pass,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -3078,6 +3151,7 @@ class Validate:
         set: list[float | int],
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -3098,13 +3172,19 @@ class Validate:
         set
             A list of values to compare against.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3205,6 +3285,7 @@ class Validate:
                 values=set,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -3218,6 +3299,7 @@ class Validate:
         set: list[float | int],
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -3238,13 +3320,19 @@ class Validate:
         set
             A list of values to compare against.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
 
@@ -3344,6 +3432,7 @@ class Validate:
                 values=set,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -3356,6 +3445,7 @@ class Validate:
         columns: str | list[str] | Column | ColumnSelector | ColumnSelectorNarwhals,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -3373,13 +3463,19 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3476,6 +3572,7 @@ class Validate:
                 column=column,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -3488,6 +3585,7 @@ class Validate:
         columns: str | list[str] | Column | ColumnSelector | ColumnSelectorNarwhals,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -3505,13 +3603,19 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3608,6 +3712,7 @@ class Validate:
                 column=column,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -3622,6 +3727,7 @@ class Validate:
         na_pass: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -3645,13 +3751,19 @@ class Validate:
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3753,6 +3865,7 @@ class Validate:
                 na_pass=na_pass,
                 pre=pre,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -3765,6 +3878,7 @@ class Validate:
         expr: any,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -3783,13 +3897,19 @@ class Validate:
             be a Polars column expression or a Narwhals one. For a Pandas DataFrame, the expression
             should either be a lambda expression or a Narwhals column expression.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step, so that the interrogation can
+            react accordingly when exceeding the set levels for different states ('warn', 'stop',
+            and 'notify'). This can be created using the [`Thresholds`](`pointblank.Thresholds`)
+            class or more simply as (1) an integer or float denoting the absolute number or fraction
+            of failing test units for the 'warn' level, (2) a tuple of 1-3 values, or (3) a
+            dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3863,6 +3983,7 @@ class Validate:
             values=expr,
             pre=pre,
             thresholds=thresholds,
+            actions=actions,
             active=active,
         )
 
@@ -3874,6 +3995,7 @@ class Validate:
         self,
         columns: str | list[str] | Column | ColumnSelector | ColumnSelectorNarwhals,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -3891,11 +4013,16 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step(s), so that the interrogation
+            can react accordingly when exceeding the set levels for different states ('warn',
+            'stop', and 'notify'). This can be created using the
+            [`Thresholds`](`pointblank.Thresholds`) class or more simply as (1) an integer or float
+            denoting the absolute number or fraction of failing test units for the 'warn' level, (2)
+            a tuple of 1-3 values, or (3) a dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step(s) meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3993,6 +4120,7 @@ class Validate:
                 column=column,
                 values=None,
                 thresholds=thresholds,
+                actions=actions,
                 active=active,
             )
 
@@ -4005,6 +4133,7 @@ class Validate:
         columns_subset: str | list[str] | None = None,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -4022,13 +4151,19 @@ class Validate:
             columns are supplied, the distinct comparison will be made over the combination of
             values in those columns.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step, so that the interrogation can
+            react accordingly when exceeding the set levels for different states ('warn', 'stop',
+            and 'notify'). This can be created using the [`Thresholds`](`pointblank.Thresholds`)
+            class or more simply as (1) an integer or float denoting the absolute number or fraction
+            of failing test units for the 'warn' level, (2) a tuple of 1-3 values, or (3) a
+            dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -4122,6 +4257,7 @@ class Validate:
             column=columns_subset,
             pre=pre,
             thresholds=thresholds,
+            actions=actions,
             active=active,
         )
 
@@ -4139,6 +4275,7 @@ class Validate:
         full_match_dtypes: bool = True,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -4177,13 +4314,19 @@ class Validate:
             substring matches are allowed, so a schema data type of `Int` would match a target table
             data type of `Int64`.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a `Thresholds` object.
+            Optional failure threshold levels for the validation step, so that the interrogation can
+            react accordingly when exceeding the set levels for different states ('warn', 'stop',
+            and 'notify'). This can be created using the [`Thresholds`](`pointblank.Thresholds`)
+            class or more simply as (1) an integer or float denoting the absolute number or fraction
+            of failing test units for the 'warn' level, (2) a tuple of 1-3 values, or (3) a
+            dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -4285,6 +4428,7 @@ class Validate:
             values=values,
             pre=pre,
             thresholds=thresholds,
+            actions=actions,
             active=active,
         )
 
@@ -4298,6 +4442,7 @@ class Validate:
         inverse: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -4321,13 +4466,19 @@ class Validate:
             Should the validation step be inverted? If `True`, then the expectation is that the row
             count of the target table should not match the specified `count=` value.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step, so that the interrogation can
+            react accordingly when exceeding the set levels for different states ('warn', 'stop',
+            and 'notify'). This can be created using the [`Thresholds`](`pointblank.Thresholds`)
+            class or more simply as (1) an integer or float denoting the absolute number or fraction
+            of failing test units for the 'warn' level, (2) a tuple of 1-3 values, or (3) a
+            dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -4400,6 +4551,7 @@ class Validate:
             values=values,
             pre=pre,
             thresholds=thresholds,
+            actions=actions,
             active=active,
         )
 
@@ -4413,6 +4565,7 @@ class Validate:
         inverse: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
+        actions: Actions | None = None,
         active: bool = True,
     ) -> Validate:
         """
@@ -4436,13 +4589,19 @@ class Validate:
             Should the validation step be inverted? If `True`, then the expectation is that the
             column count of the target table should not match the specified `count=` value.
         pre
-            A pre-processing function or lambda to apply to the data table for the validation step.
+            A optional pre-processing function or lambda to apply to the data table during
+            interrogation.
         thresholds
-            Failure threshold levels so that the validation step can react accordingly when
-            exceeding the set levels for different states (`warn`, `stop`, and `notify`). This can
-            be created simply as an integer or float denoting the absolute number or fraction of
-            failing test units for the 'warn' level. Otherwise, you can use a tuple of 1-3 values,
-            a dictionary of 1-3 entries, or a Thresholds object.
+            Optional failure threshold levels for the validation step, so that the interrogation can
+            react accordingly when exceeding the set levels for different states ('warn', 'stop',
+            and 'notify'). This can be created using the [`Thresholds`](`pointblank.Thresholds`)
+            class or more simply as (1) an integer or float denoting the absolute number or fraction
+            of failing test units for the 'warn' level, (2) a tuple of 1-3 values, or (3) a
+            dictionary of 1-3 entries.
+        actions
+            Optional actions to take when the validation step meets or exceeds any set threshold
+            levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
+            define the actions.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -4515,6 +4674,7 @@ class Validate:
             values=values,
             pre=pre,
             thresholds=thresholds,
+            actions=actions,
             active=active,
         )
 
@@ -4945,6 +5105,34 @@ class Validate:
             # is a boolean column that indicates whether the row passed the validation or not
             if collect_tbl_checked and results_tbl is not None:
                 validation.tbl_checked = results_tbl
+
+            # Perform any necessary actions if threshold levels are exceeded for each
+            # of the severity levels
+            # - `warn` is the threshold for a warning
+            # - `stop` is the threshold for stopping
+            # - `notify` is the threshold for notifying
+            for level in ["warn", "stop", "notify"]:
+                if getattr(validation, level) and (
+                    self.actions is not None or validation.actions is not None
+                ):
+
+                    #
+                    # If step-level actions are set, prefer those over actions set globally
+                    #
+
+                    if validation.actions is not None:
+
+                        # Action execution on the step level
+                        action = validation.actions._get_action(level=level)
+                        if action is not None:
+                            action()
+
+                    elif self.actions is not None:
+
+                        # Action execution on the global level
+                        action = self.actions._get_action(level=level)
+                        if action is not None:
+                            action()
 
             # If this is a row-based validation step, then extract the rows that failed
             # TODO: Add support for extraction of rows for Ibis backends

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5124,14 +5124,22 @@ class Validate:
 
                         # Action execution on the step level
                         action = validation.actions._get_action(level=level)
-                        if action is not None:
+                        if action is None:
+                            continue
+                        elif isinstance(action, str):
+                            print(action)
+                        elif callable(action):
                             action()
 
                     elif self.actions is not None:
 
                         # Action execution on the global level
                         action = self.actions._get_action(level=level)
-                        if action is not None:
+                        if action is None:
+                            continue
+                        elif isinstance(action, str):
+                            print(action)
+                        elif callable(action):
                             action()
 
             # If this is a row-based validation step, then extract the rows that failed

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5126,10 +5126,14 @@ class Validate:
                         action = validation.actions._get_action(level=level)
                         if action is None:
                             continue
-                        elif isinstance(action, str):
-                            print(action)
-                        elif callable(action):
-                            action()
+
+                        # A list of actions is expected here, so iterate over them
+                        if isinstance(action, list):
+                            for act in action:
+                                if isinstance(act, str):
+                                    print(act)
+                                elif callable(act):
+                                    act()
 
                     elif self.actions is not None:
 
@@ -5137,10 +5141,13 @@ class Validate:
                         action = self.actions._get_action(level=level)
                         if action is None:
                             continue
-                        elif isinstance(action, str):
-                            print(action)
-                        elif callable(action):
-                            action()
+
+                        if isinstance(action, list):
+                            for act in action:
+                                if isinstance(act, str):
+                                    print(act)
+                                elif callable(act):
+                                    act()
 
             # If this is a row-based validation step, then extract the rows that failed
             # TODO: Add support for extraction of rows for Ibis backends

--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -329,15 +329,15 @@ def test_actions_default():
 
     a = Actions()
 
-    assert a.warn == []
-    assert a.stop == []
-    assert a.notify == []
+    assert a.warn is None
+    assert a.stop is None
+    assert a.notify is None
 
 
 def test_actions_repr():
     a = Actions()
-    assert repr(a) == "Actions(warn=[], stop=[], notify=[])"
-    assert str(a) == "Actions(warn=[], stop=[], notify=[])"
+    assert repr(a) == "Actions(warn=None, stop=None, notify=None)"
+    assert str(a) == "Actions(warn=None, stop=None, notify=None)"
 
 
 def test_actions_str_inputs():

--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import pytest
+import re
 
 from pointblank.thresholds import (
     Thresholds,
+    Actions,
     _convert_abs_count_to_fraction,
     _normalize_thresholds_creation,
     _threshold_check,
@@ -321,3 +323,52 @@ def test_threshold_check():
     assert _threshold_check(failing_test_units=4, threshold=5) is True
     assert _threshold_check(failing_test_units=0, threshold=0) is False
     assert _threshold_check(failing_test_units=80, threshold=None) is False
+
+
+def test_actions_default():
+
+    a = Actions()
+
+    assert a.warn is None
+    assert a.stop is None
+    assert a.notify is None
+
+
+def test_actions_repr():
+    a = Actions()
+    assert repr(a) == "Actions(warn=None, stop=None, notify=None)"
+    assert str(a) == "Actions(warn=None, stop=None, notify=None)"
+
+
+def test_actions_str_inputs():
+
+    a = Actions(warn="warning", stop="stopping", notify="notifying")
+
+    assert a.warn == "warning"
+    assert a.stop == "stopping"
+    assert a.notify == "notifying"
+
+
+def test_actions_callable_inputs():
+
+    def warn():
+        return "warning"
+
+    def stop():
+        return "stopping"
+
+    def notify():
+        return "notifying"
+
+    a = Actions(warn=warn, stop=stop, notify=notify)
+
+    assert callable(a.warn)
+    assert callable(a.stop)
+    assert callable(a.notify)
+
+    assert a.warn() == "warning"
+    assert a.stop() == "stopping"
+    assert a.notify() == "notifying"
+
+    pattern = r"Actions\(warn=<function.*?>, stop=<function.*?>, notify=<function.*?>\)"
+    assert re.match(pattern, repr(a))

--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -372,3 +372,29 @@ def test_actions_callable_inputs():
 
     pattern = r"Actions\(warn=\[<function.*?>\], stop=\[<function.*?>\], notify=\[<function.*?>\]\)"
     assert re.match(pattern, repr(a))
+
+
+def test_actions_list_inputs():
+
+    def warn():
+        return "warning function"
+
+    def stop():
+        return "stopping function"
+
+    def notify():
+        return "notifying function"
+
+    a = Actions(warn=[warn, "warning string"], stop=["stopping string", stop], notify=[notify])
+
+    assert callable(a.warn[0])
+    assert isinstance(a.warn[1], str)
+    assert isinstance(a.stop[0], str)
+    assert callable(a.stop[1])
+    assert callable(a.notify[0])
+
+    assert a.warn[0]() == "warning function"
+    assert a.warn[1] == "warning string"
+    assert a.stop[0] == "stopping string"
+    assert a.stop[1]() == "stopping function"
+    assert a.notify[0]() == "notifying function"

--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -329,24 +329,24 @@ def test_actions_default():
 
     a = Actions()
 
-    assert a.warn is None
-    assert a.stop is None
-    assert a.notify is None
+    assert a.warn == []
+    assert a.stop == []
+    assert a.notify == []
 
 
 def test_actions_repr():
     a = Actions()
-    assert repr(a) == "Actions(warn=None, stop=None, notify=None)"
-    assert str(a) == "Actions(warn=None, stop=None, notify=None)"
+    assert repr(a) == "Actions(warn=[], stop=[], notify=[])"
+    assert str(a) == "Actions(warn=[], stop=[], notify=[])"
 
 
 def test_actions_str_inputs():
 
     a = Actions(warn="warning", stop="stopping", notify="notifying")
 
-    assert a.warn == "warning"
-    assert a.stop == "stopping"
-    assert a.notify == "notifying"
+    assert a.warn == ["warning"]
+    assert a.stop == ["stopping"]
+    assert a.notify == ["notifying"]
 
 
 def test_actions_callable_inputs():
@@ -362,13 +362,13 @@ def test_actions_callable_inputs():
 
     a = Actions(warn=warn, stop=stop, notify=notify)
 
-    assert callable(a.warn)
-    assert callable(a.stop)
-    assert callable(a.notify)
+    assert callable(a.warn[0])
+    assert callable(a.stop[0])
+    assert callable(a.notify[0])
 
-    assert a.warn() == "warning"
-    assert a.stop() == "stopping"
-    assert a.notify() == "notifying"
+    assert a.warn[0]() == "warning"
+    assert a.stop[0]() == "stopping"
+    assert a.notify[0]() == "notifying"
 
-    pattern = r"Actions\(warn=<function.*?>, stop=<function.*?>, notify=<function.*?>\)"
+    pattern = r"Actions\(warn=\[<function.*?>\], stop=\[<function.*?>\], notify=\[<function.*?>\]\)"
     assert re.match(pattern, repr(a))

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1103,6 +1103,93 @@ def test_validation_actions_multiple_actions_override(request, tbl_fixture, caps
     assert notification_index < notifier_index
 
 
+@pytest.mark.parametrize("tbl_fixture", TBL_LIST)
+def test_validation_actions_multiple_actions_step_only(request, tbl_fixture, capsys):
+
+    def notify_step():
+        print("NOTIFY STEP")
+
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    (
+        Validate(
+            data=tbl,
+            thresholds=Thresholds(warn_at=1, stop_at=2, notify_at=3),
+        )
+        .col_vals_gt(columns="x", value=10000, actions=Actions(notify=["step notify", notify_step]))
+        .interrogate()
+    )
+
+    # Capture the output and verify that "notification" was printed to the console
+    captured = capsys.readouterr()
+    assert "step notify" in captured.out
+    assert "NOTIFY STEP" in captured.out
+
+    # Verify that "step notify" is emitted before "NOTIFY STEP"
+    notification_index = captured.out.index("step notify")
+    notifier_index = captured.out.index("NOTIFY STEP")
+    assert notification_index < notifier_index
+
+
+@pytest.mark.parametrize("tbl_fixture", TBL_LIST)
+def test_validation_actions_inherit_none(request, tbl_fixture, capsys):
+
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    (
+        Validate(
+            data=tbl,
+            thresholds=Thresholds(warn_at=1, stop_at=2, notify_at=3),
+            actions=Actions(notify=None),
+        )
+        .col_vals_gt(columns="x", value=10000)
+        .interrogate()
+    )
+
+    # Capture the output and verify that nothing was printed to the console
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+@pytest.mark.parametrize("tbl_fixture", TBL_LIST)
+def test_validation_actions_override_none(request, tbl_fixture, capsys):
+
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    (
+        Validate(
+            data=tbl,
+            thresholds=Thresholds(warn_at=1, stop_at=2, notify_at=3),
+            actions=Actions(notify=None),
+        )
+        .col_vals_gt(columns="x", value=10000, actions=Actions(notify=None))
+        .interrogate()
+    )
+
+    # Capture the output and verify that nothing was printed to the console
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+@pytest.mark.parametrize("tbl_fixture", TBL_LIST)
+def test_validation_actions_step_only_none(request, tbl_fixture, capsys):
+
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    (
+        Validate(
+            data=tbl,
+            thresholds=Thresholds(warn_at=1, stop_at=2, notify_at=3),
+        )
+        .col_vals_gt(columns="x", value=10000, actions=Actions(notify=None))
+        .interrogate()
+    )
+
+    # Capture the output and verify that nothing was printed to the console
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
 def test_validation_with_preprocessing_pd(tbl_pd):
 
     v = (


### PR DESCRIPTION
This adds the `Actions` class and integration of actions in the `Validate` class, many validation methods that contain a `thresholds=` arg, and the `interrogate()` method. Providing input to `actions=` operates similarly to input provided to `thresholds=` (e.g., having local and global scope, with preference to local actions provided in validation methods). For now, the `Actions` parameters can accept a string (where the action is printing to the console) or a callable (which is executed). These are executed stepwise at interrogation time. 
