### PR TITLE
feat: improve appearance of `col_summary_tbl()` report table

### DIFF
--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -919,10 +919,12 @@ def _compact_decimal_fmt(value: float | int) -> str:
         formatted = fmt_number(value, decimals=2)[0]
     elif abs(value) < 0.01:
         formatted = fmt_scientific(value, decimals=1, exp_style="E1")[0]
-    elif abs(value) >= 1 and abs(value) < 1000:
+    elif abs(value) >= 1 and abs(value) < 10:
+        formatted = fmt_number(value, decimals=2, use_seps=False)[0]
+    elif abs(value) >= 10 and abs(value) < 1000:
         formatted = fmt_number(value, n_sigfig=3)[0]
     elif abs(value) >= 1000 and abs(value) < 10_000:
-        formatted = fmt_number(value, decimals=0, use_seps=False)[0]
+        formatted = fmt_number(value, n_sigfig=4, use_seps=False)[0]
     else:
         formatted = fmt_scientific(value, decimals=1, exp_style="E1")[0]
 

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -750,8 +750,8 @@ class DataScan:
                 column_number="",
                 icon="",
                 column_name="Column",
-                missing_vals="NAs",
-                unique_vals="Uniq.",
+                missing_vals="NA",
+                unique_vals="UQ",
                 mean="Mean",
                 std_dev="SD",
                 min="Min",
@@ -953,8 +953,8 @@ def _process_numerical_column_data(column_data: dict) -> dict:
     # Get the Missing and Unique value counts and fractions
     missing_vals = column_data["n_missing_values"]
     unique_vals = column_data["n_unique_values"]
-    missing_vals_frac = _compact_decimal_fmt(column_data["f_missing_values"])
-    unique_vals_frac = _compact_decimal_fmt(column_data["f_unique_values"])
+    missing_vals_frac = _compact_0_1_fmt(column_data["f_missing_values"])
+    unique_vals_frac = _compact_0_1_fmt(column_data["f_unique_values"])
 
     missing_vals_str = f"{missing_vals}<br>{missing_vals_frac}"
     unique_vals_str = f"{unique_vals}<br>{unique_vals_frac}"
@@ -1019,8 +1019,8 @@ def _process_string_column_data(column_data: dict) -> dict:
     # Get the Missing and Unique value counts and fractions
     missing_vals = column_data["n_missing_values"]
     unique_vals = column_data["n_unique_values"]
-    missing_vals_frac = _compact_decimal_fmt(column_data["f_missing_values"])
-    unique_vals_frac = _compact_decimal_fmt(column_data["f_unique_values"])
+    missing_vals_frac = _compact_0_1_fmt(column_data["f_missing_values"])
+    unique_vals_frac = _compact_0_1_fmt(column_data["f_unique_values"])
 
     missing_vals_str = f"{missing_vals}<br>{missing_vals_frac}"
     unique_vals_str = f"{unique_vals}<br>{unique_vals_frac}"
@@ -1054,14 +1054,18 @@ def _process_string_column_data(column_data: dict) -> dict:
     for key, value in descriptive_stats.items():
         formatted_val = _compact_decimal_fmt(value=value)
         descriptive_stats[key] = (
-            f'<div><div>{formatted_val}</div><div style="float: left; position: absolute;"><div title="String Lengths" style="font-size: 7px; color: #999; font-style: italic;">SL</div></div></div>'
+            f'<div><div>{formatted_val}</div><div style="float: left; position: absolute;">'
+            '<div title="string length measure" style="font-size: 7px; color: #999; '
+            'font-style: italic; cursor: help;">SL</div></div></div>'
         )
 
     # Format the quantile statistics
     for key, value in quantile_stats.items():
         formatted_val = q_formatter(value=value)
         quantile_stats[key] = (
-            f'<div><div>{formatted_val}</div><div style="float: left; position: absolute;"><div title="String Lengths" style="font-size: 7px; color: #999; font-style: italic;">SL</div></div></div>'
+            f'<div><div>{formatted_val}</div><div style="float: left; position: absolute;">'
+            '<div title="string length measure" style="font-size: 7px; color: #999; '
+            'font-style: italic; cursor: help;">SL</div></div></div>'
         )
 
     # Create a single dictionary with the statistics for the column
@@ -1105,8 +1109,8 @@ def _process_datetime_column_data(column_data: dict) -> dict:
     # Get the Missing and Unique value counts and fractions
     missing_vals = column_data["n_missing_values"]
     unique_vals = column_data["n_unique_values"]
-    missing_vals_frac = _compact_decimal_fmt(column_data["f_missing_values"])
-    unique_vals_frac = _compact_decimal_fmt(column_data["f_unique_values"])
+    missing_vals_frac = _compact_0_1_fmt(column_data["f_missing_values"])
+    unique_vals_frac = _compact_0_1_fmt(column_data["f_unique_values"])
 
     missing_vals_str = f"{missing_vals}<br>{missing_vals_frac}"
     unique_vals_str = f"{unique_vals}<br>{unique_vals_frac}"
@@ -1150,9 +1154,9 @@ def _process_boolean_column_data(column_data: dict) -> dict:
         f"<div style='font-size: 11px; color: gray;'>{column_type}</div>"
     )
 
-    # Get the Missing and Unique value counts and fractions
+    # Get the missing value count and fraction
     missing_vals = column_data["n_missing_values"]
