### PR TITLE
feat: `inverse` kwarg added to `col_vals_regex()`

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5714,6 +5714,7 @@ class Validate:
         self,
         columns: str | list[str] | Column | ColumnSelector | ColumnSelectorNarwhals,
         pattern: str,
+        inverse: bool = False,
         na_pass: bool = False,
         pre: Callable | None = None,
         segments: SegmentSpec | None = None,
@@ -5739,6 +5740,9 @@ class Validate:
             generated for each column.
         pattern
             A regular expression pattern to compare against.
+        inverse
+            Should the validation step be inverted? If `False`, the expectation is to find a
+            regex match. If `True`, the expectation is find no match.
         na_pass
             Should any encountered None, NA, or Null values be considered as passing test units? By
             default, this is `False`. Set to `True` to pass test units with missing values.
@@ -5923,6 +5927,7 @@ class Validate:
         # TODO: add check for segments
         # _check_segments(segments=segments)
         _check_thresholds(thresholds=thresholds)
+        _check_boolean_input(param=inverse, param_name="inverse")
         _check_boolean_input(param=na_pass, param_name="na_pass")
         _check_boolean_input(param=active, param_name="active")
 
@@ -5943,12 +5948,15 @@ class Validate:
         # Determine brief to use (global or local) and transform any shorthands of `brief=`
         brief = self.brief if brief is None else _transform_auto_brief(brief=brief)
 
+        # Bundle together pattern and inverse kwarg
+        values = {"pattern": pattern, "inverse": inverse}
+
         # Iterate over the columns and create a validation step for each
         for column in columns:
             val_info = _ValidationInfo(
                 assertion_type=assertion_type,
                 column=column,
-                values=pattern,
+                values=values,
                 na_pass=na_pass,
                 pre=pre,
                 segments=segments,
@@ -8334,7 +8342,8 @@ class Validate:
                 results_tbl = ColValsRegex(
                     data_tbl=data_tbl_step,
                     column=column,
-                    pattern=value,
+                    pattern=value["pattern"],
+                    inverse=value["inverse"],
                     na_pass=na_pass,
                     threshold=threshold,
                     allowed_types=compatible_dtypes,

--- a/tests/test__interrogation.py
+++ b/tests/test__interrogation.py
@@ -208,6 +208,7 @@ def test_col_vals_regex(request, tbl_fixture):
         data_tbl=tbl,
         column="y",
         pattern=r"^[0-9]$",
+        inverse=False,
         na_pass=True,
         threshold=10,
         allowed_types=["str"],

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5751,7 +5751,7 @@ def test_validation_with_selector_helper_functions(request, tbl_fixture):
         4e7,
         ["apple", "banana"],
         (10, 15),
-        "a",
+        {"pattern": "a", "inverse": False},
     ]
 
     # Check that all validation steps are active


### PR DESCRIPTION
# Summary
## Problem
I was using the regex check, but a success was defined as "no match". In dataframe libraries, it's simple to do a logical negation using `~`. Currently, `pointblank` doesn't provide an interface to do so.

Alternatively, reworking the regex to "find no match" adds a lot of complexity (both for writing and computing the regex). In my case, the appropriate "find no match" regex wasn't supported by polars because of regex "look around" limitations. 

## Solution
Now, `.col_vals_regex()` accepts an `inverse=...` kwarg to flip the match results

# Work done
- I followed the logic of `inverse` kwarg in `row_count_match()` checks
- I added `inverse` to the `Interrogator` class, which might be undesirable
- Now, regex checks pass the value `{"pattern": "my-pattern", "inverse": False}` instead of `"my-pattern"`. I modified a test accordingly.
- Updated signatures in docstrings (didn't add full-on example text)

# Remaining TODO
- Add tests to ensure that both `inverse=True` and `inverse=False` behave as expected
- Ensure that the HTML snapshots appropriately render check results (maybe we need to unpack the `dict`?)
- Update the HTML snapshots with the updated `_ValidationInfo.values`

(feel free to complete these steps if it's convenient)

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality.
