### PR TITLE
Add tolerance to row count match

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test-update:
 	pytest --snapshot-update
 
 test-coverage:
-	pytest --cov=pointblank --cov-report=term
+	pytest --cov=pointblank --cov-report=term-missing
 
 check:
 	pyright --pythonversion 3.8 pointblank

--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -1893,16 +1893,23 @@ class RowCountMatch:
     count: int
     inverse: bool
     threshold: int
+    tol : float = 0
     tbl_type: str = "local"
 
     def __post_init__(self):
 
         from pointblank.validate import get_row_count
 
-        if not self.inverse:
-            res = get_row_count(data=self.data_tbl) == self.count
+        row_count :int = get_row_count(data=self.data_tbl)
+        tol_as_raw : int = round(self.tol * row_count)
+
+        min_val : int = round(self.count - tol_as_raw)
+        max_val : int = round(self.count + tol_as_raw)
+
+        if self.inverse:
+            res : bool = not (row_count >= min_val and row_count <= max_val)
         else:
-            res = get_row_count(data=self.data_tbl) != self.count
+            res : bool = row_count >= min_val and row_count <= max_val
 
         self.test_unit_res = res
 

--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -1893,7 +1893,7 @@ class RowCountMatch:
     count: int
     inverse: bool
     threshold: int
-    tol : float = 0
+    tol : float | tuple[int, int] = 0
     tbl_type: str = "local"
 
     def __post_init__(self):
@@ -1901,10 +1901,18 @@ class RowCountMatch:
         from pointblank.validate import get_row_count
 
         row_count :int = get_row_count(data=self.data_tbl)
-        tol_as_raw : int = round(self.tol * row_count)
 
-        min_val : int = round(self.count - tol_as_raw)
-        max_val : int = round(self.count + tol_as_raw)
+        if isinstance(self.tol, tuple):
+            raw_lower_lim, raw_upper_lim = self.tol
+            min_val : int = self.count - raw_lower_lim
+            max_val : int = self.count + raw_upper_lim
+        else:
+            if self.tol > 1: # treat as literal row tolerance
+                tol_as_raw :int = self.tol
+            else:
+                tol_as_raw : int = round(self.tol * row_count)
+            min_val : int = round(self.count - tol_as_raw)
+            max_val : int = round(self.count + tol_as_raw)
 
         if self.inverse:
             res : bool = not (row_count >= min_val and row_count <= max_val)

--- a/pointblank/_typing.py
+++ b/pointblank/_typing.py
@@ -1,0 +1,11 @@
+
+from __future__ import annotations
+
+## Absolute bounds, ie. plus or minus
+type AbsoluteBounds = tuple[int, int]
+
+## Relative bounds, ie. plus or minus some percent
+type RelativeBounds = tuple[float, float]
+
+## Tolerance afforded to some check
+type Tolerance = int | float | AbsoluteBounds | RelativeBounds

--- a/pointblank/_utils.py
+++ b/pointblank/_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import inspect
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import narwhals as nw
 from narwhals.typing import FrameT
@@ -11,6 +11,13 @@ from great_tables import GT
 from great_tables.gt import _get_column_of_values
 
 from pointblank._constants import ASSERTION_TYPE_METHOD_MAP, GENERAL_COLUMN_TYPES
+
+if TYPE_CHECKING:
+    from pointblank._typing import AbsoluteBounds, Tolerance
+
+def _derive_bounds(ref : int, tol : Tolerance) -> AbsoluteBounds:
+    """Validate the integrity of a tolerance value."""
+    raise
 
 
 def _get_tbl_type(data: FrameT | Any) -> str:

--- a/pointblank/_utils.py
+++ b/pointblank/_utils.py
@@ -15,9 +15,21 @@ from pointblank._constants import ASSERTION_TYPE_METHOD_MAP, GENERAL_COLUMN_TYPE
 if TYPE_CHECKING:
     from pointblank._typing import AbsoluteBounds, Tolerance
 
