### PR TITLE
Add mssql style to TABLE_TYPE_STYLES

### DIFF
--- a/pointblank/_constants.py
+++ b/pointblank/_constants.py
@@ -147,6 +147,7 @@ TABLE_TYPE_STYLES = {
     "sqlite": {"background": "#BACBEF", "text": "#222222", "label": "SQLite"},
     "parquet": {"background": "#3F9FF9", "text": "#FFFFFF", "label": "Parquet"},
     "memtable": {"background": "#2C3E50", "text": "#FFFFFF", "label": "Ibis memtable"},
+    "mssql": {"background": "#E2E2E2", "text": "#222222", "label": "MSSQL"},
 }
 
 REPORTING_LANGUAGES = ["en", "fr", "de", "it", "es", "pt", "tr", "zh", "ru", "pl", "da", "sv", "nl"]


### PR DESCRIPTION
# Summary

A follow up PR to improve MS SQL Server support. Adds table type styling based on pointblank R style for MSSQL.

# Related GitHub Issues and PRs

- Ref: #95

# Checklist

- [ x ] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [ x ] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality.
