### PR TITLE
fix: improve schema as str when type not declared

### DIFF
--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -728,7 +728,14 @@ class Schema:
                 return new_schema
 
     def __str__(self):
-        return "Pointblank Schema\n" + "\n".join([f"  {col[0]}: {col[1]}" for col in self.columns])
+        formatted_columns = []
+        for col in self.columns:
+            if len(col) == 1:  # Only column name provided (no data type)
+                formatted_columns.append(f"  {col[0]}: <ANY>")
+            else:  # Both column name and data type provided
+                formatted_columns.append(f"  {col[0]}: {col[1]}")
+
+        return "Pointblank Schema\n" + "\n".join(formatted_columns)
 
     def __repr__(self):
         return f"Schema(columns={self.columns})"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -57,6 +57,14 @@ def test_schema_str(capfd):
     assert captured.out == expected_output
 
 
+def test_schema_str_no_data_type(capfd):
+    schema = Schema(columns=[("a",), ("b", "str")])
+    print(schema)
+    captured = capfd.readouterr()
+    expected_output = "Pointblank Schema\n  a: <ANY>\n  b: str\n"
+    assert captured.out == expected_output
+
+
 def test_schema_repr():
     schema = Schema(columns=[("a", "int"), ("b", "str")])
     expected_repr = "Schema(columns=[('a', 'int'), ('b', 'str')])"


### PR DESCRIPTION
This fix will make printed schemas work even if there is no type declared for a column.