### PR TITLE
feat: flexible date/datetime comparisons

### DIFF
--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -95,6 +95,10 @@ class Interrogator:
             import ibis
 
             if isinstance(self.compare, ColumnLiteral):
+                #
+                # Ibis column-to-column comparison
+                #
+
                 tbl = self.x.mutate(
                     pb_is_good_1=(self.x[self.column].isnull() | self.x[self.compare.name].isnull())
                     & ibis.literal(self.na_pass),
@@ -110,6 +114,10 @@ class Interrogator:
                 )
 
             else:
+                #
+                # Ibis column-to-literal comparison
+                #
+
                 tbl = self.x.mutate(
                     pb_is_good_1=self.x[self.column].isnull() & ibis.literal(self.na_pass),
                     pb_is_good_2=self.x[self.column] > ibis.literal(self.compare),
@@ -158,6 +166,10 @@ class Interrogator:
             import ibis
 
             if isinstance(self.compare, Column):
+                #
+                # Ibis column-to-column comparison
+                #
+
                 tbl = self.x.mutate(
                     pb_is_good_1=(self.x[self.column].isnull() | self.x[self.compare.name].isnull())
                     & ibis.literal(self.na_pass),
@@ -173,6 +185,10 @@ class Interrogator:
                 )
 
             else:
+                #
+                # Ibis column-to-literal comparison
+                #
+
                 tbl = self.x.mutate(
                     pb_is_good_1=self.x[self.column].isnull() & ibis.literal(self.na_pass),
                     pb_is_good_2=self.x[self.column] < ibis.literal(self.compare),
@@ -221,6 +237,10 @@ class Interrogator:
             import ibis
 
             if isinstance(self.compare, Column):
+                #
+                # Ibis column-to-column comparison
+                #
+
                 tbl = self.x.mutate(
                     pb_is_good_1=(self.x[self.column].isnull() | self.x[self.compare.name].isnull())
                     & ibis.literal(self.na_pass),
@@ -236,6 +256,10 @@ class Interrogator:
                 )
 
             else:
+                #
+                # Ibis column-to-literal comparison
+                #
+
                 tbl = self.x.mutate(
                     pb_is_good_1=self.x[self.column].isnull() & ibis.literal(self.na_pass),
                     pb_is_good_2=self.x[self.column] == ibis.literal(self.compare),
@@ -328,6 +352,10 @@ class Interrogator:
             import ibis
 
             if isinstance(self.compare, Column):
+                #
+                # Ibis column-to-column comparison
+                #
+
                 tbl = self.x.mutate(
                     pb_is_good_1=(self.x[self.column].isnull() | self.x[self.compare.name].isnull())
                     & ibis.literal(self.na_pass),
@@ -342,6 +370,9 @@ class Interrogator:
                     "pb_is_good_1", "pb_is_good_2"
                 )
 
+            #
+            # Ibis column-to-literal comparison
+            #
             tbl = self.x.mutate(
                 pb_is_good_1=self.x[self.column].isnull() & ibis.literal(self.na_pass),
                 pb_is_good_2=ibis.ifelse(
@@ -539,6 +570,10 @@ class Interrogator:
             import ibis
 
             if isinstance(self.compare, Column):
+                #
+                # Ibis column-to-column comparison
+                #
+
                 tbl = self.x.mutate(
                     pb_is_good_1=(self.x[self.column].isnull() | self.x[self.compare.name].isnull())
                     & ibis.literal(self.na_pass),
@@ -553,6 +588,9 @@ class Interrogator:
                     "pb_is_good_1", "pb_is_good_2"
                 )
 
+            #
+            # Ibis column-to-literal comparison
+            #
             tbl = self.x.mutate(
                 pb_is_good_1=self.x[self.column].isnull() & ibis.literal(self.na_pass),
                 pb_is_good_2=self.x[self.column] >= ibis.literal(self.compare),
@@ -601,6 +639,10 @@ class Interrogator:
             import ibis
 
             if isinstance(self.compare, Column):
+                #
+                # Ibis column-to-column comparison
+                #
+
                 tbl = self.x.mutate(
                     pb_is_good_1=(self.x[self.column].isnull() | self.x[self.compare.name].isnull())
                     & ibis.literal(self.na_pass),
@@ -615,6 +657,9 @@ class Interrogator:
                     "pb_is_good_1", "pb_is_good_2"
                 )
 
+            #
+            # Ibis column-to-literal comparison
+            #
             tbl = self.x.mutate(
                 pb_is_good_1=self.x[self.column].isnull() & ibis.literal(self.na_pass),
                 pb_is_good_2=self.x[self.column] <= ibis.literal(self.compare),
@@ -663,6 +708,10 @@ class Interrogator:
             import ibis
 
             if isinstance(self.low, Column) or isinstance(self.high, Column):
+                #
+                # Ibis column-to-column/column or column-to-column/literal comparison
+                #
+
                 if isinstance(self.low, Column):
                     low_val = self.x[self.low.name]
                 else:
@@ -718,6 +767,10 @@ class Interrogator:
                 ).drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
 
             else:
+                #
+                # Ibis column-to-literal/literal comparison
+                #
+
                 low_val = ibis.literal(self.low)
                 high_val = ibis.literal(self.high)
 
@@ -819,6 +872,10 @@ class Interrogator:
             import ibis
 
             if isinstance(self.low, Column) or isinstance(self.high, Column):
+                #
+                # Ibis column-to-column/column or column-to-column/literal comparison
+                #
+
                 if isinstance(self.low, Column):
                     low_val = self.x[self.low.name]
                 else:
@@ -898,6 +955,9 @@ class Interrogator:
                     pb_is_good_=tbl.pb_is_good_1 | (tbl.pb_is_good_2 | tbl.pb_is_good_3)
                 ).drop("pb_is_good_1", "pb_is_good_2", "pb_is_good_3")
 
+            #
+            # Ibis column-to-literal/literal comparison
+            #
             low_val = ibis.literal(self.low)
             high_val = ibis.literal(self.high)
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4446,7 +4446,6 @@ def test_date_validation_fixed_date(request, tbl_fixture):
     tbl = request.getfixturevalue(tbl_fixture)
 
     date_left = datetime.date(2021, 1, 1)
-
     date_right = datetime.date(2021, 3, 1)
 
     assert (
@@ -4573,7 +4572,6 @@ def test_date_validation_fixed_datetime(request, tbl_fixture):
     tbl = request.getfixturevalue(tbl_fixture)
 
     datetime_left = datetime.datetime(2021, 1, 1)
-
     datetime_right = datetime.datetime(2021, 3, 1)
 
     assert (
@@ -4664,6 +4662,302 @@ def test_date_validation_fixed_datetime(request, tbl_fixture):
         .interrogate()
         .n_passed(i=1, scalar=True)
         == 0
+    )
+
+
+@pytest.mark.parametrize("tbl_fixture", TBL_TRUE_DATES_TIMES_LIST)
+def test_date_validation_fixed_date_ddtm_col(request, tbl_fixture):
+    import datetime
+
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    date_left = datetime.date(2021, 1, 1)
+    date_right = datetime.date(2021, 3, 1)
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_gt(
+            columns="dttm_1",
+            value=date_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_ge(
+            columns="dttm_1",
+            value=date_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_eq(
+            columns="dttm_1",
+            value=date_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_ne(
+            columns="dttm_1",
+            value=date_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_lt(
+            columns="dttm_1",
+            value=date_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_lt(
+            columns="dttm_1",
+            value=date_right,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_le(
+            columns="dttm_1",
+            value=date_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_le(
+            columns="dttm_1",
+            value=date_right,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_between(
+            columns="dttm_1",
+            left=date_left,
+            right=date_right,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_between(
+            columns="dttm_1",
+            left=date_left,
+            right=date_right,
+            inclusive=(False, False),
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_outside(
+            columns="dttm_1",
+            left=date_left,
+            right=date_right,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_outside(
+            columns="dttm_1",
+            left=date_left,
+            right=date_right,
+            inclusive=(False, False),
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+
+@pytest.mark.parametrize("tbl_fixture", TBL_TRUE_DATES_TIMES_LIST)
+def test_date_validation_fixed_datetime_date_col(request, tbl_fixture):
+    import datetime
+
+    tbl = request.getfixturevalue(tbl_fixture)
+
+    datetime_left = datetime.datetime(2021, 1, 1)
+    datetime_right = datetime.datetime(2021, 3, 1)
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_gt(
+            columns="date_1",
+            value=datetime_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_ge(
+            columns="date_1",
+            value=datetime_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_eq(
+            columns="date_1",
+            value=datetime_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_ne(
+            columns="date_1",
+            value=datetime_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_lt(
+            columns="date_1",
+            value=datetime_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_lt(
+            columns="date_1",
+            value=datetime_right,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_le(
+            columns="date_1",
+            value=datetime_left,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_le(
+            columns="date_1",
+            value=datetime_right,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_between(
+            columns="date_1",
+            left=datetime_left,
+            right=datetime_right,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 2
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_between(
+            columns="date_1",
+            left=datetime_left,
+            right=datetime_right,
+            inclusive=(False, False),
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_outside(
+            columns="date_1",
+            left=datetime_left,
+            right=datetime_right,
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 0
+    )
+
+    assert (
+        Validate(data=tbl)
+        .col_vals_outside(
+            columns="date_1",
+            left=datetime_left,
+            right=datetime_right,
+            inclusive=(False, False),
+        )
+        .interrogate()
+        .n_passed(i=1, scalar=True)
+        == 1
     )
 
 


### PR DESCRIPTION
This PR introduces flexibility in date/datetime validation checks. With a date column, you can set the `value=` in a `col_vals_*()` method to a date or a datetime (the latter will be internally transformed to use a floor date). Same flexibility is present for a datetime column, where you can use a datetime or a date as input (the date is transformed to a datetime with the time part being `00:00:00`). 