### PR TITLE
feat: allow date/datetime comparison validations to use string dates and datetimes 

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8261,6 +8261,40 @@ def _convert_string_to_datetime(value: str) -> datetime.datetime:
             return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
 
 
+def _string_date_dttm_conversion(value: any) -> any:
+    """
+    Convert a string to a date or datetime object if it is in the correct format.
+    If the value is not a string, it is returned as is.
+
+    Parameters
+    ----------
+    value
+        The value to convert. It can be a string, date, or datetime object.
+
+    Returns
+    -------
+    any
+        The converted date or datetime object, or the original value if it is not a string.
+
+    Raises
+    ------
+    ValueError
+        If the string cannot be converted to a date or datetime.
+    """
+
+    if isinstance(value, str):
+        if _is_string_date(value):
+            value = _convert_string_to_date(value)
+        elif _is_string_datetime(value):
+            value = _convert_string_to_datetime(value)
+        else:
+            raise ValueError(
+                "If `value=` is provided as a string it must be a date or datetime string."
+            )
+
+    return value
+
+
 def _process_brief(brief: str | None, step: int, col: str | list[str] | None) -> str:
     # If there is no brief, return `None`
     if brief is None:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8499,7 +8499,7 @@ def _create_autobrief_or_failure_text(
             for_failure=for_failure,
         )
 
-    return None
+    return None  # pragma: no cover
 
 
 def _expect_failure_type(for_failure: bool) -> str:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8171,6 +8171,33 @@ def _is_string_date(value: str) -> bool:
     return True
 
 
+def _is_string_datetime(value: str) -> bool:
+    """
+    Check if a string represents a datetime in ISO format (YYYY-MM-DD HH:MM:SS).
+
+    Parameters
+    ----------
+    value
+        The string value to check.
+
+    Returns
+    -------
+    bool
+        True if the string is in datetime format, False otherwise.
+    """
+    if not isinstance(value, str):
+        return False
+
+    import re
+
+    # Match ISO datetime format YYYY-MM-DD HH:MM:SS with optional milliseconds
+    pattern = r"^\d{4}-\d{2}-\d{2}(\s|T)\d{2}:\d{2}:\d{2}(\.\d+)?$"
+    if not re.match(pattern, value):
+        return False
+
+    return True
+
+
 def _process_brief(brief: str | None, step: int, col: str | list[str] | None) -> str:
     # If there is no brief, return `None`
     if brief is None:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2145,6 +2145,9 @@ class Validate:
         _check_boolean_input(param=na_pass, param_name="na_pass")
         _check_boolean_input(param=active, param_name="active")
 
+        # If value is a string-based date or datetime, convert it to the appropriate type
+        value = _string_date_dttm_conversion(value=value)
+
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
             self.thresholds if thresholds is None else _normalize_thresholds_creation(thresholds)
@@ -2318,6 +2321,9 @@ class Validate:
         _check_boolean_input(param=na_pass, param_name="na_pass")
         _check_boolean_input(param=active, param_name="active")
 
+        # If value is a string-based date or datetime, convert it to the appropriate type
+        value = _string_date_dttm_conversion(value=value)
+
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
             self.thresholds if thresholds is None else _normalize_thresholds_creation(thresholds)
@@ -2490,6 +2496,9 @@ class Validate:
         _check_boolean_input(param=na_pass, param_name="na_pass")
         _check_boolean_input(param=active, param_name="active")
 
+        # If value is a string-based date or datetime, convert it to the appropriate type
+        value = _string_date_dttm_conversion(value=value)
+
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
             self.thresholds if thresholds is None else _normalize_thresholds_creation(thresholds)
@@ -2659,6 +2668,9 @@ class Validate:
         _check_thresholds(thresholds=thresholds)
         _check_boolean_input(param=na_pass, param_name="na_pass")
         _check_boolean_input(param=active, param_name="active")
+
+        # If value is a string-based date or datetime, convert it to the appropriate type
+        value = _string_date_dttm_conversion(value=value)
 
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
@@ -2834,6 +2846,9 @@ class Validate:
         _check_boolean_input(param=na_pass, param_name="na_pass")
         _check_boolean_input(param=active, param_name="active")
 