-    missing_vals_frac = _compact_decimal_fmt(column_data["f_missing_values"])
+    missing_vals_frac = _compact_0_1_fmt(column_data["f_missing_values"])
     missing_vals_str = f"{missing_vals}<br>{missing_vals_frac}"
 
     # Get the fractions of True and False values
@@ -1162,10 +1166,12 @@ def _process_boolean_column_data(column_data: dict) -> dict:
     true_vals_frac_fmt = _compact_0_1_fmt(f_true_values)
     false_vals_frac_fmt = _compact_0_1_fmt(f_false_values)
 
-    # Create an HTML string that combines fractions for the True and False values
-    true_false_vals_str = f"<span style='font-weight: bold;'>T</span>{true_vals_frac_fmt}<br><span style='font-weight: bold;'>F</span>{false_vals_frac_fmt}"
-
-    # unique_vals_str = f"{unique_vals}<br>{unique_vals_frac}"
+    # Create an HTML string that combines fractions for the True and False values; this will be
+    # used in the Unique Vals column of the report table
+    true_false_vals_str = (
+        f"<span style='font-weight: bold;'>T</span>{true_vals_frac_fmt}<br>"
+        f"<span style='font-weight: bold;'>F</span>{false_vals_frac_fmt}"
+    )
 
     # Create a single dictionary with the statistics for the column
     stats_dict = {

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -724,13 +724,11 @@ class DataScan:
             )
             .tab_style(
                 style=style.borders(sides="left", color="#D3D3D3", style="solid"),
-                locations=loc.body(columns=["missing_vals", "mean", "iqr"]),
+                locations=loc.body(columns=["missing_vals", "mean", "min", "iqr"]),
             )
             .tab_style(
                 style=style.borders(sides="left", color="#E5E5E5", style="dashed"),
-                locations=loc.body(
-                    columns=["std_dev", "min", "p05", "q_1", "med", "q_3", "p95", "max"]
-                ),
+                locations=loc.body(columns=["std_dev", "p05", "q_1", "med", "q_3", "p95", "max"]),
             )
             .tab_style(
                 style=style.borders(sides="left", style="none"),
@@ -755,11 +753,19 @@ class DataScan:
                 mean="Mean",
                 std_dev="SD",
                 min="Min",
-                p05="P05",
-                q_1="Q1",
+                p05=html(
+                    'P<span style="font-size: 0.75em; vertical-align: sub; position: relative; line-height: 0.5em;">5</span>'
+                ),
+                q_1=html(
+                    'Q<span style="font-size: 0.75em; vertical-align: sub; position: relative; line-height: 0.5em;">1</span>'
+                ),
                 med="Med",
-                q_3="Q3",
-                p95="P95",
+                q_3=html(
+                    'Q<span style="font-size: 0.75em; vertical-align: sub; position: relative; line-height: 0.5em;">3</span>'
+                ),
+                p95=html(
+                    'P<span style="font-size: 0.75em; vertical-align: sub; position: relative; line-height: 0.5em;">95</span>'
+                ),
                 max="Max",
                 iqr="IQR",
             )

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -1070,7 +1070,7 @@ def _process_string_column_data(column_data: dict) -> dict:
         "q_3": "&mdash;",
         "p95": "&mdash;",
         "max": quantile_stats["max"],
-        "iqr": quantile_stats["iqr"],
+        "iqr": "&mdash;",
     }
 
     return stats_dict

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -1037,27 +1037,6 @@ def _process_string_column_data(column_data: dict) -> dict:
     descriptive_stats = column_data["statistics"]["string_lengths"]["descriptive"]
     quantile_stats = column_data["statistics"]["string_lengths"]["quantiles"]
 
-    # Get all values from the descriptive and quantile stats into a single list
-    quantile_stats_vals = [v[1] for v in quantile_stats.items()]
-
-    # Determine if the quantile stats are all integerlike
-    integerlike = []
-
-    # Determine if the quantile stats are integerlike
-    for val in quantile_stats_vals:
-        # Check if a quantile value is a number and then if it is intergerlike
-        if not isinstance(val, (int, float)):
-            continue
-        else:
-            integerlike.append(val % 1 == 0)
-    quantile_vals_integerlike = all(integerlike)
-
-    # Determine the formatter to use for the quantile values
-    if quantile_vals_integerlike:
-        q_formatter = _compact_integer_fmt
-    else:
-        q_formatter = _compact_decimal_fmt
-
     # Format the descriptive statistics (mean and standard deviation)
     for key, value in descriptive_stats.items():
         formatted_val = _compact_decimal_fmt(value=value)
@@ -1069,7 +1048,7 @@ def _process_string_column_data(column_data: dict) -> dict:
 
     # Format the quantile statistics
     for key, value in quantile_stats.items():
-        formatted_val = q_formatter(value=value)
+        formatted_val = _compact_integer_fmt(value=value)
         quantile_stats[key] = (
             f'<div><div>{formatted_val}</div><div style="float: left; position: absolute;">'
             '<div title="string length measure" style="font-size: 7px; color: #999; '


### PR DESCRIPTION
This PR cleans up the appearance of the report table generated by `col_summary_tbl()`. For string-based columns, the report table indicates those cells where values are based on string lengths. We also only include only the `min`, `median`, and `max` string length quartile stats.