### PR TITLE
feat: Add `limit=` parameter to `get_step_report()`

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8575,6 +8575,14 @@ def _step_report_row_based(
             mark_missing_values=False,
         )
 
+        if limit < extract_length:
+            extract_length_resolved = limit
+            extract_of_x_rows = "FIRST"
+
+        else:
+            extract_length_resolved = extract_length
+            extract_of_x_rows = "ALL"
+
         step_report = (
             extract_tbl.tab_header(
                 title=f"Report for Validation Step {i}",
@@ -8586,8 +8594,8 @@ def _step_report_row_based(
                     f"<div style='padding-top: 3px;'><strong>{n_failed}</strong> / "
                     f"<strong>{n}</strong> TEST UNIT FAILURES "
                     f"IN COLUMN <strong>{column_position}</strong></div>"
-                    "<div style='padding-top: 10px;'>EXTRACT OF "
-                    f"<strong>{extract_length}</strong> ROWS WITH "
+                    f"<div style='padding-top: 10px;'>EXTRACT OF {extract_of_x_rows} "
+                    f"<strong>{extract_length_resolved}</strong> ROWS WITH "
                     "<span style='color: #B22222;'>TEST UNIT FAILURES IN RED</span>:"
                     "</div></div>"
                 ),

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8562,12 +8562,15 @@ def _step_report_row_based(
         )
 
     else:
+        if limit is None:
+            limit = extract_length
+
         # Create a preview of the extracted data
         extract_tbl = _generate_display_table(
             data=extract,
-            n_head=1000,
-            n_tail=1000,
-            limit=2000,
+            n_head=limit,
+            n_tail=0,
+            limit=limit,
             incl_header=False,
             mark_missing_values=False,
         )

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -7533,6 +7533,7 @@ class Validate:
                 all_passed=all_passed,
                 extract=extract,
                 tbl_preview=tbl_preview,
+                limit=limit,
             )
 
         elif assertion_type == "col_schema_match":
@@ -8485,6 +8486,7 @@ def _step_report_row_based(
     all_passed: bool,
     extract: any,
     tbl_preview: GT,
+    limit: int | None,
 ):
     # Get the length of the extracted data for the step
     extract_length = get_row_count(extract)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -7468,6 +7468,10 @@ class Validate:
         if i not in self._get_validation_dict(i=None, attr="i") and not debug_return_df:
             raise ValueError(f"Step {i} does not exist in the validation plan.")
 
+        # If limit is `0` or less, raise an error
+        if limit is not None and limit <= 0:
+            raise ValueError("The limit must be an integer value greater than 0.")
+
         # Convert the `validation_info` object to a dictionary
         validation_info_dict = _validation_info_as_dict(validation_info=self.validation_info)
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -7371,7 +7371,7 @@ class Validate:
 
         return gt_tbl
 
-    def get_step_report(self, i: int) -> GT:
+    def get_step_report(self, i: int, limit: int | None = 10) -> GT:
         """
         Get a detailed report for a single validation step.
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -7375,8 +7375,8 @@ class Validate:
         """
         Get a detailed report for a single validation step.
 
-        The `get_step_report()` method returns a report of what went well, or what failed
-        spectacularly, for a given validation step. The report includes a summary of the validation
+        The `get_step_report()` method returns a report of what went well---or what failed
+        spectacularly---for a given validation step. The report includes a summary of the validation
         step and a detailed breakdown of the interrogation results. The report is presented as a GT
         table object, which can be displayed in a notebook or exported to an HTML file.
 
@@ -7388,7 +7388,11 @@ class Validate:
         Parameters
         ----------
         i
-            The step number for which to get a detailed report.
+            The step number for which to get the report.
+        limit
+            The number of rows to display for those validation steps that check values in rows (the
+            `col_vals_*()` validation steps). The default is `10` rows and the limit can be removed
+            entirely by setting `limit=None`.
 
         Returns
         -------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5642,8 +5642,17 @@ def test_get_step_report_no_fail(tbl_type):
         .interrogate()
     )
 
+    # Test every step report and ensure it's a GT object
     for i in range(1, 18):
         assert isinstance(validation.get_step_report(i=i), GT.GT)
+
+    # Test with a limit of `2` for every step report
+    for i in range(1, 18):
+        assert isinstance(validation.get_step_report(i=i, limit=2), GT.GT)
+
+    # Test with `limit=None` for every step report
+    for i in range(1, 18):
+        assert isinstance(validation.get_step_report(i=i, limit=None), GT.GT)
 
 
 def test_get_step_report_failing_inputs():
@@ -5657,13 +5666,19 @@ def test_get_step_report_failing_inputs():
     with pytest.raises(ValueError):
         validation.get_step_report(i=2)
 
+    with pytest.raises(ValueError):
+        validation.get_step_report(i=1, limit=0)
+
+    with pytest.raises(ValueError):
+        validation.get_step_report(i=1, limit=-5)
+
 
 def test_get_step_report_inactive_step():
     small_table = load_dataset(dataset="small_table", tbl_type="pandas")
 
     validation = Validate(small_table).col_vals_gt(columns="a", value=0, active=False).interrogate()
 
-    validation.get_step_report(i=1) == "This validation step is inactive."
+    assert validation.get_step_report(i=1) == "This validation step is inactive."
 
 
 def test_get_step_report_non_supported_steps():


### PR DESCRIPTION
Though not all step reports will use a `limit=` value, it is useful for those step reports based on `col_vals_*()` validation steps. This PR adds the `limit=` arg to `get_step_report()` and modifies the header text to reflect whether all failing rows are shown or not.

Fixes: #113   