### PR TITLE
feat: add ability to execute final actions for validation (post-interrogation actions)

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -98,6 +98,7 @@ quartodoc:
           members: []
         - name: Thresholds
         - name: Actions
+          members: []
         - name: FinalActions
         - name: Schema
           members: []

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -98,6 +98,7 @@ quartodoc:
           members: []
         - name: Thresholds
         - name: Actions
+        - name: FinalActions
         - name: Schema
           members: []
         - name: DraftValidation

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -196,4 +196,5 @@ quartodoc:
         - name: get_column_count
         - name: get_row_count
         - name: get_action_metadata
+        - name: get_validation_summary
         - name: config

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -24,13 +24,14 @@ from pointblank.datascan import DataScan, col_summary_tbl
 from pointblank.draft import DraftValidation
 from pointblank.schema import Schema
 from pointblank.tf import TF
-from pointblank.thresholds import Actions, Thresholds
+from pointblank.thresholds import Actions, FinalActions, Thresholds
 from pointblank.validate import (
     Validate,
     config,
     get_action_metadata,
     get_column_count,
     get_row_count,
+    get_validation_summary,
     load_dataset,
     missing_vals_tbl,
     preview,
@@ -42,6 +43,7 @@ __all__ = [
     "Validate",
     "Thresholds",
     "Actions",
+    "FinalActions",
     "Schema",
     "DataScan",
     "DraftValidation",
@@ -59,6 +61,7 @@ __all__ = [
     "preview",
     "missing_vals_tbl",
     "get_action_metadata",
+    "get_validation_summary",
     "get_column_count",
     "get_row_count",
 ]

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -625,3 +625,6 @@ class FinalActions:
             return f"FinalActions({self.actions.__name__})"
         else:
             return f"FinalActions({self.actions})"  # pragma: no cover
+
+    def __str__(self) -> str:
+        return self.__repr__()

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -624,4 +624,4 @@ class FinalActions:
         elif callable(self.actions):
             return f"FinalActions({self.actions.__name__})"
         else:
-            return f"FinalActions({self.actions})"
+            return f"FinalActions({self.actions})"  # pragma: no cover

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -511,8 +511,43 @@ class FinalActions:
         that will be executed with no arguments, or (2) a string message that will be printed to the
         console.
 
+    Returns
+    -------
+    FinalActions
+        An `FinalActions` object. This can be used when using the
+        [`Validate`](`pointblank.Validate`) class (to set final actions for the validation
+        workflow).
+
+    Types of Actions
+    ----------------
+    Final actions can be defined in two different ways:
+
+    1. **String**: A message to be displayed when the validation is complete.
+    2. **Callable**: A function that is called when the validation is complete.
+
+    The actions are executed at the end of the validation workflow. When providing a string, it will
+    simply be printed to the console. A callable will also be executed at the time of validation
+    completion. Several strings and callables can be provided to the `FinalActions` class, and
+    they will be executed in the order they are provided.
+
+    Crafting Callables with `get_validation_summary()`
+    -------------------------------------------------
+    When creating a callable function to be used as a final action, you can use the
+    [`get_validation_summary()`](`pointblank.get_validation_summary`) function to retrieve the
+    summary of the validation results. This summary contains information about the validation
+    workflow, including the number of test units, the number of failing test units, and the
+    threshold levels that were exceeded. You can use this information to craft your final action
+    message or to take specific actions based on the validation results.
+
     Examples
     --------
+    Final actions provide a powerful way to respond to the overall results of a validation workflow.
+    They're especially useful for sending notifications, generating reports, or taking corrective
+    actions based on the complete validation outcome.
+
+    The following example shows how to create a final action that checks for critical failures
+    and sends an alert:
+
     ```python
     import pointblank as pb
 
@@ -531,16 +566,23 @@ class FinalActions:
     )
     ```
 
-    Multiple final actions can be provided:
+    In this example, the `send_alert()` function is defined to check the validation summary for
+    critical failures. If any are found, an alert message is printed to the console. The function is
+    passed to the `FinalActions` class, which ensures it will be executed after all validation steps
+    are complete. Note that we used the `get_validation_summary()` function to retrieve the summary
+    of the validation results to help craft the alert message.
+
+    Multiple final actions can be provided in a sequence. They will be executed in the order they
+    are specified after all validation steps have completed:
 
     ```python
     validation = (
         pb.Validate(
             data=my_data,
             final_actions=pb.FinalActions(
-                "Validation complete.",
-                send_alert,
-                generate_report
+                "Validation complete.",  # a string message
+                send_alert,              # a callable function
+                generate_report          # another callable function
             )
         )
         .col_vals_gt(columns="revenue", value=0)

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -543,6 +543,16 @@ class FinalActions:
     actions: list | str | Callable
 
     def __init__(self, *args):
+        # Check that all arguments are either strings or callables
+        for arg in args:
+            if not isinstance(arg, (str, Callable)) and not (
+                isinstance(arg, list) and all(isinstance(item, (str, Callable)) for item in arg)
+            ):
+                raise TypeError(
+                    f"All final actions must be strings, callables, or lists of strings/callables. "
+                    f"Got {type(arg).__name__} instead."
+                )
+
         if len(args) == 0:
             self.actions = []
         elif len(args) == 1:

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Callable
 
-__all__ = ["Thresholds", "Actions"]
+__all__ = ["Thresholds", "Actions", "FinalActions"]
 
 
 @dataclass
@@ -484,3 +484,20 @@ class Actions:
 
     def _get_action(self, level: str) -> list[str | Callable]:
         return getattr(self, level)
+
+
+@dataclass
+class FinalActions:
+    """Define actions to be taken after validation is complete."""
+
+    actions: list | str | Callable
+
+    def __init__(self, *args):
+        if len(args) == 0:
+            self.actions = []
+        elif len(args) == 1:
+            # If a single action is provided, store it directly (not in a list)
+            self.actions = args[0]
+        else:
+            # Multiple actions, store as a list
+            self.actions = list(args)

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -561,3 +561,16 @@ class FinalActions:
         else:
             # Multiple actions, store as a list
             self.actions = list(args)
+
+    def __repr__(self) -> str:
+        if isinstance(self.actions, list):
+            action_reprs = ", ".join(
+                f"'{a}'" if isinstance(a, str) else a.__name__ for a in self.actions
+            )
+            return f"FinalActions([{action_reprs}])"
+        elif isinstance(self.actions, str):
+            return f"FinalActions('{self.actions}')"
+        elif callable(self.actions):
+            return f"FinalActions({self.actions.__name__})"
+        else:
+            return f"FinalActions({self.actions})"

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -373,6 +373,15 @@ class Actions:
     displayed as `"WARNING: 'col_vals_gt' threshold exceeded for column a."` when the 'warning'
     threshold is exceeded in a 'col_vals_gt' validation step involving column `a`.
 
+    Crafting Callables with `get_action_metadata()`
+    -----------------------------------------------
+    When creating a callable function to be used as an action, you can use the
+    [`get_action_metadata()`](`pointblank.get_action_metadata`) function to retrieve metadata about
+    the step where the action is executed. This metadata contains information about the validation
+    step, including the step type, level, step number, column name, and associated value. You can
+    use this information to craft your action message or to take specific actions based on the
+    metadata provided.
+
     Examples
     --------
     ```{python}

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -488,7 +488,57 @@ class Actions:
 
 @dataclass
 class FinalActions:
-    """Define actions to be taken after validation is complete."""
+    """
+    Define actions to be taken after validation is complete.
+
+    Final actions are executed after all validation steps have been completed. They provide a
+    mechanism to respond to the overall validation results, such as sending alerts when critical
+    failures are detected or generating summary reports.
+
+    Parameters
+    ----------
+    *actions
+        One or more actions to execute after validation. An action can be (1) a callable function
+        that will be executed with no arguments, or (2) a string message that will be printed to the
+        console.
+
+    Examples
+    --------
+    ```python
+    import pointblank as pb
+
+    def send_alert():
+        summary = pb.get_validation_summary()
+        if summary["highest_severity"] == "critical":
+            print(f"ALERT: Critical validation failures found in {summary['table_name']}")
+
+    validation = (
+        pb.Validate(
+            data=my_data,
+            final_actions=pb.FinalActions(send_alert)
+        )
+        .col_vals_gt(columns="revenue", value=0)
+        .interrogate()
+    )
+    ```
+
+    Multiple final actions can be provided:
+
+    ```python
+    validation = (
+        pb.Validate(
+            data=my_data,
+            final_actions=pb.FinalActions(
+                "Validation complete.",
+                send_alert,
+                generate_report
+            )
+        )
+        .col_vals_gt(columns="revenue", value=0)
+        .interrogate()
+    )
+    ```
+    """
 
     actions: list | str | Callable
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2263,6 +2263,24 @@ class Validate:
         # Normalize the thresholds value (if any) to a Thresholds object
         self.thresholds = _normalize_thresholds_creation(self.thresholds)
 
+        # Check that `actions` is an Actions object if provided
+        # TODO: allow string, callable, of list of either and upgrade to Actions object
+        if self.actions is not None and not isinstance(self.actions, Actions):  # pragma: no cover
+            raise TypeError(
+                "The actions parameter must be an Actions object. "
+                "Please use Actions() to wrap your actions."
+            )
+
+        # Check that `final_actions` is a FinalActions object if provided
+        # TODO: allow string, callable, of list of either and upgrade to FinalActions object
+        if self.final_actions is not None and not isinstance(
+            self.final_actions, FinalActions
+        ):  # pragma: no cover
+            raise TypeError(
+                "The final_actions parameter must be a FinalActions object. "
+                "Please use FinalActions() to wrap your actions."
+            )
+
         # Normalize the reporting language identifier and error if invalid
         if self.lang not in ["zh-Hans", "zh-Hant"]:
             self.lang = _normalize_reporting_language(lang=self.lang)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -226,6 +226,11 @@ def get_validation_summary():
 
     Examples
     --------
+    Final actions are executed after the completion of all validation steps. They provide an
+    opportunity to take appropriate actions based on the overall validation results. Here's an
+    example of a final action function (`send_report()`) that sends an alert when critical
+    validation failures are detected:
+
     ```python
     import pointblank as pb
 
@@ -246,6 +251,32 @@ def get_validation_summary():
         .interrogate()
     )
     ```
+
+    Note that `send_alert_email()` in the example above is a placeholder function that would be
+    implemented by the user to send email alerts. This function is not provided by the Pointblank
+    package.
+
+    The `get_validation_summary()` function can also be used to create custom reporting for
+    validation results:
+
+    ```python
+    def log_validation_results():
+        summary = pb.get_validation_summary()
+
+        print(f"Validation completed with status: {summary['status']}")
+        print(f"Steps: {summary['step_count']} total")
+        print(f"  - {summary['passing_steps']} passing, {summary['failing_steps']} failing")
+        print(
+            f"  - Severity: {summary['warning_steps']} warnings, {summary['error_steps']} errors, "
+            f"{summary['critical_steps']} critical"
+        )
+
+        if summary['status'] in ["ERROR", "CRITICAL"]:
+            print("⚠️ Action required: Please review failing validation steps!")
+    ```
+
+    Final actions work well with both simple logging and more complex notification systems,
+    allowing you to integrate validation results into your broader data quality workflows.
     """
     if hasattr(_final_action_context, "summary"):
         return _final_action_context.summary

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -9500,41 +9500,21 @@ class Validate:
             "validation_duration": validation_duration,
         }
 
-        # If final_actions is a FinalActions object, extract the action(s)
-        if isinstance(self.final_actions, FinalActions):
-            actions = self.final_actions.actions
-        else:
-            # For backward compatibility
-            actions = self.final_actions
+        # Extract the actions from FinalActions object and execute
+        action = self.final_actions.actions
 
-        # Process the actions
-        if isinstance(actions, str):
-            print(actions)
-        elif callable(actions):
-            # Execute the callable within the context manager
-            with _final_action_context_manager(summary):
-                # For backward compatibility, still pass the validate object directly if the
-                # function expects a parameter
-                import inspect
-
-                sig = inspect.signature(actions)
-                if len(sig.parameters) > 0:
-                    actions(self)
-                else:
-                    actions()
-        elif isinstance(actions, list):
-            for action in actions:
-                if isinstance(action, str):
-                    print(action)
-                elif callable(action):
-                    with _final_action_context_manager(summary):
-                        import inspect
-
-                        sig = inspect.signature(action)
-                        if len(sig.parameters) > 0:
-                            action(self)
-                        else:
-                            action()
+        # Execute the action within the context manager
+        with _final_action_context_manager(summary):
+            if isinstance(action, str):
+                print(action)
+            elif callable(action):
+                action()
+            elif isinstance(action, list):
+                for single_action in action:
+                    if isinstance(single_action, str):
+                        print(single_action)
+                    elif callable(single_action):
+                        single_action()
 
     def _get_highest_severity_level(self):
         """Get the highest severity level reached across all validation steps."""

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2267,8 +2267,8 @@ class Validate:
         # TODO: allow string, callable, of list of either and upgrade to Actions object
         if self.actions is not None and not isinstance(self.actions, Actions):  # pragma: no cover
             raise TypeError(
-                "The actions parameter must be an Actions object. "
-                "Please use Actions() to wrap your actions."
+                "The `actions=` parameter must be an `Actions` object. "
+                "Please use `Actions()` to wrap your actions."
             )
 
         # Check that `final_actions` is a FinalActions object if provided
@@ -2277,8 +2277,8 @@ class Validate:
             self.final_actions, FinalActions
         ):  # pragma: no cover
             raise TypeError(
-                "The final_actions parameter must be a FinalActions object. "
-                "Please use FinalActions() to wrap your actions."
+                "The `final_actions=` parameter must be a `FinalActions` object. "
+                "Please use `FinalActions()` to wrap your finalizing actions."
             )
 
         # Normalize the reporting language identifier and error if invalid

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -9427,6 +9427,12 @@ class Validate:
         # Get the overall status based on the validation results
         status = self._get_overall_status()
 
+        # Get row count using the dedicated function that handles all table types correctly
+        row_count = get_row_count(self.data)
+
+        # Get column count using the dedicated function that handles all table types correctly
+        column_count = get_column_count(self.data)
+
         # Create a summary of validation results as a dictionary
         summary = {
             "step_count": len(self.validation_info),
@@ -9438,8 +9444,8 @@ class Validate:
             "validation_duration": (self.time_end - self.time_start).total_seconds()
             if self.time_end and self.time_start
             else 0,
-            "row_count": getattr(self, "n_rows", 0),
-            "column_count": len(self.data.columns) if hasattr(self.data, "columns") else 0,
+            "row_count": row_count,
+            "column_count": column_count,
             "table_name": self.tbl_name or "Unknown",
             "status": status,
             "steps_with_issues": [step.i for step in self.validation_info if not step.all_passed],

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2081,6 +2081,12 @@ def test_final_actions_repr():
     assert repr(actions) == "FinalActions(dummy_function)"
 
 
+def test_final_actions_str():
+    # Test string method of FinalActions
+    actions = FinalActions(["action1", "action2"])
+    assert str(actions) == "FinalActions(['action1', 'action2'])"
+
+
 def test_validation_with_preprocessing_pd(tbl_pd):
     v = (
         Validate(tbl_pd)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2056,6 +2056,31 @@ def test_validation_with_final_actions_highest_severity_critical(tbl_type, capsy
     assert "critical" in captured.out
 
 
+def test_final_actions_type_error():
+    # Expect a TypeError when passing an invalid type to FinalActions
+    with pytest.raises(TypeError):
+        FinalActions(3)
+
+
+def test_final_actions_repr():
+    # Test `FinalActions` with a list of strings
+    actions = FinalActions(["action1", "action2"])
+    assert repr(actions) == "FinalActions(['action1', 'action2'])"
+    # Test with a single string
+    actions = FinalActions("action1")
+    assert repr(actions) == "FinalActions('action1')"
+    # Test with nothing provided
+    actions = FinalActions()
+    assert repr(actions) == "FinalActions([])"
+
+    # Test with a callable
+    def dummy_function():
+        pass
+
+    actions = FinalActions(dummy_function)
+    assert repr(actions) == "FinalActions(dummy_function)"
+
+
 def test_validation_with_preprocessing_pd(tbl_pd):
     v = (
         Validate(tbl_pd)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -23,9 +23,11 @@ import narwhals as nw
 
 from pointblank.validate import (
     Actions,
+    FinalActions,
     get_action_metadata,
     get_column_count,
     get_row_count,
+    get_validation_summary,
     load_dataset,
     missing_vals_tbl,
     PointblankConfig,
@@ -1826,6 +1828,65 @@ def test_validation_actions_get_action_metadata(tbl_type, capsys):
     assert "Step: 16, Type: rows_distinct, Column: ['a', 'b', 'c']" in captured.out
     assert "Step: 17, Type: col_count_match, Column: None" in captured.out
     assert "Step: 18, Type: row_count_match, Column: None" in captured.out
+
+
+@pytest.mark.parametrize("tbl_type", ["pandas", "polars", "duckdb"])
+def test_validation_with_final_actions(tbl_type, capsys):
+    def final_info():
+        summary = get_validation_summary()
+
+        passing_steps = summary["list_passing_steps"]
+        failing_steps = summary["list_failing_steps"]
+        n_units_per_step = summary["dict_n"]
+
+        print(
+            f"Validation completed with the highest severity being: {summary['highest_severity']}"
+        )
+        print(
+            f"Steps: {summary['n_steps']} total, {summary['n_passing_steps']} passing, {summary['n_failing_steps']} failing"
+        )
+        print(
+            f"Severity: {summary['n_warning_steps']} warnings, {summary['n_error_steps']} errors, {summary['n_critical_steps']} critical"
+        )
+        print(f"Passing steps: {passing_steps}")
+        print(f"Failing steps: {failing_steps}")
+        print(f"Test units per step: {n_units_per_step}")
+        print(
+            f"Table: {summary['tbl_name']} ({summary['tbl_row_count']} rows, {summary['tbl_column_count']} columns)"
+        )
+
+        if summary["highest_severity"] in ["ERROR", "CRITICAL"]:
+            print("IMPORTANT: Critical validation failures detected!")
+
+        print(f"Validation process took {summary['validation_duration']}s.")
+
+    (
+        Validate(
+            data=load_dataset(dataset="game_revenue", tbl_type=tbl_type),
+            tbl_name="game_revenue",
+            label="Comprehensive validation example",
+            thresholds=Thresholds(warning=0.10, error=0.25, critical=0.35),
+            final_actions=FinalActions(final_info),
+        )
+        .col_vals_in_set(columns="item_type", set=["iap", "ad"])
+        .rows_distinct(columns_subset=["player_id", "session_id", "time"])
+        .col_vals_in_set(columns="acquisition", set=["google", "facebook", "organic"])
+        .col_vals_gt(columns="session_duration", value=20)
+        .col_vals_ge(columns="item_revenue", value=0.5)
+        .interrogate()
+    )
+
+    # Capture the output and verify that several lines were printed to the console
+    captured = capsys.readouterr()
+    assert "Validation completed with the highest severity being: critical" in captured.out
+
+    assert "Steps: 5 total, 1 passing, 4 failing" in captured.out
+    assert "Severity: 3 warnings, 2 errors, 1 critical" in captured.out
+    assert "Passing steps: [1]" in captured.out
+    assert "Failing steps: [2, 3, 4, 5]" in captured.out
+    assert "Test units per step: {1: 2000, 2: 2000, 3: 2000, 4: 2000, 5: 2000}" in captured.out
+    assert "Table: game_revenue (2000 rows, 11 columns)" in captured.out
+    assert "Validation process took " in captured.out
 
 
 def test_validation_with_preprocessing_pd(tbl_pd):


### PR DESCRIPTION
This PR introduces the `FinalActions` class and integrates it into the `Validate` workflow. It'll allow users to define actions that execute after all validation steps have completed. The key changes here:

- added the `FinalActions` class for wrapping strings, callables, or lists of actions (similar to the `Actions` class)
- enhanced the `Validate` class to accept a `final_actions=` parameter
- implemented the `_execute_final_actions()` method in `Validate` to run final actions after interrogation
- added the `_get_highest_severity_level()` method to determine overall validation status
- created a context manager system for providing summary data to final actions
- added documentation and tests

Here's an example of how it works:

```python
import pointblank as pb

def send_alert():
    summary = pb.get_validation_summary()
    if summary["highest_severity"] == "critical":
        print(f"ALERT: Critical validation failures in {summary['tbl_name']}")

validation = (
    pb.Validate(
        data=my_data,
        final_actions=pb.FinalActions(
            "Validation complete.",
            send_alert
        )
    )
    .col_vals_gt(columns="revenue", value=0)
    .interrogate()
)
```

Final actions also have access to a summary dictionary through the new `get_validation_summary()` function. This makes it easy to take appropriate actions based on validation results. The implementation allows for a parallel usage to creating an actions callable for `actions=` with the `get_action_metadata()` helper function.