+        # If value is a string-based date or datetime, convert it to the appropriate type
+        value = _string_date_dttm_conversion(value=value)
+
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
             self.thresholds if thresholds is None else _normalize_thresholds_creation(thresholds)
@@ -3007,6 +3022,9 @@ class Validate:
         _check_thresholds(thresholds=thresholds)
         _check_boolean_input(param=na_pass, param_name="na_pass")
         _check_boolean_input(param=active, param_name="active")
+
+        # If value is a string-based date or datetime, convert it to the appropriate type
+        value = _string_date_dttm_conversion(value=value)
 
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
@@ -3202,13 +3220,17 @@ class Validate:
         _check_boolean_input(param=na_pass, param_name="na_pass")
         _check_boolean_input(param=active, param_name="active")
 
+        # If `left=` or `right=` is a string-based date or datetime, convert to the appropriate type
+        left = _string_date_dttm_conversion(value=left)
+        right = _string_date_dttm_conversion(value=right)
+
+        # Place the `left=` and `right=` values in a tuple for inclusion in the validation info
+        value = (left, right)
+
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
             self.thresholds if thresholds is None else _normalize_thresholds_creation(thresholds)
         )
-
-        # Place the `left` and `right` values in a tuple for inclusion in the validation info
-        value = (left, right)
 
         # If `columns` is a ColumnSelector or Narwhals selector, call `col()` on it to later
         # resolve the columns
@@ -3400,16 +3422,17 @@ class Validate:
         _check_boolean_input(param=na_pass, param_name="na_pass")
         _check_boolean_input(param=active, param_name="active")
 
-        if isinstance(columns, str):
-            columns = [columns]
+        # If `left=` or `right=` is a string-based date or datetime, convert to the appropriate type
+        left = _string_date_dttm_conversion(value=left)
+        right = _string_date_dttm_conversion(value=right)
+
+        # Place the `left=` and `right=` values in a tuple for inclusion in the validation info
+        value = (left, right)
 
         # Determine threshold to use (global or local) and normalize a local `thresholds=` value
         thresholds = (
             self.thresholds if thresholds is None else _normalize_thresholds_creation(thresholds)
         )
-
-        # Place the `left` and `right` values in a tuple for inclusion in the validation info
-        value = (left, right)
 
         # If `columns` is a ColumnSelector or Narwhals selector, call `col()` on it to later
         # resolve the columns

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8198,6 +8198,33 @@ def _is_string_datetime(value: str) -> bool:
     return True
 
 
+def _convert_string_to_date(value: str) -> datetime.date:
+    """
+    Convert a string to a datetime.date object.
+
+    Parameters
+    ----------
+    value
+        The string value to convert.
+
+    Returns
+    -------
+    datetime.date
+        The converted date object.
+
+    Raises
+    ------
+    ValueError
+        If the string cannot be converted to a date.
+    """
+    if not _is_string_date(value):
+        raise ValueError(f"Cannot convert '{value}' to a date.")
+
+    import datetime
+
+    return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+
+
 def _process_brief(brief: str | None, step: int, col: str | list[str] | None) -> str:
     # If there is no brief, return `None`
     if brief is None:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2035,8 +2035,8 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         value
-            The value to compare against. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
+            The value to compare against. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column
             comparison.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
@@ -2209,8 +2209,8 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         value
-            The value to compare against. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
+            The value to compare against. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column
             comparison.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
@@ -2382,8 +2382,8 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         value
-            The value to compare against. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
+            The value to compare against. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column
             comparison.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
@@ -2554,8 +2554,8 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         value
-            The value to compare against. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
+            The value to compare against. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column
             comparison.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
@@ -2724,8 +2724,8 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         value
-            The value to compare against. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
+            The value to compare against. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column
             comparison.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
@@ -2898,8 +2898,8 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         value
-            The value to compare against. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
+            The value to compare against. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column
             comparison.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
@@ -3075,13 +3075,13 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         left
-            The lower bound of the range. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
-            comparison for the lower bound.
+            The lower bound of the range. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column comparison
+            for the lower bound.
         right
-            The upper bound of the range. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
-            comparison for the upper bound.
+            The upper bound of the range. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column comparison
+            for the upper bound.
         inclusive
             A tuple of two boolean values indicating whether the comparison should be inclusive. The
             position of the boolean values correspond to the `left=` and `right=` values,
