### PR TITLE
feat: better customize header in step reports (through `.get_step_report(header=...)`

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8890,7 +8890,8 @@ class Validate:
             from this default, free text can be provided for the header. This will be interpreted as
             Markdown text and transformed internally to HTML. You can provide one of two templating
             elements: `{title}` and `{details}`. The default header has the template
-            `"{title}{details}"` so you can easily start from that and modify as you see fit.
+            `"{title}{details}"` so you can easily start from that and modify as you see fit. If you
+            don't want a header at all, you can set `header=None` to remove it entirely.
         limit
             The number of rows to display for those validation steps that check values in rows (the
             `col_vals_*()` validation steps). The default is `10` rows and the limit can be removed
@@ -10366,7 +10367,10 @@ def _step_report_row_based(
 
         # TODO: localize all text fragments according to `lang=` parameter
 
-        if header == ":default:":
+        if header is None:
+            pass
+
+        elif header == ":default:":
             step_report = step_report.tab_header(
                 title=html(f"Report for Validation Step {i} {CHECK_MARK_SPAN}"),
                 subtitle=html(
@@ -10457,6 +10461,10 @@ def _step_report_row_based(
             "</div>"
             "</div>"
         )
+
+        # If `header` is None then don't add a header and just return the step report
+        if header is None:
+            return step_report
 
         # Generate the default template text for the header when `":default:"` is used
         if header == ":default:":
@@ -10761,6 +10769,10 @@ def _step_report_schema_in_order(
     # If the version of `great_tables` is `>=0.17.0` then disable Quarto table processing
     if version("great_tables") >= "0.17.0":
         step_report = step_report.tab_options(quarto_disable_processing=True)
+
+    # If `header` is None then don't add a header and just return the step report
+    if header is None:
+        return step_report
 
     # Get the other parameters for the `col_schema_match()` function
     case_sensitive_colnames = schema_info["params"]["case_sensitive_colnames"]
@@ -11166,6 +11178,10 @@ def _step_report_schema_any_order(
     # If the version of `great_tables` is `>=0.17.0` then disable Quarto table processing
     if version("great_tables") >= "0.17.0":
         step_report = step_report.tab_options(quarto_disable_processing=True)
+
+    # If `header` is None then don't add a header and just return the step report
+    if header is None:
+        return step_report
 
     # Get the other parameters for the `col_schema_match()` function
     case_sensitive_colnames = schema_info["params"]["case_sensitive_colnames"]

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10460,6 +10460,8 @@ def _step_report_row_based(
         if header == ":default:":
             header = "{title}{details}"
 
+        # Use commonmark to convert the header text to HTML
+        header = commonmark.commonmark(header)
 
         # Place any templated text in the header
         header = header.format(title=title, details=details)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10458,7 +10458,8 @@ def _step_report_row_based(
 
         # Generate the default template text for the header when `":default:"` is used
         if header == ":default:":
-            header = "{title}<br>{details}"
+            header = "{title}{details}"
+
 
         # Place any templated text in the header
         header = header.format(title=title, details=details)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -11259,7 +11259,12 @@ def _create_col_schema_match_params_html(
     )
 
     return (
-        '<div style="display: flex;"><div style="margin-right: 5px;">COLUMN SCHEMA MATCH</div>'
-        f"{complete_text}{in_order_text}{case_sensitive_colnames_text}{case_sensitive_dtypes_text}"
-        f"{full_match_dtypes_text}</div>"
+        '<div style="display: flex; font-size: 13.7px; padding-top: 7px;">'
+        '<div style="margin-right: 5px;">COLUMN SCHEMA MATCH</div>'
+        f"{complete_text}"
+        f"{in_order_text}"
+        f"{case_sensitive_colnames_text}"
+        f"{case_sensitive_dtypes_text}"
+        f"{full_match_dtypes_text}"
+        "</div>"
     )

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10362,6 +10362,8 @@ def _step_report_row_based(
         else:
             step_report = tbl_preview
 
+        # TODO: localize all text fragments according to `lang=` parameter
+
         if header == ":default:":
             step_report = step_report.tab_header(
                 title=html(f"Report for Validation Step {i} {CHECK_MARK_SPAN}"),

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8886,9 +8886,11 @@ class Validate:
             column selector expressions don't resolve to any columns.
         header
             Options for customizing the header of the step report. The default is the `":default:"`
-            value which produces a generic header. Aside from this default, text can be provided for
-            the header. This will be interpreted as Markdown text and transformed internally to
-            HTML.
+            value which produces a header with a standard title and set of details underneath. Aside
+            from this default, free text can be provided for the header. This will be interpreted as
+            Markdown text and transformed internally to HTML. You can provide one of two templating
+            elements: `{title}` and `{details}`. The default header has the template
+            `"{title}{details}"` so you can easily start from that and modify as you see fit.
         limit
             The number of rows to display for those validation steps that check values in rows (the
             `col_vals_*()` validation steps). The default is `10` rows and the limit can be removed
@@ -10632,23 +10634,6 @@ def _step_report_schema_in_order(
     if debug_return_df:
         return schema_combined
 
-    # Get the other parameters for the `col_schema_match()` function
-    case_sensitive_colnames = schema_info["params"]["case_sensitive_colnames"]
-    case_sensitive_dtypes = schema_info["params"]["case_sensitive_dtypes"]
-    full_match_dtypes = schema_info["params"]["full_match_dtypes"]
-
-    # Generate text for the `col_schema_match()` parameters
-    col_schema_match_params_html = _create_col_schema_match_params_html(
-        complete=complete,
-        in_order=True,
-        case_sensitive_colnames=case_sensitive_colnames,
-        case_sensitive_dtypes=case_sensitive_dtypes,
-        full_match_dtypes=full_match_dtypes,
-    )
-
-    # Get the passing symbol for the step
-    passing_symbol = CHECK_MARK_SPAN if all_passed else CROSS_MARK_SPAN
-
     step_report = (
         GT(schema_combined, id="pb_step_tbl")
         .fmt_markdown(columns=None)
@@ -10737,15 +10722,6 @@ def _step_report_schema_in_order(
         .tab_options(source_notes_font_size="12px")
     )
 
-    if header == ":default:":
-        step_report = step_report.tab_header(
-            title=html(f"Report for Validation Step {step} {passing_symbol}"),
-            subtitle=html(col_schema_match_params_html),
-        )
-
-    else:
-        step_report = step_report.tab_header(title=md(header))
-
     if schema_length == "shorter":
         # Add background color to the missing column on the exp side
         step_report = step_report.tab_style(
@@ -10785,6 +10761,39 @@ def _step_report_schema_in_order(
     # If the version of `great_tables` is `>=0.17.0` then disable Quarto table processing
     if version("great_tables") >= "0.17.0":
         step_report = step_report.tab_options(quarto_disable_processing=True)
+
+    # Get the other parameters for the `col_schema_match()` function
+    case_sensitive_colnames = schema_info["params"]["case_sensitive_colnames"]
+    case_sensitive_dtypes = schema_info["params"]["case_sensitive_dtypes"]
+    full_match_dtypes = schema_info["params"]["full_match_dtypes"]
+
+    # Get the passing symbol for the step
+    passing_symbol = CHECK_MARK_SPAN if all_passed else CROSS_MARK_SPAN
+
+    # Generate the title for the step report
+    title = f"Report for Validation Step {step} {passing_symbol}"
+
+    # Generate the details for the step report
+    details = _create_col_schema_match_params_html(
+        complete=complete,
+        in_order=True,
+        case_sensitive_colnames=case_sensitive_colnames,
+        case_sensitive_dtypes=case_sensitive_dtypes,
+        full_match_dtypes=full_match_dtypes,
+    )
+
+    # Generate the default template text for the header when `":default:"` is used
+    if header == ":default:":
+        header = "{title}{details}"
+
+    # Use commonmark to convert the header text to HTML
+    header = commonmark.commonmark(header)
+
+    # Place any templated text in the header
+    header = header.format(title=title, details=details)
+
+    # Create the header with `header` string
+    step_report = step_report.tab_header(title=md(header))
 
     return step_report
 
@@ -11051,23 +11060,6 @@ def _step_report_schema_any_order(
     if debug_return_df:
         return schema_combined
 
-    # Get the other parameters for the `col_schema_match()` function
-    case_sensitive_colnames = schema_info["params"]["case_sensitive_colnames"]
-    case_sensitive_dtypes = schema_info["params"]["case_sensitive_dtypes"]
-    full_match_dtypes = schema_info["params"]["full_match_dtypes"]
-
-    # Generate text for the `col_schema_match()` parameters
-    col_schema_match_params_html = _create_col_schema_match_params_html(
-        complete=complete,
-        in_order=False,
-        case_sensitive_colnames=case_sensitive_colnames,
-        case_sensitive_dtypes=case_sensitive_dtypes,
-        full_match_dtypes=full_match_dtypes,
-    )
-
-    # Get the passing symbol for the step
-    passing_symbol = CHECK_MARK_SPAN if all_passed else CROSS_MARK_SPAN
-
     step_report = (
         GT(schema_combined, id="pb_step_tbl")
         .fmt_markdown(columns=None)
@@ -11157,15 +11149,6 @@ def _step_report_schema_any_order(
         .tab_options(source_notes_font_size="12px")
     )
 
-    if header == ":default:":
-        step_report = step_report.tab_header(
-            title=html(f"Report for Validation Step {step} {passing_symbol}"),
-            subtitle=html(col_schema_match_params_html),
-        )
-
-    else:
-        step_report = step_report.tab_header(title=md(header))
-
     # Add background color to signify limits of target table schema (on LHS side)
     if len(colnames_exp_unmatched) > 0:
         step_report = step_report.tab_style(
@@ -11183,6 +11166,39 @@ def _step_report_schema_any_order(
     # If the version of `great_tables` is `>=0.17.0` then disable Quarto table processing
     if version("great_tables") >= "0.17.0":
         step_report = step_report.tab_options(quarto_disable_processing=True)
+
+    # Get the other parameters for the `col_schema_match()` function
+    case_sensitive_colnames = schema_info["params"]["case_sensitive_colnames"]
+    case_sensitive_dtypes = schema_info["params"]["case_sensitive_dtypes"]
+    full_match_dtypes = schema_info["params"]["full_match_dtypes"]
+
+    # Get the passing symbol for the step
+    passing_symbol = CHECK_MARK_SPAN if all_passed else CROSS_MARK_SPAN
+
+    # Generate the title for the step report
+    title = f"Report for Validation Step {step} {passing_symbol}"
+
+    # Generate the details for the step report
+    details = _create_col_schema_match_params_html(
+        complete=complete,
+        in_order=False,
+        case_sensitive_colnames=case_sensitive_colnames,
+        case_sensitive_dtypes=case_sensitive_dtypes,
+        full_match_dtypes=full_match_dtypes,
+    )
+
+    # Generate the default template text for the header when `":default:"` is used
+    if header == ":default:":
+        header = "{title}{details}"
+
+    # Use commonmark to convert the header text to HTML
+    header = commonmark.commonmark(header)
+
+    # Place any templated text in the header
+    header = header.format(title=title, details=details)
+
+    # Create the header with `header` string
+    step_report = step_report.tab_header(title=md(header))
 
     return step_report
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10435,27 +10435,34 @@ def _step_report_row_based(
             not_shown = " (NOT SHOWN)"
             shown_failures = ""
 
-        if header == ":default:":
-            step_report = step_report.tab_header(
-                title=f"Report for Validation Step {i}",
-                subtitle=html(
-                    "<div>"
-                    "ASSERTION <span style='border-style: solid; border-width: thin; "
-                    "border-color: lightblue; padding-left: 2px; padding-right: 2px;'>"
-                    f"<code style='color: #303030;'>{text}</code></span><br>"
-                    f"<div style='padding-top: 3px;'><strong>{n_failed}</strong> / "
-                    f"<strong>{n}</strong> TEST UNIT FAILURES "
-                    f"IN COLUMN <strong>{column_position}</strong>{not_shown}</div>"
-                    f"<div style='padding-top: 10px;'>EXTRACT OF {extract_of_x_rows} "
-                    f"<strong>{extract_length_resolved}</strong> ROWS {shown_failures}:"
-                    "</div></div>"
-                ),
-            )
+        title = f"Report for Validation Step {i}"
+        details = (
+            "<div style='font-size: 13.6px;'>"
+            "<div style='padding-top: 7px;'>"
+            "ASSERTION <span style='border-style: solid; border-width: thin; "
+            "border-color: lightblue; padding-left: 2px; padding-right: 2px;'>"
+            f"<code style='color: #303030;'>{text}</code></span>"
+            "</div>"
+            "<div style='padding-top: 7px;'>"
+            f"<strong>{n_failed}</strong> / "
+            f"<strong>{n}</strong> TEST UNIT FAILURES "
+            f"IN COLUMN <strong>{column_position}</strong>{not_shown}"
+            "</div>"
+            f"<div>EXTRACT OF {extract_of_x_rows} "
+            f"<strong>{extract_length_resolved}</strong> ROWS {shown_failures}:"
+            "</div>"
+            "</div>"
+        )
 
-        else:
-            step_report = step_report.tab_header(
-                title=md(header),
-            )
+        # Generate the default template text for the header when `":default:"` is used
+        if header == ":default:":
+            header = "{title}<br>{details}"
+
+        # Place any templated text in the header
+        header = header.format(title=title, details=details)
+
+        # Create the header with `header` string
+        step_report = step_report.tab_header(title=md(header))
 
     return step_report
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -6640,9 +6640,17 @@ def test_get_step_report_no_fail(tbl_type):
     for i in range(1, 18):
         assert isinstance(validation.get_step_report(i=i, limit=None), GT.GT)
 
-    # Test with a custom header
+    # Test with a custom header using static text
     for i in range(1, 18):
         assert isinstance(validation.get_step_report(i=i, header="Custom header"), GT.GT)
+
+    # Test with a custom header using templating elements
+    for i in range(1, 18):
+        assert isinstance(validation.get_step_report(i=i, header="Title {title} {details}"), GT.GT)
+
+    # Test with header removal
+    for i in range(1, 18):
+        assert isinstance(validation.get_step_report(i=i, header=None), GT.GT)
 
     #
     # Tests with a subset of columns


### PR DESCRIPTION
This PR makes a second attempt to better let the user customize the header in a step report. Previously, the `header=` arg would accept text that would completely replace the header. However, the header in a step report consists of a title element and a larger details element. You couldn't replace only the title portion without wiping out the details part in the process.

Here, we allow for use of templating, where the default template is `"{title}{details}"` (and `header=":default:"` calls up this standard template). If you wanted to replace the title and keep the details, you'd supply `"Custom Title {details}"`. Here's an example:

 ```python
import pointblank as pb

validation = (
    pb.Validate(data=pb.load_dataset(dataset="game_revenue", tbl_type="polars"))
    .col_vals_lt(columns="item_revenue", value=200)
    .col_vals_gt(columns="item_revenue", value=0)
    .col_vals_gt(columns="session_duration", value=5)
    .col_vals_in_set(columns="item_type", set=["iap", "ad"])
    .col_vals_regex(columns="player_id", pattern=r"[A-Z]{12}\d{3}")
    .interrogate()
)

validation.get_step_report(
    i=3,
    header="Custom Title {details}",
)
```

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/f9cc5541-42b8-43ee-90d9-b93d487fc79b" />

Fixes: https://github.com/posit-dev/pointblank/issues/111