### PR TITLE
feat: allow `assert_passing()` to interrogate when needed

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8772,6 +8772,10 @@ class Validate:
         assertion made is printed in the `AssertionError` message if a failure occurs, ensuring
         some details are preserved.
 
+        If the validation has not yet been interrogated, this method will automatically call
+        [`interrogate()`](`pointblank.Validate.interrogate`) with default parameters before checking
+        for passing tests.
+
         Raises
         -------
         AssertionError
@@ -8781,8 +8785,9 @@ class Validate:
         --------
         In the example below, we'll use a simple Polars DataFrame with three columns (`a`, `b`, and
         `c`). There will be three validation steps, and the second step will have a failing test
-        unit (the value `10` isn't less than `9`). After interrogation, the `assert_passing()`
-        method is used to assert that all validation steps passed perfectly.
+        unit (the value `10` isn't less than `9`). The `assert_passing()` method is used to assert
+        that all validation steps passed perfectly, automatically performing the interrogation if
+        needed.
 
         ```{python}
         #| error: True
@@ -8803,12 +8808,16 @@ class Validate:
             .col_vals_gt(columns="a", value=0)
             .col_vals_lt(columns="b", value=9) # this assertion is false
             .col_vals_in_set(columns="c", set=["a", "b"])
-            .interrogate()
         )
 
+        # No need to call [`interrogate()`](`pointblank.Validate.interrogate`) explicitly
         validation.assert_passing()
         ```
         """
+        # Check if validation has been interrogated
+        if not hasattr(self, "time_start") or self.time_start is None:
+            # Auto-interrogate with default parameters
+            self.interrogate()
 
         if not self.all_passed():
             failed_steps = [

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8031,7 +8031,7 @@ class Validate:
 
         After interrogation is complete, the `Validate` object will have gathered information, and
         we can use methods like [`n_passed()`](`pointblank.Validate.n_passed`),
-        [`f_failed()`](`pointblank.Validate.f_failed`)`, etc., to understand how the table performed
+        [`f_failed()`](`pointblank.Validate.f_failed`), etc., to understand how the table performed
         against the validation plan. A visual representation of the validation results can be viewed
         by printing the `Validate` object; this will display the validation table in an HTML viewing
         environment.

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -10178,8 +10178,25 @@ def test_assert_passing_example() -> None:
         .col_vals_in_set(columns="c", set=["a", "b"])
         .interrogate()
     )
-
     passing_validation.assert_passing()
+
+    validation_no_interrogation = (
+        Validate(data=tbl)
+        .col_vals_gt(columns="a", value=0)
+        .col_vals_lt(columns="b", value=9)  # this step will not pass
+        .col_vals_in_set(columns="c", set=["a", "b"])
+    )
+    with pytest.raises(AssertionError, match="Step 2: Expect that values in `b`"):
+        validation_no_interrogation.assert_passing()
+
+    passing_validation_no_interrogation = (
+        Validate(data=tbl)
+        .col_vals_gt(columns="a", value=0)
+        # now, the invalid step passes
+        .col_vals_in_set(columns="c", set=["a", "b"])
+    )
+
+    passing_validation_no_interrogation.assert_passing()
 
 
 def test_prep_column_text():


### PR DESCRIPTION
This PR is a minor update to the `assert_passing()` method. It provides some convenience by executing `.interrogate()` on `Validate` objects that haven't been interrogated. And interrogated `Validate` continue to work as they did before with `assert_passing()`.