### PR TITLE
feat: templating for `brief` and `Actions` text

### DIFF
--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -341,6 +341,28 @@ class Actions:
     If providing a list of strings or callables, each item in the list will be executed in order.
     Such a list can contain a mix of strings and callables.
 
+    String Templating
+    -----------------
+    When using a string as an action, you can include placeholders for the following variables:
+
+    - `{type}`: The validation step type where the action is executed (e.g., 'col_vals_gt',
+    'col_vals_lt', etc.)
+    - `{level}`: The threshold level where the action is executed ('warning', 'error', or
+    'critical')
+    - `{step}` or `{i}`: The step number in the validation workflow where the action is executed
+    - `{col}` or `{column}`: The column name where the action is executed
+    - `{val}` or `{value}`: An associated value for the validation method (e.g., the value to
+    compare against in a 'col_vals_gt' validation step)
+    - `{time}`: A datetime value for when the action was executed
+
+    The first two placeholders can also be used in uppercase (e.g., `{TYPE}` or `{LEVEL}`) and the
+    corresponding values will be displayed in uppercase. The placeholders are replaced with the
+    actual values during interrogation.
+
+    For example, the string `"{LEVEL}: '{type}' threshold exceeded for column {col}."` will be
+    displayed as `"WARNING: 'col_vals_gt' threshold exceeded for column a."` when the 'warning'
+    threshold is exceeded in a 'col_vals_gt' validation step involving column `a`.
+
     Examples
     --------
     ```{python}
@@ -361,7 +383,7 @@ class Actions:
         pb.Validate(
             data=pb.load_dataset(dataset="game_revenue", tbl_type="duckdb"),
             thresholds=pb.Thresholds(warning=0.05, error=0.10, critical=0.15),
-            actions=pb.Actions(critical="Major data quality issue found."),
+            actions=pb.Actions(critical="Major data quality issue found in step {step}."),
         )
         .col_vals_regex(columns="player_id", pattern=r"[A-Z]{12}\d{3}")
         .col_vals_gt(columns="item_revenue", value=0.05)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -7649,7 +7649,7 @@ def _normalize_reporting_language(lang: str | None) -> str:
     return lang.lower()
 
 
-def _process_brief(brief: str | None, step: int, col: str | None) -> str:
+def _process_brief(brief: str | None, step: int, col: str | list[str] | None) -> str:
     # If there is no brief, return `None`
     if brief is None:
         return None
@@ -7662,6 +7662,10 @@ def _process_brief(brief: str | None, step: int, col: str | None) -> str:
     # If a `col` value is available for the validation step *and* the brief contains a placeholder
     # for the column name then replace with `col`; placeholders are: {col} and {column}
     if col is not None:
+        # If a list of columns is provided, then join the columns into a comma-separated string
+        if isinstance(col, list):
+            col = ", ".join(col)
+
         brief = brief.replace("{col}", col)
         brief = brief.replace("{column}", col)
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -1838,8 +1838,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2006,8 +2006,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2173,8 +2173,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2339,8 +2339,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2503,8 +2503,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2671,8 +2671,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -2850,8 +2850,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3042,8 +3042,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3218,8 +3218,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3370,8 +3370,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
 
@@ -3517,8 +3517,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3661,8 +3661,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3813,8 +3813,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -3963,8 +3963,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -4081,8 +4081,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -4226,8 +4226,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -4394,8 +4394,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -4560,8 +4560,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes
@@ -4722,8 +4722,8 @@ class Validate:
             levels. If provided, the [`Actions`](`pointblank.Actions`) class should be used to
             define the actions.
         brief
-            An optional brief description of the validation step. If not provided, a brief will be
-            automatically generated.
+            An optional brief description of the validation step. The templating elements `"{col}"`
+            and `"{step}"` can be used to insert the column name and step number, respectively.
         active
             A boolean value indicating whether the validation step should be active. Using `False`
             will make the validation step inactive (still reporting its presence and keeping indexes

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -4952,6 +4952,10 @@ class Validate:
             assertion_category = METHOD_CATEGORY_MAP[assertion_method]
             compatible_dtypes = COMPATIBLE_DTYPES.get(assertion_method, [])
 
+            # Process the `brief` text for the validation step by including template variables to
+            # the user-supplied text
+            validation.brief = _process_brief(brief=validation.brief, step=validation.i, col=column)
+
             # Generate the autobrief description for the validation step; it's important to perform
             # that here since text components like the column and the value(s) have been resolved
             # at this point
@@ -7630,6 +7634,25 @@ def _normalize_reporting_language(lang: str | None) -> str:
         )
 
     return lang.lower()
+
+
+def _process_brief(brief: str | None, step: int, col: str | None) -> str:
+    # If there is no brief, return `None`
+    if brief is None:
+        return None
+
+    # If the brief contains a placeholder for the step number then replace with `step`;
+    # placeholders are: {step} and {i}
+    brief = brief.replace("{step}", str(step))
+    brief = brief.replace("{i}", str(step))
+
+    # If a `col` value is available for the validation step *and* the brief contains a placeholder
+    # for the column name then replace with `col`; placeholders are: {col} and {column}
+    if col is not None:
+        brief = brief.replace("{col}", col)
+        brief = brief.replace("{column}", col)
+
+    return brief
 
 
 def _create_autobrief(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1040,6 +1040,92 @@ def test_validation_check_thresholds_inherit(request, tbl_fixture):
 
 
 @pytest.mark.parametrize("tbl_fixture", TBL_LIST)
+def test_validation_briefs(request, tbl_fixture):
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    schema = Schema(columns=["x", "y", "z"])
+    brief_text = "Check of column `{col}`. Step {step}"
+
+    # Perform every type of validation step and provide templated briefs for each
+    v = (
+        Validate(tbl)
+        .col_vals_gt(columns="x", value=0, brief=brief_text)
+        .col_vals_lt(columns="x", value=2, brief=brief_text)
+        .col_vals_eq(columns="z", value=4, brief=brief_text)
+        .col_vals_ne(columns="z", value=6, brief=brief_text)
+        .col_vals_ge(columns="z", value=8, brief=brief_text)
+        .col_vals_le(columns="z", value=10, brief=brief_text)
+        .col_vals_between(columns="x", left=0, right=5, brief=brief_text)
+        .col_vals_outside(columns="x", left=-5, right=0, brief=brief_text)
+        .col_vals_in_set(columns="x", set=[1, 2], brief=brief_text)
+        .col_vals_not_in_set(columns="x", set=[1, 2], brief=brief_text)
+        .col_vals_null(columns="x", brief=brief_text)
+        .col_vals_not_null(columns="x", brief=brief_text)
+        .col_exists(columns="x", brief=brief_text)
+        .rows_distinct(brief=brief_text)
+        .rows_distinct(columns_subset=["x", "y"], brief=brief_text)
+        .col_schema_match(schema=schema, brief=brief_text)
+        .row_count_match(count=5, brief=brief_text)
+        .col_count_match(count=3, brief=brief_text)
+        .interrogate()
+    )
+
+    # `col_vals_gt()`
+    assert v.validation_info[0].brief == "Check of column `x`. Step 1"
+
+    # `col_vals_lt()`
+    assert v.validation_info[1].brief == "Check of column `x`. Step 2"
+
+    # `col_vals_eq()`
+    assert v.validation_info[2].brief == "Check of column `z`. Step 3"
+
+    # `col_vals_ne()`
+    assert v.validation_info[3].brief == "Check of column `z`. Step 4"
+
+    # `col_vals_ge()`
+    assert v.validation_info[4].brief == "Check of column `z`. Step 5"
+
+    # `col_vals_le()`
+    assert v.validation_info[5].brief == "Check of column `z`. Step 6"
+
+    # `col_vals_between()`
+    assert v.validation_info[6].brief == "Check of column `x`. Step 7"
+
+    # `col_vals_outside()`
+    assert v.validation_info[7].brief == "Check of column `x`. Step 8"
+
+    # `col_vals_in_set()`
+    assert v.validation_info[8].brief == "Check of column `x`. Step 9"
+
+    # `col_vals_not_in_set()`
+    assert v.validation_info[9].brief == "Check of column `x`. Step 10"
+
+    # `col_vals_null()`
+    assert v.validation_info[10].brief == "Check of column `x`. Step 11"
+
+    # `col_vals_not_null()`
+    assert v.validation_info[11].brief == "Check of column `x`. Step 12"
+
+    # `col_exists()`
+    assert v.validation_info[12].brief == "Check of column `x`. Step 13"
+
+    # `rows_distinct()`
+    assert v.validation_info[13].brief == "Check of column `{col}`. Step 14"
+
+    # `rows_distinct()` - subset of columns
+    assert v.validation_info[14].brief == "Check of column `x, y`. Step 15"
+
+    # `col_schema_match()`
+    assert v.validation_info[15].brief == "Check of column `{col}`. Step 16"
+
+    # `row_count_match()`
+    assert v.validation_info[16].brief == "Check of column `{col}`. Step 17"
+
+    # `col_count_match()`
+    assert v.validation_info[17].brief == "Check of column `{col}`. Step 18"
+
+
+@pytest.mark.parametrize("tbl_fixture", TBL_LIST)
 def test_validation_autobriefs(request, tbl_fixture):
     tbl = request.getfixturevalue(tbl_fixture)
 


### PR DESCRIPTION
This PR adds the ability to use templating variables for strings passed to the `brief=` argument, available in all validation methods. If using a string as a value when calling `Actions`, that string could use an expanded set of templating variables (six in total). Documentation has been added to explain which vars can be used for `brief=` and within `Actions`.