### PR TITLE
`col_vals_expr` added to  list constant of row-based validation

### DIFF
--- a/pointblank/_constants.py
+++ b/pointblank/_constants.py
@@ -105,6 +105,7 @@ ROW_BASED_VALIDATION_TYPES = [
     "col_vals_regex",
     "col_vals_null",
     "col_vals_not_null",
+    "col_vals_expr",
     "conjointly",
 ]
 


### PR DESCRIPTION
# Summary
Seems to be an oversight. One line fix solved the issue

# Related GitHub Issues and PRs
#196 

# Checklist
No test were added. It seems to be a red herring that this missing feature was uncaught.

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality.