-def _derive_bounds(ref : int, tol : Tolerance) -> AbsoluteBounds:
-    """Validate the integrity of a tolerance value."""
-    raise
+def _derive_single_bound(ref: int, tol : int | float) -> int:
+    """Derive a single bound using the reference."""
+    if not isinstance(tol, float | int):
+        raise TypeError("Tolerance must be a number or a tuple of numbers.")
+    if tol < 0:
+        raise ValueError("Tolerance must be non-negative.")
+    return int(tol * ref) if tol < 1 else int(tol)
+
+def _derive_bounds(ref: int, tol: Tolerance) -> AbsoluteBounds:
+    """Validate and extract the absolute bounds of the tolerance."""
+    if isinstance(tol, tuple):
+        return tuple(_derive_single_bound(ref, t) for t in tol)
+
+    bound = _derive_single_bound(ref, tol)
+    return bound, bound
 
 
 def _get_tbl_type(data: FrameT | Any) -> str:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -4706,28 +4706,10 @@ class Validate:
             count = get_row_count(count)
 
         # Check the integrity of tolerance
-        bounds: AbsoluteBounds = _derive_bounds(count)
-        if isinstance(tol, tuple):
-            for val in tol:
-                if not isinstance(val, int):
-                    msg = "Each element passed to `tol` must be an integer if defining upper and lower."
-                    raise TypeError(msg)
-                if val < 0:
-                    msg = (
-                        "If passing a tuple to `tol`, both bounds should be positive. Each limit is "
-                        "subtracted from the target, ie. (5, 5) means plus or minus 5."
-                    )
-                    raise ValueError(msg)
-        elif isinstance(tol, int | float):
-            if tol < 0:
-                msg = "Value passed to `tol` must be positive."
-                raise ValueError(msg)
-        else:
-            msg = f"`tol` must be a tuple of limits, int, or float, not {type(tol)!s}."
-            raise TypeError(msg)
+        bounds: AbsoluteBounds = _derive_bounds(ref = int(count), tol = tol)
 
         # Package up the `count=` and boolean params into a dictionary for later interrogation
