### PR TITLE
Parallel and randomly ordered tests

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -29,7 +29,7 @@ jobs:
           pip install -e '.[dev]'
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-cov pytest-snapshot pandas polars ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0 chatlas requests shiny
+          pip install pytest pytest-randomly pytest-xdist pytest-cov pytest-snapshot pandas polars ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0 chatlas requests shiny
       - name: pytest unit tests
         run: |
           make test

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -29,7 +29,7 @@ jobs:
           pip install -e '.[dev]'
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-randomly pytest-xdist pytest-cov pytest-snapshot pandas polars ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0 chatlas requests shiny
+          pip install pytest pytest-rerunfailures pytest-randomly pytest-xdist pytest-cov pytest-snapshot pandas polars ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0 chatlas requests shiny
       - name: pytest unit tests
         run: |
           make test

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 .PHONY: check
 
+.PHONY: test
 test:
-	pytest --cov=pointblank --cov-report=xml
+	@uv run pytest \
+		--cov=pointblank \
+		--cov-report=term-missing \
+		--randomly-seed 123 \
+		-n auto
 
 test-update:
 	pytest --snapshot-update
 
-test-coverage:
-	pytest --cov=pointblank --cov-report=term-missing
 
 lint: ## Run ruff formatter and linter
 	@uv run ruff format

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ test:
 		--cov=pointblank \
 		--cov-report=term-missing \
 		--randomly-seed 123 \
-		-n auto
+		-n auto \
+		--reruns 3 \
+		--reruns-delay 1
 
 test-update:
 	pytest --snapshot-update

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: test
 test:
-	@uv run pytest \
+	@pytest \
 		--cov=pointblank \
 		--cov-report=term-missing \
 		--randomly-seed 123 \

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -7,6 +7,7 @@ import datetime
 import inspect
 import json
 import re
+import tempfile
 import threading
 from dataclasses import dataclass
 from importlib.metadata import version
