### PR TITLE
convert set items to strings to get_step_report

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8446,7 +8446,7 @@ def _step_report_row_based(
         symbol_right = "&gt;" if inclusive[1] else "&ge;"
         text = f"<code style='color: #303030; font-family: monospace; font-size: smaller;'>{column} {symbol_left} {values[0]}, {column} {symbol_right} {values[1]}</code>"
     elif assertion_type == "col_vals_in_set":
-        elements = ", ".join(values)
+        elements = ", ".join(map(str, values))
         text = f"<code style='color: #303030; font-family: monospace; font-size: smaller;'>{column} &isinv; {{{elements}}}</code>"
     elif assertion_type == "col_vals_not_in_set":
         elements = ", ".join(values)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5442,6 +5442,7 @@ def test_get_step_report_no_fail(tbl_type):
         .col_vals_ge(columns="d", value=500)
         .col_vals_between(columns="a", left=2, right=10)
         .col_vals_outside(columns="a", left=7, right=20)
+        .col_vals_in_set(columns="a", set=[1, 2, 3, 4, 5])
         .col_vals_in_set(columns="f", set=["low", "mid", "high"])
         .col_vals_not_in_set(columns="f", set=["l", "mid", "m"])
         .col_vals_null(columns="b")


### PR DESCRIPTION
closes #79

# Summary

Small change to ensure that integers and floats can be displayed as a `set` in the step report for a `.col_vals_in_set` step.

# Related GitHub Issues and PRs

- Ref: #79

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
