### PR TITLE
feat: add in Python 3.8 and 3.9 compatible type aliases

### DIFF
--- a/pointblank/_typing.py
+++ b/pointblank/_typing.py
@@ -1,26 +1,37 @@
 from __future__ import annotations
 
-from typing import TypeAlias
+import sys
+from typing import List, Tuple, Union
 
-## Absolute bounds, ie. plus or minus
-AbsoluteBounds: TypeAlias = tuple[int, int]
+# Check Python version for TypeAlias support
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
 
-## Relative bounds, ie. plus or minus some percent
-RelativeBounds: TypeAlias = tuple[float, float]
+    # Python 3.10+ style type aliases
+    AbsoluteBounds: TypeAlias = Tuple[int, int]
+    RelativeBounds: TypeAlias = Tuple[float, float]
+    Tolerance: TypeAlias = Union[int, float, AbsoluteBounds, RelativeBounds]
+    SegmentValue: TypeAlias = Union[str, List[str]]
+    SegmentTuple: TypeAlias = Tuple[str, SegmentValue]
+    SegmentItem: TypeAlias = Union[str, SegmentTuple]
+    SegmentSpec: TypeAlias = Union[str, SegmentTuple, List[SegmentItem]]
+else:
+    # Python 3.8 and 3.9 compatible type aliases
+    AbsoluteBounds = Tuple[int, int]
+    RelativeBounds = Tuple[float, float]
+    Tolerance = Union[int, float, AbsoluteBounds, RelativeBounds]
+    SegmentValue = Union[str, List[str]]
+    SegmentTuple = Tuple[str, SegmentValue]
+    SegmentItem = Union[str, SegmentTuple]
+    SegmentSpec = Union[str, SegmentTuple, List[SegmentItem]]
 
-## Tolerance afforded to some check
-Tolerance: TypeAlias = int | float | AbsoluteBounds | RelativeBounds
-
-## Types for data segmentation
-
-## Value(s) that can be used in a segment tuple
-SegmentValue: TypeAlias = str | list[str]
-
-## (column, value(s)) format for segments
-SegmentTuple: TypeAlias = tuple[str, SegmentValue]
-
-## Individual segment item (string or tuple)
-SegmentItem: TypeAlias = str | SegmentTuple
-
-## Full segment specification options
-SegmentSpec: TypeAlias = str | SegmentTuple | list[SegmentItem]
+# Add docstrings for better IDE support
+AbsoluteBounds.__doc__ = "Absolute bounds (i.e., plus or minus)"
+RelativeBounds.__doc__ = "Relative bounds (i.e., plus or minus some percent)"
+Tolerance.__doc__ = "Tolerance (i.e., the allowed deviation)"
+SegmentValue.__doc__ = "Value(s) that can be used in a segment tuple"
+SegmentTuple.__doc__ = "(column, value(s)) format for segments"
+SegmentItem.__doc__ = "Individual segment item (string or tuple)"
+SegmentSpec.__doc__ = (
+    "Full segment specification options (i.e., all options for segment specification)"
+)


### PR DESCRIPTION
This PR addresses an issue where type aliases currently don't work in versions below Python 3.10. We now check the Python version for and use either:

- Python 3.10+ style type aliases
- Python 3.8- and 3.9-compatible type aliases

Fixes: https://github.com/posit-dev/pointblank/issues/173