### PR TITLE
WIP: Add a `.shiny` submodule (do not merge)

### DIFF
--- a/pointblank/shiny.py
+++ b/pointblank/shiny.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib
+from typing import Callable, Literal
+
+from htmltools import Tag, Tagifiable
+
+__all__ = (
+    "pb_server",
+    "pb_ui",
+)
+
+
+try:
+    importlib.import_module("polars")
+except ImportError:
+    raise ImportError(
+        "The point_blank.shiny module requires the polars package to be installed."
+        " Please install it with this command:"
+        "\n\n    pip install polars"
+    )
+
+try:
+    from great_tables import GT, loc, style
+    from great_tables.shiny import output_gt, render_gt
+except ImportError:
+    raise ImportError(
+        "The point_blank.shiny module requires the great_tables package to be installed."
+        " Please install it with this command:"
+        "\n\n    pip install great_tables"
+    )
+
+try:
+    from shiny import Inputs, Outputs, Session, module, reactive, render, ui
+except ImportError:
+    raise ImportError(
+        "The point_blank.shiny module requires the shiny package to be installed."
+        " Please install it with this command:"
+        "\n\n    pip install shiny"
+    )
+
+
+from .validate import Validate
+
+
+@module.ui
+def pb_ui(title: str | None = None) -> Tagifiable:
+    return ui.navset_card_underline(
+        ui.nav_panel("Data Preview", output_gt("data_table")),
+        ui.nav_panel("Overall Report", output_gt("report_table")),
+        ui.nav_panel(
+            "Individual Steps", ui.output_ui("ui_select_report_step"), output_gt("step_table")
+        ),
+        title=title,
+    )
+
+
+@module.server
+def pb_server(
+    user_in: Inputs,
+    output: Outputs,
+    session: Session,
+    validator: Callable[[], Validate],
+    display_table: Callable[[], GT] | None = None,
+):
+    @reactive.calc
+    def validation() -> Validate:
+        return validator().interrogate()
+
+    @reactive.calc
+    def step_choices() -> dict[Literal["Successes", "Failures"], dict[int, str]]:
+        n_failures = validation().n_failed()
+
+        choices = {
+            "Successes": {step: f"Step {step}" for step, n in n_failures.items() if n == 0},
+            "Failures": {
+                step: f"Step {step} ({n} failures)" for step, n in n_failures.items() if n > 0
+            },
+        }
+        return choices
+
+    @render_gt
+    def data_table() -> GT:
+        if display_table is not None:
+            return display_table()
+        else:
+            return (
+                GT(validation().data.head(10))
+                .tab_style(style.text(weight="bold"), loc.column_header())
+                .opt_stylize(style=1)
+            )
+
+    @render_gt
+    def report_table() -> GT:
+        return validation().get_tabular_report(title="MLRC Report")
+
+    @render.ui
+    def ui_select_report_step() -> Tag:
+        return ui.input_select(
+            "select_valid_step", "Select Validation Step", choices=step_choices()
+        )
+
+    @render_gt
+    def step_table() -> GT:
+        step = int(user_in.select_valid_step())
+        return validation().get_step_report(step)


### PR DESCRIPTION
# Summary

Here's the basic start on adding the `.shiny` submodule. Locally, I've created a little app similar (but better) to the one I posted in Discord. 

There's still a lot to do (namely tests and docs). The basic premise of the approach is this:

* Provide shiny "modules" so that users can easily plug pointblank's `GT` output into a shiny app
* User inputs to the server module include:
  * A reactive value/calc (callable) that returns a `pb.Validate` object. We `pointblank` will call `.interogate()` on it
  * An optional reactive value/calc (callable) that returns a `GT` instance to preview the data the way the user might want. If this isn't provided, we build a simple one ourselves:
  
 ```python
@module.server
def pb_server(
    user_in: Inputs,
    output: Outputs,
    session: Session,
    validator: Callable[[], Validate],
    display_table: Callable[[], GT] | None = None,
):
    ...

    @render_gt
    def data_table() -> GT:
        if display_table is not None:
            return display_table()
        else:
            return (
                GT(validation().data.head(10))
                .tab_style(style.text(weight="bold"), loc.column_header())
                .opt_stylize(style=1)
            )
```

