### PR TITLE
feat: add `highest_level=` parameter to `Actions` class

### DIFF
--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -317,6 +317,10 @@ class Actions:
     critical
         A string, `Callable`, or list of `Callable`/string values for the 'critical' level. Using
         `None` means no action should be performed at the 'critical' level.
+    highest_only
+        A boolean value that, when set to `True`, will only execute the action for the highest
+        threshold level that is exceeded. This is useful when you want to ensure that only the most
+        severe action is taken when multiple threshold levels are exceeded.
 
     Returns
     -------
@@ -438,6 +442,7 @@ class Actions:
     warning: str | Callable | list[str | Callable] | None = None
     error: str | Callable | list[str | Callable] | None = None
     critical: str | Callable | list[str | Callable] | None = None
+    highest_only: bool = False
 
     def __post_init__(self):
         self.warning = self._ensure_list(self.warning)

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -318,9 +318,9 @@ class Actions:
         A string, `Callable`, or list of `Callable`/string values for the 'critical' level. Using
         `None` means no action should be performed at the 'critical' level.
     highest_only
-        A boolean value that, when set to `True`, will only execute the action for the highest
-        threshold level that is exceeded. This is useful when you want to ensure that only the most
-        severe action is taken when multiple threshold levels are exceeded.
+        A boolean value that, when set to `True` (the default), results in executing only the action
+        for the highest threshold level that is exceeded. Useful when you want to ensure that only
+        the most severe action is taken when multiple threshold levels are exceeded.
 
     Returns
     -------
@@ -442,7 +442,7 @@ class Actions:
     warning: str | Callable | list[str | Callable] | None = None
     error: str | Callable | list[str | Callable] | None = None
     critical: str | Callable | list[str | Callable] | None = None
-    highest_only: bool = False
+    highest_only: bool = True
 
     def __post_init__(self):
         self.warning = self._ensure_list(self.warning)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5449,6 +5449,9 @@ class Validate:
                                     with _action_context_manager(metadata):
                                         act()
 
+                        if validation.actions.highest_only:
+                            break
+
                     elif self.actions is not None:
                         # Action execution on the global level
                         action = self.actions._get_action(level=level)
@@ -5489,10 +5492,8 @@ class Validate:
                                     with _action_context_manager(metadata):
                                         act()
 