@@ -516,10 +517,10 @@ def load_dataset(
         data_path = files("pointblank.data") / f"{dataset}-duckdb.zip"
 
         # Unzip the DuckDB dataset to a temporary directory
-        with ZipFile(data_path, "r") as z:
-            z.extractall(path="datasets")
+        with tempfile.TemporaryDirectory() as tmp, ZipFile(data_path, "r") as z:
+            z.extractall(path=tmp)
 
-            data_path = f"datasets/{dataset}.ddb"
+            data_path = f"{tmp}/{dataset}.ddb"
 
             dataset = ibis.connect(f"duckdb://{data_path}").table(dataset)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,9 @@ dev = [
     "pyright>=1.1.244",
     "pytest>=3",
     "pytest-cov",
+    "pytest-randomly>=3.16.0",
     "pytest-snapshot",
+    "pytest-xdist>=3.6.1",
     "quartodoc>=0.8.1; python_version >= '3.9'",
     "ruff>=0.9.9",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ docs = [
 
 [dependency-groups]
 dev = [
-    "black",
+    "chatlas>=0.6.1",
     "duckdb>=1.1.3",
     "griffe==0.38.1",
     "ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
     "pytest>=3",
     "pytest-cov",
     "pytest-randomly>=3.16.0",
+    "pytest-rerunfailures>=15.0",
     "pytest-snapshot",
     "pytest-xdist>=3.6.1",
     "quartodoc>=0.8.1; python_version >= '3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ dev = [
     "polars>=1.17.1",
     "pre-commit==2.15.0",
     "pyarrow",
-    "pyright>=1.1.244",
     "pytest>=3",
     "pytest-cov",
     "pytest-randomly>=3.16.0",

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -381,18 +381,11 @@ def test_format_to_integer_float_no_df_lib():
         assert _format_to_float_value(1000) == "1,000.00"
 
 
-def test_format_to_integer_float_only_polars():
+def test_format_to_integer_float_only_polars(monkeypatch):
     # Mock the absence of the Pandas library
-    with patch.dict(sys.modules, {"pandas": None}):
-        assert _format_to_integer_value(1000) == "1,000"
-        assert _format_to_float_value(1000) == "1,000.00"
-
-
-def test_format_to_integer_float_only_pandas():
-    # Mock the absence of the Polars library
-    with patch.dict(sys.modules, {"polars": None}):
-        assert _format_to_integer_value(1000) == "1,000"
-        assert _format_to_float_value(1000) == "1,000.00"
+    monkeypatch.delitem(sys.modules, "pandas", raising=False)
+    assert _format_to_integer_value(1000) == "1,000"
+    assert _format_to_float_value(1000) == "1,000.00"
 
 
 def test_get_fn_name():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -9,6 +9,9 @@ from unittest.mock import patch
 import pytest
 import random
 import itertools
+import tempfile
+import shutil
+from pathlib import Path
 from functools import partial
 import contextlib
 import datetime
@@ -203,25 +206,37 @@ def tbl_dates_times_text_parquet():
 @pytest.fixture
 def tbl_duckdb():
     file_path = pathlib.Path.cwd() / "tests" / "tbl_files" / "tbl_xyz.ddb"
-    return ibis.connect(f"duckdb://{file_path}").table("tbl_xyz")
+    with tempfile.TemporaryDirectory() as tmp:
+        fpath: Path = Path(tmp) / "tab.ddb"
+        shutil.copy(file_path, fpath)
+        return ibis.connect(f"duckdb://{fpath!s}").table("tbl_xyz")
 
 
 @pytest.fixture
 def tbl_missing_duckdb():
     file_path = pathlib.Path.cwd() / "tests" / "tbl_files" / "tbl_xyz_missing.ddb"
-    return ibis.connect(f"duckdb://{file_path}").table("tbl_xyz_missing")
+    with tempfile.TemporaryDirectory() as tmp:
+        fpath: Path = Path(tmp) / "tab_missing.ddb"
+        shutil.copy(file_path, fpath)
+        return ibis.connect(f"duckdb://{fpath!s}").table("tbl_xyz_missing")
 
 
 @pytest.fixture
 def tbl_dates_times_text_duckdb():
     file_path = pathlib.Path.cwd() / "tests" / "tbl_files" / "tbl_dates_times_text.ddb"
-    return ibis.connect(f"duckdb://{file_path}").table("tbl_dates_times_text")
+    with tempfile.TemporaryDirectory() as tmp:
+        fpath: Path = Path(tmp) / "tbl_dates_times_text.ddb"
+        shutil.copy(file_path, fpath)
+        return ibis.connect(f"duckdb://{fpath!s}").table("tbl_dates_times_text")
 
 
 @pytest.fixture
 def tbl_true_dates_times_duckdb():
     file_path = pathlib.Path.cwd() / "tests" / "tbl_files" / "tbl_true_dates_times.ddb"
-    return ibis.connect(f"duckdb://{file_path}").table("tbl_true_dates_times")
+    with tempfile.TemporaryDirectory() as tmp:
+        fpath: Path = Path(tmp) / "tbl_true_dates_times.ddb"
+        shutil.copy(file_path, fpath)
+        return ibis.connect(f"duckdb://{fpath!s}").table("tbl_true_dates_times")
 
 
 @pytest.fixture


### PR DESCRIPTION
This pr will close #164 . There's 1 change to the source code - when a duckdb dataset is loaded, it's extracted to a temporary directory and not source folder in site packages. 

Moving to tmp before connecting also has the effect of removing the need for write permissions to your source code location. For example if users have their environment sitting on a shared location, loading a duckdb dataset should(?) fail since they could not extract it. I'm also unsure of duckdb's file locking rules on this, they seem to handle connecting to a file differently than the other libraries. I'm also fairly certain Ibis is the one checking for locked files on behalf of duckdb. I'm not familiar with the Ibis library enough to hypothesize the mechanism.

In summary, serializing the loading of example datasets probably has some other benefits.

The only other code that needed updating were the fixtures that similarly loaded duckdb tables. I had them copy the example data to temporary locations.