I've included a brief app that demonstrates usage.

### Questions
1) I've never worked with Quarto and haven't yet tried to build the docs for pointblank. Will a Quarto doc with `server: shiny` work with the doc builds? More to the point, how would you like this documented?
2) For the example, do you have a preference for working with pandas over polars? Narwhals? I know the narwhals/great_tables/pointblank ecosystem is actively evolving. Looking ahead, what would you like to see here?
3) I'm sure I'll have more.

# Related GitHub Issues and PRs

None. Working based on this:
https://discord.com/channels/1345877328982446110/1346204992226197627/1346257619396067400

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality.
- [ ] I've written a `.qmd` example show casing the module's usage


![image](https://github.com/user-attachments/assets/3b2abff4-b031-447a-ac69-f58f60f0b920)


### Example App

<details> <summary>Click to see app source</summary>

```python
from great_tables import GT, data, loc, style
from shiny import App, reactive, ui

import pointblank as pb
from pointblank.shiny import pb_server, pb_ui

CARS_ID = "cars_validation"


app_ui = ui.page_fluid(
    ui.input_slider("num_rows", "Rows in Preview (GT Cars only)", 5, 50, 10, step=5),
    ui.navset_tab(
        ui.nav_panel(
            ui.h4("GT Cars Data"),
            ui.input_select("select_drivetrain", "Select Drivetrain Type", ["rwd", "awd"]),
            pb_ui(CARS_ID, title="GT Cars Data Validation"),
        ),
    ),
)


def server(user_in, output, session):
    @reactive.calc
    def car_data():
        drivetrain = user_in.select_drivetrain()
        return data.gtcars.assign(hp=lambda df: df["hp"]).loc[
            lambda df: df["drivetrain"] == drivetrain
        ]

    @reactive.calc
    def cars_validator() -> pb.Validate:
        schema = pb.Schema(
            columns=[
                ("mfr", "object"),
                ("model", "object"),
                ("year", "int64"),
                ("trim", "object"),
                ("bdy_style", "object"),
                ("hp", "float64"),
                ("hp_rpm", "float64"),
                ("trq", "float64"),
                ("trq_rpm", "float64"),
                ("mpg_c", "float64"),
                ("mpg_h", "float64"),
                ("drivetrain", "object"),
                ("trsmn", "object"),
                ("ctry_origin", "object"),
                ("msrp", "float64"),
            ]
        )
        valid = (
            pb.Validate(car_data(), thresholds=(0, 0, 0), label="Cars Validation")
            .col_schema_match(schema, complete=True)
            .col_vals_ge("hp", 0)
            .col_vals_ge("hp_rpm", 5500)
            .col_vals_in_set("bdy_style", ["coupe", "sedan", "convertible"])
            .col_vals_in_set("ctry_origin", ["Germany", "Italy", "United Kingdom", "United States"])
            .interrogate()
        )
        return valid

    @reactive.calc
    def cars_table() -> GT:
        return (
            GT(car_data().head(user_in.num_rows()).reset_index())
            .tab_style(style.text(weight="bold"), loc.column_header())
            .cols_hide("index")
            .fmt_currency("msrp", use_subunits=False)
            .cols_label(
                {
                    "mfr": "Make",
                    "model": "Model",
                    "year": "Year",
                    "trim": "Package",
                    "bdy_style": "Body",
                    "drivetrain": "Drivetrain",
                    "trsmn": "Transmission",
                    "ctry_origin": "Country",
                    "msrp": "MSRP",
                    "hp": "Power ({{hp}})",
                    "hp_rpm": "Engine Speed @ Max. Power ({{rev / min}})",
                    "trq": "Torque ({{ft-lbs}})",
                    "trq_rpm": "Engine Speed @ Max. Torque ({{rev / min}})",
                    "mpg_c": "City",
                    "mpg_h": "Highway",
                }
            )
            .opt_stylize()
        )

    _ = pb_server(
        CARS_ID,
        validator=cars_validator  # reactive calc that defines the validation,
        display_table=cars_table  # optional reactive calc that returns a GT of the dataset
)


app = App(app_ui, server)
```

</details>