### PR TITLE
feat: add ability to directly use CSV data as `Validate` inputs

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -2341,6 +2341,9 @@ class Validate:
     locale: str | None = None
 
     def __post_init__(self):
+        # Handle CSV file input for the data parameter
+        self.data = self._process_csv_input(self.data)
+
         # Check input of the `thresholds=` argument
         _check_thresholds(thresholds=self.thresholds)
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -1972,8 +1972,10 @@ class Validate:
     Parameters
     ----------
     data
-        The table to validate, which could be a DataFrame object or an Ibis table object. Read the
-        *Supported Input Table Types* section for details on the supported table types.
+        The table to validate, which could be a DataFrame object, an Ibis table object, or a CSV
+        file path. When providing a CSV file path (as a string or `pathlib.Path` object), the file
+        will be automatically loaded using an available DataFrame library (Polars or Pandas). Read
+        the *Supported Input Table Types* section for details on the supported table types.
     tbl_name
         An optional name to assign to the input table object. If no value is provided, a name will
         be generated based on whatever information is available. This table name will be displayed

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 from dataclasses import dataclass
 from importlib.metadata import version
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 from zipfile import ZipFile
 


### PR DESCRIPTION
This pull request enhances the `Validate` class to support CSV file inputs directly, allowing users to validate data stored in CSV files without manually loading them. It also introduces automated library selection for CSV parsing (Polars preferred, Pandas as fallback).