@@ -3273,13 +3273,13 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         left
-            The lower bound of the range. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
-            comparison for the lower bound.
+            The lower bound of the range. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column comparison
+            for the lower bound.
         right
-            The upper bound of the range. This can be a single numeric value or a single column name
-            given in [`col()`](`pointblank.col`). The latter option allows for a column-column
-            comparison for the upper bound.
+            The upper bound of the range. This can be a single value or a single column name given
+            in [`col()`](`pointblank.col`). The latter option allows for a column-column comparison
+            for the upper bound.
         inclusive
             A tuple of two boolean values indicating whether the comparison should be inclusive. The
             position of the boolean values correspond to the `left=` and `right=` values,

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8225,6 +8225,42 @@ def _convert_string_to_date(value: str) -> datetime.date:
     return datetime.datetime.strptime(value, "%Y-%m-%d").date()
 
 
+def _convert_string_to_datetime(value: str) -> datetime.datetime:
+    """
+    Convert a string to a datetime.datetime object.
+
+    Parameters
+    ----------
+    value
+        The string value to convert.
+
+    Returns
+    -------
+    datetime.datetime
+        The converted datetime object.
+
+    Raises
+    ------
+    ValueError
+        If the string cannot be converted to a datetime.
+    """
+    if not _is_string_datetime(value):
+        raise ValueError(f"Cannot convert '{value}' to a datetime.")
+
+    import datetime
+
+    if "T" in value:
+        if "." in value:
+            return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
+        else:
+            return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+    else:
+        if "." in value:
+            return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f")
+        else:
+            return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+
+
 def _process_brief(brief: str | None, step: int, col: str | list[str] | None) -> str:
     # If there is no brief, return `None`
     if brief is None:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8144,6 +8144,33 @@ def _normalize_reporting_language(lang: str | None) -> str:
     return lang.lower()
 
 
+def _is_string_date(value: str) -> bool:
+    """
+    Check if a string represents a date in ISO format (YYYY-MM-DD).
+
+    Parameters
+    ----------
+    value
+        The string value to check.
+
+    Returns
+    -------
+    bool
+        True if the string is in date format, False otherwise.
+    """
+    if not isinstance(value, str):
+        return False
+
+    import re
+
+    # Match ISO date format YYYY-MM-DD
+    pattern = r"^\d{4}-\d{2}-\d{2}$"
+    if not re.match(pattern, value):
+        return False
+
+    return True
+
+
 def _process_brief(brief: str | None, step: int, col: str | list[str] | None) -> str:
     # If there is no brief, return `None`
     if brief is None:


### PR DESCRIPTION
In previous PRs, we opened up the possibility to use `datetime.date` and `datetime.datetime` objects for the `value=` parameter in several validation methods (e.g., `col_vals_gt()`, `col_vals_between()`, etc.). So long as the columns are date or datetime columns, the validation will proceed as expected during interrogation.

This PR makes it so that the date or datetime input provided to `value=` can be a string-based date or datetime. The major requirement is that the string date or datetime must follow ISO-8601 formatting guidelines. With this, the following example now works:

```python
import pointblank as pb
import polars as pl

pl_df = pl.DataFrame(
    {
        "date_1": ["2021-01-01", "2021-02-01"],
        "date_2": ["2021-02-01", "2021-03-01"],
        "dttm_1": ["2021-01-01 02:30:00", "2021-02-01 02:30:00"],
        "dttm_2": ["2021-02-01 03:30:00", "2021-03-01 03:30:00"],
    }
)

pl_df = pl_df.with_columns(
    [
        pl.col("date_1").str.to_date(),
        pl.col("date_2").str.to_date(),
        pl.col("dttm_1").str.to_datetime(),
        pl.col("dttm_2").str.to_datetime(),
    ]
)

validation = (
    pb.Validate(data=pl_df)
    .col_vals_gt(
        columns="dttm_1",
        value="2021-01-01 01:25:21.232",
    )
    .col_vals_lt(
        columns="date_2",
        value="2021-03-02",
    )
    .interrogate()
)

validation
```

This yields the validation report:

<img width="925" alt="image" src="https://github.com/user-attachments/assets/14b31937-5481-4605-9033-be730c3dd179" />
