### PR TITLE
Feat assert below threshold

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -168,6 +168,7 @@ quartodoc:
         - name: Validate.get_data_extracts
         - name: Validate.all_passed
         - name: Validate.assert_passing
+        - name: Validate.assert_below_threshold
         - name: Validate.n
         - name: Validate.n_passed
         - name: Validate.n_failed

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8878,28 +8878,28 @@ class Validate:
         import pointblank as pb
         pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
         ```
-        Create a validation plan with thresholds and assert that results stay below the 'warning'
-        level:
+        Below are some examples of how to use the `assert_below_threshold()` method. First, we'll
+        create a simple Polars DataFrame with two columns (`a` and `b`).
 
         ```{python}
-        import pointblank as pb
         import polars as pl
 
-        # Create a table with some potentially problematic data
         tbl = pl.DataFrame({
             "a": [7, 4, 9, 7, 12],
             "b": [9, 8, 10, 5, 10]
         })
         ```
 
-        Create validation plan with thresholds (`warning=0.1`, `error=0.2`, `critical=0.3`),
-        interrogate, and display the validation report table:
+        Then a validation plan will be created with thresholds (`warning=0.1`, `error=0.2`,
+        `critical=0.3`). After interrogating, we display the validation report table:
 
         ```{python}
+        import pointblank as pb
+
         validation = (
             pb.Validate(data=tbl, thresholds=(0.1, 0.2, 0.3))
-            .col_vals_gt(columns="a", value=5)  # Some will fail
-            .col_vals_lt(columns="b", value=10)  # Some will fail
+            .col_vals_gt(columns="a", value=5)   # 1 failing test unit
+            .col_vals_lt(columns="b", value=10)  # 2 failing test units
             .interrogate()
         )
 
@@ -8922,7 +8922,11 @@ class Validate:
         validation.assert_below_threshold(level="critical", i=1)  # Won't raise an error
         ```
 
-        Provide a custom error message with the `message=` parameter.
+        As the first step is below the 'critical' threshold (it exceeds the 'warning' and 'error'
+        thresholds), no error is raised and nothing is printed.
+
+        We can also provide a custom error message with the `message=` parameter. Let's try that
+        here:
 
         ```{python}
         try:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8872,6 +8872,12 @@ class Validate:
 
         Examples
         --------
+        ```{python}
+        #| echo: false
+        #| output: false
+        import pointblank as pb
+        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        ```
         Create a validation plan with thresholds and assert that results stay below the 'warning'
         level:
 
@@ -8886,8 +8892,8 @@ class Validate:
         })
         ```
 
-        Create validation plan with thresholds (`warning=0.1`, `error=0.2`, `critical=0.3`) and
-        interrogate:
+        Create validation plan with thresholds (`warning=0.1`, `error=0.2`, `critical=0.3`),
+        interrogate, and display the validation report table:
 
         ```{python}
         validation = (
@@ -8896,9 +8902,12 @@ class Validate:
             .col_vals_lt(columns="b", value=10)  # Some will fail
             .interrogate()
         )
+
+        validation
         ```
 
-        This will raise an `AssertionError` if any step exceeds the 'warning' threshold:
+        Using `assert_below_threshold(level="warning")` will raise an `AssertionError` if any step
+        exceeds the 'warning' threshold:
 
         ```{python}
         try:


### PR DESCRIPTION
This PR adds the new `assert_below_threshold()` method to the `Validate` class. This method allows users to programmatically verify that validation failures remain below specified threshold levels ('warning', 'error', or 'critical').

Things it does:

- raises an AssertionError if any validation step exceeds the specified threshold level
- supports checking specific validation steps via the i parameter
- auto-interrogates data if validation hasn't been performed yet
- allows custom error messages
- returns validation step details in the error message (for easier debugging)
- integrates with the existing threshold system ('warning', 'error', 'critical')

This method is useful in automated testing environments where you want to ensure your data quality meets minimum standards before proceeding. Here's an example:

```python

# Create validation with thresholds
validation = (
    pb.Validate(data=df, thresholds=(0.1, 0.2, 0.3))
    .col_vals_gt(columns="amount", value=0)
    .col_vals_lt(columns="price", value=1000)
    .interrogate()
)

# Will raise AssertionError if any validation exceeds warning threshold
validation.assert_below_threshold(level="warning")

# Or check only against critical threshold
validation.assert_below_threshold(level="critical") 

# Or check specific steps
validation.assert_below_threshold(level="error", i=[1, 3])
```

This complements the existing `assert_passing()` method.