-        values = {"count": count, "inverse": inverse, "abs_tol_bounds": abs_tol_bounds}
+        values = {"count": count, "inverse": inverse, "abs_tol_bounds": bounds}
 
         val_info = _ValidationInfo(
             assertion_type=assertion_type,
@@ -5225,7 +5207,7 @@ class Validate:
                     count=value["count"],
                     inverse=value["inverse"],
                     threshold=threshold,
-                    tol = value["tol"],
+                    abs_tol_bounds = value["abs_tol_bounds"],
                     tbl_type=tbl_type,
                 ).get_test_results()
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -4551,6 +4551,7 @@ class Validate:
     def row_count_match(
         self,
         count: int | FrameT | Any,
+        tol: float = 0,
         inverse: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
@@ -4660,7 +4661,7 @@ class Validate:
             count = get_row_count(count)
 
         # Package up the `count=` and boolean params into a dictionary for later interrogation
-        values = {"count": count, "inverse": inverse}
+        values = {"count": count, "inverse": inverse, "tol": tol}
 
         val_info = _ValidationInfo(
             assertion_type=assertion_type,
@@ -5158,6 +5159,7 @@ class Validate:
                     count=value["count"],
                     inverse=value["inverse"],
                     threshold=threshold,
+                    tol = value["tol"],
                     tbl_type=tbl_type,
                 ).get_test_results()
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -4663,18 +4663,22 @@ class Validate:
         # Check the integrity of tolerance
         if isinstance(tol, tuple):
             for val in tol:
+                if not isinstance(val, int):
+                    msg = "Each element passed to `tol` must be an integer if defining upper and lower."
+                    raise TypeError(msg)
                 if val < 0:
                     msg = (
                         "If passing a tuple to `tol`, both bounds should be positive. Each limit is "
                         "subtracted from the target, ie. (5, 5) means plus or minus 5."
                     )
                     raise ValueError(msg)
-                if not isinstance(val, int):
-                    msg = "Each element passed to `tol` must be an integer if defining upper and lower."
-                    raise ValueError(msg)
-        elif tol < 0:
-            msg = "Value passed to `tol` must be positive."
-            raise ValueError(tol)
+        elif isinstance(tol, int | float):
+            if tol < 0:
+                msg = "Value passed to `tol` must be positive."
+                raise ValueError(msg)
+        else:
+            msg = f"`tol` must be a tuple of limits, int, or float, not {type(tol)!s}."
+            raise TypeError(msg)
 
         # Package up the `count=` and boolean params into a dictionary for later interrogation
         values = {"count": count, "inverse": inverse, "tol": tol}

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -4576,6 +4576,14 @@ class Validate:
             The expected row count of the table. This can be an integer value, a Polars or Pandas
             DataFrame object, or an Ibis backend table. If a DataFrame/table is provided, the row
             count of that object will be used as the expected count.
+        tol
+            The tolerance allowable for the row count match. This can be specified as a single
+            numeric value (integer or float) or as a tuple of two integers representing the lower
+            and upper bounds of the tolerance range. If a single integer value (greater than 1) is
+            provided, it represents the absolute bounds of the tolerance, ie. plus or minus the value.
+            If a float value (between 0-1) is provided, it represents the relative tolerance, ie.
+            plus or minus the relative percentage of the target. If a tuple is provided, it represents
+            the lower and upper absolute bounds of the tolerance range. See the examples for more.
         inverse
             Should the validation step be inverted? If `True`, then the expectation is that the row
             count of the target table should not match the specified `count=` value.
@@ -4641,6 +4649,37 @@ class Validate:
 
         The validation table shows that the expectation value of `13` matches the actual count of
         rows in the target table. So, the single test unit passed.
+
+
+        Let's modify our example to show the different ways we can allow some tolerance to our validation
+        by using the `tol` argument.
+
+        ```{python}
+        smaller_small_table = small_table.sample(n = 12) # within the lower bound
+        validation = (
+            pb.Validate(data=smaller_small_table)
+            .row_count_match(count=13,tol=(2, 0)) # minus 2 but plus 0, ie. 11-13
+            .interrogate()
+        )
+
+        validation
+
+        validation = (
+            pb.Validate(data=smaller_small_table)
+            .row_count_match(count=13,tol=.05) # .05% tolerance of 13
+            .interrogate()
+        )
+
+        even_smaller_table = small_table.sample(n = 2)
+        validation = (
+            pb.Validate(data=even_smaller_table)
+            .row_count_match(count=13,tol=5) # plus or minus 5; this test will fail
+            .interrogate()
+        )
+
+        validation
+        ```
+
         """
 
         assertion_type = _get_fn_name()

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -64,6 +64,7 @@ from pointblank._utils import (
     _is_lib_present,
     _is_value_a_df,
     _select_df_lib,
+    _derive_bounds
 )
 from pointblank._utils_check_args import (
     _check_column,
@@ -74,6 +75,11 @@ from pointblank._utils_check_args import (
     _check_boolean_input,
 )
 from pointblank._utils_html import _create_table_type_html, _create_table_dims_html
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pointblank._typing import Tolerance, AbsoluteBounds
 
 __all__ = [
     "Validate",
@@ -4551,7 +4557,7 @@ class Validate:
     def row_count_match(
         self,
         count: int | FrameT | Any,
-        tol: float | tuple[int, int] = 0,
+        tol: Tolerance = 0,
         inverse: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
@@ -4700,6 +4706,7 @@ class Validate:
             count = get_row_count(count)
 
         # Check the integrity of tolerance
+        bounds: AbsoluteBounds = _derive_bounds(count)
         if isinstance(tol, tuple):
             for val in tol:
                 if not isinstance(val, int):
@@ -4720,7 +4727,7 @@ class Validate:
             raise TypeError(msg)
 
         # Package up the `count=` and boolean params into a dictionary for later interrogation
-        values = {"count": count, "inverse": inverse, "tol": tol}
+        values = {"count": count, "inverse": inverse, "abs_tol_bounds": abs_tol_bounds}
 
         val_info = _ValidationInfo(
             assertion_type=assertion_type,

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -4551,7 +4551,7 @@ class Validate:
     def row_count_match(
         self,
         count: int | FrameT | Any,
-        tol: float = 0,
+        tol: float | tuple[int, int] = 0,
         inverse: bool = False,
         pre: Callable | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
@@ -4659,6 +4659,22 @@ class Validate:
         # the expected count
         if _is_value_a_df(count) or "ibis.expr.types.relations.Table" in str(type(count)):
             count = get_row_count(count)
+
+        # Check the integrity of tolerance
+        if isinstance(tol, tuple):
+            for val in tol:
+                if val < 0:
+                    msg = (
+                        "If passing a tuple to `tol`, both bounds should be positive. Each limit is "
+                        "subtracted from the target, ie. (5, 5) means plus or minus 5."
+                    )
+                    raise ValueError(msg)
+                if not isinstance(val, int):
+                    msg = "Each element passed to `tol` must be an integer if defining upper and lower."
+                    raise ValueError(msg)
+        elif tol < 0:
+            msg = "Value passed to `tol` must be positive."
+            raise ValueError(tol)
 
         # Package up the `count=` and boolean params into a dictionary for later interrogation
         values = {"count": count, "inverse": inverse, "tol": tol}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,3 +122,8 @@ testpaths = [
 
 [tool.black]
 line-length = 100
+
+[tool.coverage.report]
+exclude_also = [
+    "if TYPE_CHECKING:"
+]

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2677,6 +2677,32 @@ def test_invalid_row_count_tol(val : float | tuple[int, int], e: Exception, exc 
         Validate(data=data).row_count_match(count = 3, tol=val)
 
 
+def test_row_count_example_tol() -> None:
+    small_table = load_dataset("small_table")
+    smaller_small_table = small_table.sample(n = 12) # within the lower bound
+    (
+        Validate(data=smaller_small_table)
+        .row_count_match(count=13,tol=(2, 0)) # minus 2 but plus 0, ie. 11-13
+        .interrogate()
+        .assert_passing()
+    )
+
+    (
+            Validate(data=smaller_small_table)
+            .row_count_match(count=13,tol=.05) # .05% tolerance of 13
+            .interrogate()
+            .assert_passing()
+        )
+
+    even_smaller_table = small_table.sample(n = 2)
+    with pytest.raises(AssertionError):
+        (
+            Validate(data=even_smaller_table)
+            .row_count_match(count=13,tol=5) # plus or minus 5; this test will fail
+            .interrogate()
+            .assert_passing()
+        )
+
 @pytest.mark.parametrize(('nrows','target_count','tol','should_pass'),
                          [
                             (98, 100, .05, True),

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,9 +5,9 @@ import sys
 import re
 from unittest.mock import patch
 import pytest
+import random
 import itertools
 from functools import partial
-import numpy as np
 import contextlib
 
 import pandas as pd
@@ -2669,9 +2669,7 @@ def test_row_count_match(request, tbl_fixture):
                             (98, 100, .95, True),
                          ])
 def test_row_count_tol(nrows : int, target_count: int, tol : float, should_pass : bool) -> None:
-
-    rng = np.random.default_rng()
-    data = pl.DataFrame({"foocol": rng.integers(0, 100, size = nrows)})
+    data = pl.DataFrame({"foocol": [random.random()] * nrows})
 
     catcher = contextlib.nullcontext if should_pass else partial(pytest.raises, AssertionError, match = "All tests did not pass")
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2661,6 +2661,22 @@ def test_row_count_match(request, tbl_fixture):
 
     assert Validate(tbl).row_count_match(count=tbl).interrogate().n_passed(i=1, scalar=True) == 1
 
+@pytest.mark.parametrize(('val','e', 'exc'),
+                         [
+                             ((-1, 5), ValueError, 'If passing a tuple to `tol`, both bounds should be positive. Each limit is'),
+                             ([100, 5], TypeError, '`tol` must be a tuple of limits'),
+                             ((5, -1), ValueError, 'If passing a tuple to `tol`, both bounds should be positive. Each limit is'),
+                             ((None, .05), TypeError, 'Each element passed to `tol` must be an integer if defining upper and lower'),
+                             (('fooval', 100), TypeError, 'Each element passed to `tol` must be an integer if defining upper and lower'),
+                             (-1, ValueError, 'Value passed to `tol` must be positive'),
+                         ])
+def test_invalid_row_count_tol(val : float | tuple[int, int], e: Exception, exc :str) -> None:
+    data = pl.DataFrame({"foocol": [1, 2, 3]})
+
+    with pytest.raises(expected_exception=e, match = exc):
+        Validate(data=data).row_count_match(count = 3, tol=val)
+
+
 @pytest.mark.parametrize(('nrows','target_count','tol','should_pass'),
                          [
                             (98, 100, .05, True),

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,3 +1,6 @@
+
+from __future__ import annotations
+
 import pathlib
 
 import pprint
@@ -47,6 +50,11 @@ from pointblank.column import (
     first_n,
     last_n,
 )
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 TBL_LIST = [
@@ -2663,14 +2671,14 @@ def test_row_count_match(request, tbl_fixture):
 
 @pytest.mark.parametrize(('val','e', 'exc'),
                          [
-                             ((-1, 5), ValueError, 'If passing a tuple to `tol`, both bounds should be positive. Each limit is'),
-                             ([100, 5], TypeError, '`tol` must be a tuple of limits'),
-                             ((5, -1), ValueError, 'If passing a tuple to `tol`, both bounds should be positive. Each limit is'),
-                             ((None, .05), TypeError, 'Each element passed to `tol` must be an integer if defining upper and lower'),
-                             (('fooval', 100), TypeError, 'Each element passed to `tol` must be an integer if defining upper and lower'),
-                             (-1, ValueError, 'Value passed to `tol` must be positive'),
+                             ((-1, 5), ValueError, 'Tolerance must be non-negative'),
+                             ([100, 5], TypeError, 'Tolerance must be a number or a tuple of numbers'),
+                             ((5, -1), ValueError, 'Tolerance must be non-negative'),
+                             ((None, .05), TypeError, 'Tolerance must be a number or a tuple of numbers'),
+                             (('fooval', 100), TypeError, 'Tolerance must be a number or a tuple of numbers'),
+                             (-1, ValueError, 'Tolerance must be non-negative'),
                          ])
-def test_invalid_row_count_tol(val : float | tuple[int, int], e: Exception, exc :str) -> None:
+def test_invalid_row_count_tol(val: Any, e: Exception, exc :str) -> None:
     data = pl.DataFrame({"foocol": [1, 2, 3]})
 
     with pytest.raises(expected_exception=e, match = exc):
@@ -2688,10 +2696,10 @@ def test_row_count_example_tol() -> None:
     )
 
     (
-            Validate(data=smaller_small_table)
-            .row_count_match(count=13,tol=.05) # .05% tolerance of 13
-            .interrogate()
-            .assert_passing()
+        Validate(data=smaller_small_table)
+        .row_count_match(count=13,tol=.5) # .50% tolerance of 13
+        .interrogate()
+        .assert_passing()
         )
 
     even_smaller_table = small_table.sample(n = 2)
@@ -2702,6 +2710,8 @@ def test_row_count_example_tol() -> None:
             .interrogate()
             .assert_passing()
         )
+
+test_row_count_example_tol()
 
 @pytest.mark.parametrize(('nrows','target_count','tol','should_pass'),
                          [

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2664,11 +2664,14 @@ def test_row_count_match(request, tbl_fixture):
 @pytest.mark.parametrize(('nrows','target_count','tol','should_pass'),
                          [
                             (98, 100, .05, True),
-                            (104, 100, .05, True),
+                            (98, 100, 5, True),
+                            (104, 100, (5, 5), True),
                             (0, 100, .05, False),
+                            (0, 100, 5, False),
+                            (0, 100, (5, 5), False),
                             (98, 100, .95, True),
                          ])
-def test_row_count_tol(nrows : int, target_count: int, tol : float, should_pass : bool) -> None:
+def test_row_count_tol(nrows : int, target_count: int, tol : float | tuple[int, int], should_pass : bool) -> None:
     data = pl.DataFrame({"foocol": [random.random()] * nrows})
 
     catcher = contextlib.nullcontext if should_pass else partial(pytest.raises, AssertionError, match = "All tests did not pass")


### PR DESCRIPTION
I added a tolerance to the row count match validation. It is useful for source data that is updating constantly or very large, ie. big time streaming data. I want the ability to allow for some tolerance.