### PR TITLE
Ensure that validations can work with LazyFrames

### DIFF
--- a/pointblank/_constants.py
+++ b/pointblank/_constants.py
@@ -162,6 +162,7 @@ TABLE_TYPE_STYLES = {
     "polars": {"background": "#0075FF", "text": "#FFFFFF", "label": "Polars"},
     "polars-lazy": {"background": "#0075FF", "text": "#FFFFFF", "label": "Polars (LazyFrame)"},
     "narwhals": {"background": "#78BEAF", "text": "#222222", "label": "Narwhals"},
+    "narwhals-lazy": {"background": "#78BEAF", "text": "#222222", "label": "Narwhals (LazyFrame)"},
     "duckdb": {"background": "#000000", "text": "#FFFFFF", "label": "DuckDB"},
     "mysql": {"background": "#EBAD40", "text": "#222222", "label": "MySQL"},
     "postgres": {"background": "#3E638B", "text": "#FFFFFF", "label": "PostgreSQL"},

--- a/pointblank/_constants.py
+++ b/pointblank/_constants.py
@@ -160,6 +160,7 @@ TABLE_TYPE_STYLES = {
     "pandas": {"background": "#150458", "text": "#FFFFFF", "label": "Pandas"},
     "polars": {"background": "#0075FF", "text": "#FFFFFF", "label": "Polars"},
     "polars-lazy": {"background": "#0075FF", "text": "#FFFFFF", "label": "Polars (LazyFrame)"},
+    "narwhals": {"background": "#78BEAF", "text": "#222222", "label": "Narwhals"},
     "duckdb": {"background": "#000000", "text": "#FFFFFF", "label": "DuckDB"},
     "mysql": {"background": "#EBAD40", "text": "#222222", "label": "MySQL"},
     "postgres": {"background": "#3E638B", "text": "#FFFFFF", "label": "PostgreSQL"},

--- a/pointblank/_constants.py
+++ b/pointblank/_constants.py
@@ -159,6 +159,7 @@ MODEL_PROVIDERS = [
 TABLE_TYPE_STYLES = {
     "pandas": {"background": "#150458", "text": "#FFFFFF", "label": "Pandas"},
     "polars": {"background": "#0075FF", "text": "#FFFFFF", "label": "Polars"},
+    "polars-lazy": {"background": "#0075FF", "text": "#FFFFFF", "label": "Polars (LazyFrame)"},
     "duckdb": {"background": "#000000", "text": "#FFFFFF", "label": "DuckDB"},
     "mysql": {"background": "#EBAD40", "text": "#222222", "label": "MySQL"},
     "postgres": {"background": "#3E638B", "text": "#FFFFFF", "label": "PostgreSQL"},

--- a/pointblank/_utils.py
+++ b/pointblank/_utils.py
@@ -88,6 +88,17 @@ def _get_tbl_type(data: FrameT | Any) -> str:
     return "unknown"  # pragma: no cover
 
 
+def _is_narwhals_table(data: any) -> bool:
+    # Check if the data is a Narwhals DataFrame
+    type_str = str(type(data)).lower()
+
+    if "narwhals" in type_str:
+        # If the object is not a Narwhals DataFrame, return False
+        return True
+
+    return False
+
+
 def _is_lazy_frame(data: any) -> bool:
     # Check if the data is a Polars or Narwhals DataFrame
     type_str = str(type(data)).lower()

--- a/pointblank/_utils.py
+++ b/pointblank/_utils.py
@@ -88,6 +88,18 @@ def _get_tbl_type(data: FrameT | Any) -> str:
     return "unknown"  # pragma: no cover
 
 
+def _is_lazy_frame(data: any) -> bool:
+    # Check if the data is a Polars or Narwhals DataFrame
+    type_str = str(type(data)).lower()
+
+    if "polars" not in type_str and "narwhals" not in type_str:
+        # If the object is neither a Polars nor a Narwhals DataFrame, return False
+        return False
+
+    # Check if the data is a lazy frame
+    return "lazy" in type_str
+
+
 def _is_lib_present(lib_name: str) -> bool:
     import importlib
 

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -4,7 +4,7 @@ import copy
 from dataclasses import dataclass
 
 from pointblank._constants import IBIS_BACKENDS
-from pointblank._utils import _get_tbl_type, _is_lib_present
+from pointblank._utils import _get_tbl_type, _is_lazy_frame, _is_lib_present
 
 __all__ = ["Schema"]
 
@@ -321,7 +321,10 @@ class Schema:
             self.columns = list(schema_dict.items())
 
         elif table_type == "polars":
-            schema_dict = dict(self.tbl.schema.items())
+            if _is_lazy_frame(data=self.tbl):
+                schema_dict = dict(self.tbl.collect_schema())
+            else:
+                schema_dict = dict(self.tbl.schema.items())
             schema_dict = {k: str(v) for k, v in schema_dict.items()}
             self.columns = list(schema_dict.items())
 

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -4,7 +4,7 @@ import copy
 from dataclasses import dataclass
 
 from pointblank._constants import IBIS_BACKENDS
-from pointblank._utils import _get_tbl_type, _is_lazy_frame, _is_lib_present
+from pointblank._utils import _get_tbl_type, _is_lazy_frame, _is_lib_present, _is_narwhals_table
 
 __all__ = ["Schema"]
 
@@ -315,7 +315,15 @@ class Schema:
         table_type = _get_tbl_type(self.tbl)
 
         # Collect column names and dtypes from the DataFrame and store as a list of tuples
-        if table_type == "pandas":
+        if _is_narwhals_table(self.tbl):
+            if _is_lazy_frame(data=self.tbl):
+                schema_dict = dict(self.tbl.collect_schema())
+            else:
+                schema_dict = dict(self.tbl.schema.items())
+            schema_dict = {k: str(v) for k, v in schema_dict.items()}
+            self.columns = list(schema_dict.items())
+
+        elif table_type == "pandas":
             schema_dict = dict(self.tbl.dtypes)
             schema_dict = {k: str(v) for k, v in schema_dict.items()}
             self.columns = list(schema_dict.items())

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -8284,12 +8284,28 @@ class Validate:
                     data_tbl=data_tbl_step, segments_expr=validation.segments
                 )
 
+            # ------------------------------------------------
+            # Determine table type and `collect()` if needed
+            # ------------------------------------------------
+
+            if tbl_type not in IBIS_BACKENDS:
+                tbl_type = "local"
+
+            # If the table is a lazy frame, we need to collect it
+            if _is_lazy_frame(data_tbl_step):
+                data_tbl_step = data_tbl_step.collect()
+
+            # ------------------------------------------------
+            # Set the number of test units
+            # ------------------------------------------------
+
             validation.n = NumberOfTestUnits(df=data_tbl_step, column=column).get_test_units(
                 tbl_type=tbl_type
             )
 
-            if tbl_type not in IBIS_BACKENDS:
-                tbl_type = "local"
+            # ------------------------------------------------
+            # Validation stage
+            # ------------------------------------------------
 
             if assertion_category == "COMPARE_ONE":
                 results_tbl = ColValsCompareOne(

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -70,6 +70,7 @@ from pointblank._utils import (
     _get_tbl_type,
     _is_lazy_frame,
     _is_lib_present,
+    _is_narwhals_table,
     _is_value_a_df,
     _select_df_lib,
 )
@@ -10492,6 +10493,10 @@ class Validate:
         if tbl_info == "polars":
             if _is_lazy_frame(self.data):
                 tbl_info = "polars-lazy"
+
+        # Determine if the input table is a Narwhals DF
+        if _is_narwhals_table(self.data):
+            tbl_info = "narwhals"
 
         # Get the thresholds object
         thresholds = self.thresholds

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -68,6 +68,7 @@ from pointblank._utils import (
     _format_to_integer_value,
     _get_fn_name,
     _get_tbl_type,
+    _is_lazy_frame,
     _is_lib_present,
     _is_value_a_df,
     _select_df_lib,

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -1723,6 +1723,9 @@ def get_column_count(data: FrameT | Any) -> int:
     elif "pandas" in str(type(data)):
         return data.shape[1]
 
+    elif "narwhals" in str(type(data)):
+        return len(data.columns)
+
     else:
         raise ValueError("The input table type supplied in `data=` is not supported.")
 
@@ -1814,6 +1817,9 @@ def get_row_count(data: FrameT | Any) -> int:
         return int(data.height)
 
     elif "pandas" in str(type(data)):
+        return data.shape[0]
+
+    elif "narwhals" in str(type(data)):
         return data.shape[0]
 
     else:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10482,6 +10482,11 @@ class Validate:
         # Get information on the input data table
         tbl_info = _get_tbl_type(data=self.data)
 
+        # If the table is a Polars one, determine if it's a LazyFrame
+        if tbl_info == "polars":
+            if _is_lazy_frame(self.data):
+                tbl_info = "polars-lazy"
+
         # Get the thresholds object
         thresholds = self.thresholds
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10507,7 +10507,11 @@ class Validate:
 
         # Determine if the input table is a Narwhals DF
         if _is_narwhals_table(self.data):
-            tbl_info = "narwhals"
+            # Determine if the Narwhals table is a LazyFrame
+            if _is_lazy_frame(self.data):
+                tbl_info = "narwhals-lazy"
+            else:
+                tbl_info = "narwhals"
 
         # Get the thresholds object
         thresholds = self.thresholds

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4979,7 +4979,7 @@ def test_comprehensive_validation_with_polars_lazyframe():
         Validate(
             data=small_table_lazy,
             tbl_name="small_table",
-            label="Simple pointblank validation example",
+            label="Validation example with Polars LazyFrame",
             thresholds=Thresholds(warning=0.10, error=0.25, critical=0.35),
         )
         .col_vals_gt(columns="d", value=100)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5012,9 +5012,9 @@ def test_comprehensive_validation_with_polars_lazyframe():
         .rows_complete(columns_subset=["a", "b", "c"])
         .col_vals_expr(expr=pl.col("d") > pl.col("a"))
         .conjointly(
-            lambda df: df["d"] > df["a"],
-            lambda df: df["a"] > 0,
-            lambda df: df["a"] + df["d"] < 12000,
+            lambda df: pl.col("d") > pl.col("a"),
+            lambda df: pl.col("a") > 0,
+            lambda df: pl.col("a") + pl.col("d") < 12000,
         )
         .specially(expr=lambda: [True, True])
         .interrogate()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5021,6 +5021,51 @@ def test_comprehensive_validation_with_polars_lazyframe():
     )
 
 
+def test_comprehensive_validation_with_narwhals_dataframe():
+    # Create a Narwhals DF from the small_table dataset
+    small_table_nw = nw.from_native(load_dataset(dataset="small_table", tbl_type="polars"))
+
+    (
+        Validate(
+            data=small_table_nw,
+            tbl_name="small_table",
+            label="Validation example with Narwhals DataFrame (from Polars DF)",
+            thresholds=Thresholds(warning=0.10, error=0.25, critical=0.35),
+        )
+        .col_vals_gt(columns="d", value=100)
+        .col_vals_lt(columns="c", value=5)
+        .col_vals_eq(columns="a", value=3)
+        .col_vals_ne(columns="c", value=10, na_pass=True)
+        .col_vals_le(columns="a", value=7)
+        .col_vals_ge(columns="d", value=500, na_pass=True)
+        .col_vals_between(columns="c", left=0, right=10, na_pass=True)
+        .col_vals_outside(columns="a", left=8, right=9, inclusive=(False, True))
+        .col_vals_eq(columns="a", value=10, active=False)
+        .col_vals_ge(columns="a", value=20, pre=lambda dfn: dfn.with_columns(nw.col("a") * 20))
+        .col_vals_gt(
+            columns="new", value=20, pre=lambda dfn: dfn.with_columns(new=nw.col("a") * 15)
+        )
+        .col_vals_in_set(columns="f", set=["low", "mid", "high"])
+        .col_vals_not_in_set(columns="f", set=["l", "h", "m"])
+        .col_vals_null(columns="c")
+        .col_vals_not_null(columns="date_time")
+        .col_vals_regex(columns="b", pattern=r"[0-9]-[a-z]{3}-[0-9]{3}")
+        .col_exists(columns="z")
+        .col_schema_match(schema=Schema(columns=[("a", "Int64")]), complete=False, in_order=False)
+        .row_count_match(count=13)
+        .row_count_match(count=2, inverse=True)
+        .col_count_match(count=8)
+        .col_count_match(count=2, inverse=True)
+        .rows_distinct()
+        .rows_distinct(columns_subset=["a", "b", "c"])
+        .rows_complete()
+        .rows_complete(columns_subset=["a", "b", "c"])
+        .col_vals_expr(expr=nw.col("d") > nw.col("a"))
+        .specially(expr=lambda: [True, True])
+        .interrogate()
+    )
+
+
 @pytest.mark.parametrize("tbl_fixture", TBL_TRUE_DATES_TIMES_LIST)
 def test_date_validation_across_cols(request, tbl_fixture):
     tbl = request.getfixturevalue(tbl_fixture)


### PR DESCRIPTION
This PR enables support for Polars and Narwhals LazyFrames. A bonus addition is that Narwhals DFs/LFs can now serve as direct inputs for validation.

Now, this works:

```python
import pointblank as pb
import polars as pl

small_table_lazy = pb.load_dataset(dataset="small_table", tbl_type="polars").lazy()

(
    pb.Validate(
        data=small_table_lazy,
        tbl_name="small_table",
        label="Simple pointblank validation example",
        thresholds=pb.Thresholds(warning=0.10, error=0.25, critical=0.35),
    )
    .col_vals_gt(columns="d", value=100)
    .col_vals_lt(columns="c", value=5)
    .col_vals_eq(columns="a", value=3)
    .col_vals_ne(columns="c", value=10, na_pass=True)
    .col_vals_le(columns="a", value=7)
    .col_vals_ge(columns="d", value=500, na_pass=True)
    .interrogate()
)
```

<img width="948" alt="image" src="https://github.com/user-attachments/assets/4be78030-fa82-4cc6-82a7-ce15d7faf169" />


Fixes: https://github.com/posit-dev/pointblank/issues/192