### PR TITLE
feat: Add the `min_tbl_width=` arg in `preview()` to improve display of narrow preview tables

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -357,6 +357,10 @@ def preview(
     max_col_width
         The maximum width of the columns (in pixels) before the text is truncated. The default value
         is `250` (`"250px"`).
+    min_tbl_width
+        The minimum width of the table in pixels. If the sum of the column widths is less than this
+        value, the all columns are sized up to reach this minimum width value. The default value is
+        `500` (`"500px"`).
     incl_header
         Should the table include a header with the table type and table dimensions? Set to `True` by
         default.

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -466,6 +466,7 @@ def preview(
         limit=limit,
         show_row_numbers=show_row_numbers,
         max_col_width=max_col_width,
+        min_tbl_width=min_tbl_width,
         incl_header=incl_header,
         mark_missing_values=True,
     )
@@ -478,7 +479,8 @@ def _generate_display_table(
     n_tail: int = 5,
     limit: int | None = 50,
     show_row_numbers: bool = True,
-    max_col_width: int | None = 250,
+    max_col_width: int = 250,
+    min_tbl_width: int = 500,
     incl_header: bool = None,
     mark_missing_values: bool = True,
     row_number_list: list[int] | None = None,

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -349,12 +349,14 @@ def preview(
         The number of rows to show from the end of the table. Set to `5` by default.
     limit
         The limit value for the sum of `n_head=` and `n_tail=` (the total number of rows shown).
-        If the sum of `n_head=` and `n_tail=` exceeds the limit, an error is raised.
+        If the sum of `n_head=` and `n_tail=` exceeds the limit, an error is raised. The default
+        value is `50`.
     show_row_numbers
         Should row numbers be shown? The numbers shown reflect the row numbers of the head and tail
-        in the full table.
+        in the input `data=` table. By default, this is set to `True`.
     max_col_width
-        The maximum width of the columns in pixels. This is `250` (`"250px"`) by default.
+        The maximum width of the columns (in pixels) before the text is truncated. The default value
+        is `250` (`"250px"`).
     incl_header
         Should the table include a header with the table type and table dimensions? Set to `True` by
         default.

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -309,9 +309,9 @@ def preview(
     columns_subset: str | list[str] | Column | None = None,
     n_head: int = 5,
     n_tail: int = 5,
-    limit: int | None = 50,
+    limit: int = 50,
     show_row_numbers: bool = True,
-    max_col_width: int | None = 250,
+    max_col_width: int = 250,
     incl_header: bool = None,
 ) -> GT:
     """

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -312,6 +312,7 @@ def preview(
     limit: int = 50,
     show_row_numbers: bool = True,
     max_col_width: int = 250,
+    min_tbl_width: int = 500,
     incl_header: bool = None,
 ) -> GT:
     """


### PR DESCRIPTION
This PR adds the `min_tbl_width=` arg to the `preview()` function. Previously, very narrow tables would truncate information in the `preview()` table's header area. The new parameter adds width equally to each of the columns in those situations where the total width is below the threshold. The default of `500px` provides ample space for the table header to display its information about the table.