-                    if (validation.actions is not None and validation.actions.highest_only) or (
-                        self.actions is not None and self.actions.highest_only
-                    ):
-                        break
+                        if self.actions.highest_only:
+                            break
 
             # If this is a row-based validation step, then extract the rows that failed
             # TODO: Add support for extraction of rows for Ibis backends

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -7966,6 +7966,10 @@ def _process_action_str(
     # If a `col` value is available for the validation step *and* the action string contains a
     # placeholder for the column name then replace with `col`; placeholders are: {col} and {column}
     if col is not None:
+        # If a list of columns is provided, then join the columns into a comma-separated string
+        if isinstance(col, list):
+            col = ", ".join(col)
+
         action_str = action_str.replace("{col}", col)
         action_str = action_str.replace("{column}", col)
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5394,9 +5394,9 @@ class Validate:
             if collect_tbl_checked and results_tbl is not None:
                 validation.tbl_checked = results_tbl
 
-            # Perform any necessary actions if threshold levels are exceeded for each
-            # of the severity levels ('warning', 'error', 'critical')
-            for level in ["warning", "error", "critical"]:
+            # Perform any necessary actions if threshold levels are exceeded for each of
+            # the severity levels (in descending order of 'critical', 'error', and 'warning')
+            for level in ["critical", "error", "warning"]:
                 if getattr(validation, level) and (
                     self.actions is not None or validation.actions is not None
                 ):
@@ -5488,6 +5488,11 @@ class Validate:
                                     # Execute the action within the context manager
                                     with _action_context_manager(metadata):
                                         act()
+
+                    if (validation.actions is not None and validation.actions.highest_only) or (
+                        self.actions is not None and self.actions.highest_only
+                    ):
+                        break
 
             # If this is a row-based validation step, then extract the rows that failed
             # TODO: Add support for extraction of rows for Ibis backends

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1572,6 +1572,104 @@ def test_validation_actions_step_only_none(request, tbl_fixture, capsys):
 
 
 @pytest.mark.parametrize("tbl_type", ["pandas", "polars", "duckdb"])
+def test_validation_actions_global_highest(tbl_type, capsys):
+    (
+        Validate(
+            data=load_dataset(dataset="small_table", tbl_type=tbl_type),
+            thresholds=Thresholds(warning=1, error=2, critical=3),
+            actions=Actions(
+                warning="W_global", error="E_global", critical="C_global", highest_only=True
+            ),
+        )
+        .col_vals_gt(columns="d", value=10000)
+        .interrogate()
+    )
+
+    # Capture the output and verify that only the highest priority level
+    # message printed to the console
+    captured = capsys.readouterr()
+    assert "C_global" in captured.out
+    assert "E_global" not in captured.out
+    assert "W_global" not in captured.out
+
+
+@pytest.mark.parametrize("tbl_type", ["pandas", "polars", "duckdb"])
+def test_validation_actions_global_all(tbl_type, capsys):
+    (
+        Validate(
+            data=load_dataset(dataset="small_table", tbl_type=tbl_type),
+            thresholds=Thresholds(warning=1, error=2, critical=3),
+            actions=Actions(
+                warning="W_global", error="E_global", critical="C_global", highest_only=False
+            ),
+        )
+        .col_vals_gt(columns="d", value=10000)
+        .interrogate()
+    )
+
+    # Capture the output and verify that all three level messages are printed to the console
+    captured = capsys.readouterr()
+    assert "C_global" in captured.out
+    assert "E_global" in captured.out
+    assert "W_global" in captured.out
+
+
+@pytest.mark.parametrize("tbl_type", ["pandas", "polars", "duckdb"])
+def test_validation_actions_local_highest(tbl_type, capsys):
+    (
+        Validate(
+            data=load_dataset(dataset="small_table", tbl_type=tbl_type),
+            thresholds=Thresholds(warning=1, error=2, critical=3),
+            actions=Actions(
+                warning="W_global", error="E_global", critical="C_global", highest_only=False
+            ),
+        )
+        .col_vals_gt(
+            columns="d",
+            value=10000,
+            actions=Actions(
+                warning="W_local", error="E_local", critical="C_local", highest_only=True
+            ),
+        )
+        .interrogate()
+    )
+
+    # Capture the output and verify that only the highest priority level
+    # message printed to the console
+    captured = capsys.readouterr()
+    assert "C_local" in captured.out
+    assert "E_local" not in captured.out
+    assert "W_local" not in captured.out
+
+
+@pytest.mark.parametrize("tbl_type", ["pandas", "polars", "duckdb"])
+def test_validation_actions_local_all(tbl_type, capsys):
+    (
+        Validate(
+            data=load_dataset(dataset="small_table", tbl_type=tbl_type),
+            thresholds=Thresholds(warning=1, error=2, critical=3),
+            actions=Actions(
+                warning="W_global", error="E_global", critical="C_global", highest_only=True
+            ),
+        )
+        .col_vals_gt(
+            columns="d",
+            value=10000,
+            actions=Actions(
+                warning="W_local", error="E_local", critical="C_local", highest_only=False
+            ),
+        )
+        .interrogate()
+    )
+
+    # Capture the output and verify that all three level messages are printed to the console
+    captured = capsys.readouterr()
+    assert "C_local" in captured.out
+    assert "E_local" in captured.out
+    assert "W_local" in captured.out
+
+
+@pytest.mark.parametrize("tbl_type", ["pandas", "polars", "duckdb"])
 def test_validation_actions_get_action_metadata(tbl_type, capsys):
     def log_issue():
         metadata = get_action_metadata()


### PR DESCRIPTION
When defining actions for thresholds, the case may be that:

1. three thresholds are set
2. three actions are set (only per threshold level)
3. all three thresholds are exceeded and all three actions are triggered/executed

Having all three actions fire can result in undesired redundancy (i.e., over-signalling failure) and it's likely more often the case you'll want only the action from the most severe threshold that was exceeded.

This PR solves this by adding the `highest_level=` parameter to `Actions` class. It's set to `True` by default so the less common scenario (the one above) can be accessed with `highest_level=False`.

Here's an example of its use:

```python
import pointblank as pb

(
     Validate(
         data=pb.load_dataset(dataset="small_table"),
         thresholds=pb.Thresholds(warning=1, error=2, critical=3),
     )
     .col_vals_gt(
         columns="d",
         value=10000,
         actions=pb.Actions(
             warning="W_local", error="E_local", critical="C_local", highest_only=True
         ),
     )
     .interrogate()
)
```

```bash
C_local
```

With `highest_only=False` we'd get this in the console:

```
C_local
E_local
W_local
```