### PR TITLE
docs: update scrollbar style

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -24,7 +24,7 @@ li a {
 
 dt {
     height: 32px;
-    overflow-x: scroll;
+    overflow-x: visible;
     margin-left: -4px;
 }
 


### PR DESCRIPTION
This PR changes the overflow style for `dt` from scroll to visible to avoid the scrollbar obscuring the API docs on Windows.

Fixes: https://github.com/posit-dev/pointblank/issues/211