### PR TITLE
fix: improve messages with `pb validate <data>` default; add `--list-checks` option

### DIFF
--- a/pointblank/cli.py
+++ b/pointblank/cli.py
@@ -548,7 +548,9 @@ def _rich_print_scan_table(
         console.print(f"[red]Error displaying table: {str(e)}[/red]")
 
 
-def _rich_print_gt_table(gt_table: Any, preview_info: dict | None = None) -> None:
+def _rich_print_gt_table(
+    gt_table: Any, preview_info: dict | None = None, show_summary: bool = True
+) -> None:
     """Convert a GT table to Rich table and display it in the terminal.
 
     Args:
@@ -558,6 +560,7 @@ def _rich_print_gt_table(gt_table: Any, preview_info: dict | None = None) -> Non
             - head_rows: Number of head rows shown
             - tail_rows: Number of tail rows shown
             - is_complete: Whether the entire dataset is shown
+        show_summary: Whether to show the row count summary at the bottom
     """
     try:
         # Try to extract the underlying data from the GT table
@@ -861,44 +864,45 @@ def _rich_print_gt_table(gt_table: Any, preview_info: dict | None = None) -> Non
             console.print()
             console.print(rich_table)
 
-            # Show summary info
-            total_rows = len(rows)
+            # Show summary info (conditionally)
+            if show_summary:
+                total_rows = len(rows)
 
-            # Use preview info if available, otherwise fall back to old logic
-            if preview_info:
-                total_dataset_rows = preview_info.get("total_rows", total_rows)
-                head_rows = preview_info.get("head_rows", 0)
-                tail_rows = preview_info.get("tail_rows", 0)
-                is_complete = preview_info.get("is_complete", False)
+                # Use preview info if available, otherwise fall back to old logic
+                if preview_info:
+                    total_dataset_rows = preview_info.get("total_rows", total_rows)
+                    head_rows = preview_info.get("head_rows", 0)
+                    tail_rows = preview_info.get("tail_rows", 0)
+                    is_complete = preview_info.get("is_complete", False)
 
-                if is_complete:
-                    console.print(f"\n[dim]Showing all {total_rows} rows.[/dim]")
-                elif head_rows > 0 and tail_rows > 0:
-                    console.print(
-                        f"\n[dim]Showing first {head_rows} and last {tail_rows} rows from {total_dataset_rows:,} total rows.[/dim]"
-                    )
-                elif head_rows > 0:
-                    console.print(
-                        f"\n[dim]Showing first {head_rows} rows from {total_dataset_rows:,} total rows.[/dim]"
-                    )
-                elif tail_rows > 0:
-                    console.print(
-                        f"\n[dim]Showing last {tail_rows} rows from {total_dataset_rows:,} total rows.[/dim]"
-                    )
+                    if is_complete:
+                        console.print(f"\n[dim]Showing all {total_rows} rows.[/dim]")
+                    elif head_rows > 0 and tail_rows > 0:
+                        console.print(
+                            f"\n[dim]Showing first {head_rows} and last {tail_rows} rows from {total_dataset_rows:,} total rows.[/dim]"
+                        )
+                    elif head_rows > 0:
+                        console.print(
+                            f"\n[dim]Showing first {head_rows} rows from {total_dataset_rows:,} total rows.[/dim]"
+                        )
+                    elif tail_rows > 0:
+                        console.print(
+                            f"\n[dim]Showing last {tail_rows} rows from {total_dataset_rows:,} total rows.[/dim]"
+                        )
+                    else:
+                        # Fallback for other cases
+                        console.print(
+                            f"\n[dim]Showing {total_rows} rows from {total_dataset_rows:,} total rows.[/dim]"
+                        )
                 else:
-                    # Fallback for other cases
-                    console.print(
-                        f"\n[dim]Showing {total_rows} rows from {total_dataset_rows:,} total rows.[/dim]"
-                    )
-            else:
-                # Original logic as fallback
-                max_rows = 50  # This should match the limit used above
-                if total_rows > max_rows:
-                    console.print(
-                        f"\n[dim]Showing first {max_rows} of {total_rows} rows. Use --output-html to see all data.[/dim]"
-                    )
-                else:
-                    console.print(f"\n[dim]Showing all {total_rows} rows.[/dim]")
+                    # Original logic as fallback
+                    max_rows = 50  # This should match the limit used above
+                    if total_rows > max_rows:
+                        console.print(
+                            f"\n[dim]Showing first {max_rows} of {total_rows} rows. Use --output-html to see all data.[/dim]"
+                        )
+                    else:
+                        console.print(f"\n[dim]Showing all {total_rows} rows.[/dim]")
 
         else:
             # If we can't extract data, show the success message
@@ -2056,7 +2060,7 @@ def validate(
                             )
 
                             # Display using our Rich table function
-                            _rich_print_gt_table(preview_table)
+                            _rich_print_gt_table(preview_table, show_summary=False)
 
                         if write_extract:
                             try:
@@ -3025,7 +3029,7 @@ def run(
                                 )
 
                                 # Display using our Rich table function
-                                _rich_print_gt_table(preview_table)
+                                _rich_print_gt_table(preview_table, show_summary=False)
                             else:
                                 console.print(
                                     f"\n[cyan]Step {step_num}:[/cyan] {step_info.assertion_type}"

--- a/pointblank/cli.py
+++ b/pointblank/cli.py
@@ -1486,7 +1486,7 @@ def missing(data_source: str, output_html: str | None):
     help="Numeric value for comparison (required for col-vals-gt, col-vals-ge, col-vals-lt, and col-vals-le checks)",
 )
 @click.option(
-    "--show-extract", is_flag=True, help="Show preview of failing rows if validation fails"
+    "--show-extract", is_flag=True, help="Show extract of failing rows if validation fails"
 )
 @click.option(
     "--write-extract", type=str, help="Save failing rows to folder. Provide base name for folder."
@@ -1988,10 +1988,10 @@ def validate(
 
             # Dynamic message based on check type
             if check == "rows-distinct":
-                extract_message = "[yellow]Preview of failing rows (duplicates):[/yellow]"
+                extract_message = "[yellow]Extract of failing rows (duplicates):[/yellow]"
                 row_type = "duplicate rows"
             elif check == "rows-complete":
-                extract_message = "[yellow]Preview of failing rows (incomplete rows):[/yellow]"
+                extract_message = "[yellow]Extract of failing rows (incomplete rows):[/yellow]"
                 row_type = "incomplete rows"
             elif check == "col-exists":
                 extract_message = (
@@ -2000,21 +2000,21 @@ def validate(
                 row_type = "missing column"
             elif check == "col-vals-in-set":
                 extract_message = (
-                    f"[yellow]Preview of failing rows (invalid values in '{column}'):[/yellow]"
+                    f"[yellow]Extract of failing rows (invalid values in '{column}'):[/yellow]"
                 )
                 row_type = "rows with invalid values"
             elif check == "col-vals-gt":
                 extract_message = (
-                    f"[yellow]Preview of failing rows (values in '{column}' <= {value}):[/yellow]"
+                    f"[yellow]Extract of failing rows (values in '{column}' <= {value}):[/yellow]"
                 )
                 row_type = f"rows with values <= {value}"
             elif check == "col-vals-ge":
                 extract_message = (
-                    f"[yellow]Preview of failing rows (values in '{column}' < {value}):[/yellow]"
+                    f"[yellow]Extract of failing rows (values in '{column}' < {value}):[/yellow]"
                 )
                 row_type = f"rows with values < {value}"
             else:
-                extract_message = "[yellow]Preview of failing rows:[/yellow]"
+                extract_message = "[yellow]Extract of failing rows:[/yellow]"
                 row_type = "failing rows"
 
             if show_extract:
@@ -2836,7 +2836,7 @@ validation = (
 @click.option("--output-html", type=click.Path(), help="Save HTML validation report to file")
 @click.option("--output-json", type=click.Path(), help="Save JSON validation summary to file")
 @click.option(
-    "--show-extract", is_flag=True, help="Show preview of failing rows if validation fails"
+    "--show-extract", is_flag=True, help="Show extract of failing rows if validation fails"
 )
 @click.option(
     "--write-extract",
@@ -2993,7 +2993,7 @@ def run(
                 console.print()
 
                 if show_extract:
-                    extract_title = "Preview of failing rows from validation steps"
+                    extract_title = "Extract of failing rows from validation steps"
                     if len(validations) > 1:
                         extract_title += f" (Validation {i})"
                     console.print(f"[yellow]{extract_title}:[/yellow]")

--- a/pointblank/cli.py
+++ b/pointblank/cli.py
@@ -1468,8 +1468,9 @@ def missing(data_source: str, output_html: str | None):
         ]
     ),
     default="rows-distinct",
-    help="Type of validation check to perform",
+    help="Type of validation check to perform. Use --list-checks to see all options.",
 )
+@click.option("--list-checks", is_flag=True, help="List available validation checks and exit")
 @click.option(
     "--column",
     help="Column name to validate (required for col-vals-not-null, col-exists, col-vals-in-set, col-vals-gt, col-vals-ge, col-vals-lt, and col-vals-le checks)",
@@ -1502,6 +1503,7 @@ def validate(
     write_extract: str | None,
     limit: int,
     exit_code: bool,
+    list_checks: bool,
 ):
     """
     Perform simple, single-step data validations.
@@ -1519,6 +1521,10 @@ def validate(
 
     AVAILABLE CHECKS:
 
+    Use --list-checks to see all available validation methods with examples.
+
+    The default check is 'rows-distinct' which checks for duplicate rows.
+
     \b
     - rows-distinct: Check if all rows in the dataset are unique (no duplicates)
     - rows-complete: Check if all rows are complete (no missing values in any column)
@@ -1533,6 +1539,8 @@ def validate(
     Examples:
 
     \b
+    pb validate data.csv                                              # Uses default validation (rows-distinct)
+    pb validate data.csv --list-checks                               # Show all available checks
     pb validate data.csv --check rows-distinct
     pb validate data.csv --check rows-distinct --show-extract
     pb validate data.csv --check rows-distinct --write-extract failing_rows_folder
@@ -1544,6 +1552,61 @@ def validate(
     pb validate data.csv --check col-vals-in-set --column status --set "active,inactive,pending"
     """
     try:
+        # Handle --list-checks option
+        if list_checks:
+            console.print("[bold bright_cyan]Available Validation Checks:[/bold bright_cyan]")
+            console.print()
+            console.print("[bold magenta]Basic checks:[/bold magenta]")
+            console.print(
+                "  • [bold cyan]rows-distinct[/bold cyan]     Check for duplicate rows [yellow](default)[/yellow]"
+            )
+            console.print(
+                "  • [bold cyan]rows-complete[/bold cyan]     Check for missing values in any column"
+            )
+            console.print()
+            console.print(
+                "[bold magenta]Column-specific checks [bright_black](require --column)[/bright_black]:[/bold magenta]"
+            )
+            console.print("  • [bold cyan]col-exists[/bold cyan]        Check if a column exists")
+            console.print(
+                "  • [bold cyan]col-vals-not-null[/bold cyan] Check for null values in a column"
+            )
+            console.print()
+            console.print(
+                "[bold magenta]Value comparison checks [bright_black](require --column and --value)[/bright_black]:[/bold magenta]"
+            )
+            console.print(
+                "  • [bold cyan]col-vals-gt[/bold cyan]       Values greater than threshold"
+            )
+            console.print(
+                "  • [bold cyan]col-vals-ge[/bold cyan]       Values greater than or equal to threshold"
+            )
+            console.print("  • [bold cyan]col-vals-lt[/bold cyan]       Values less than threshold")
+            console.print(
+                "  • [bold cyan]col-vals-le[/bold cyan]       Values less than or equal to threshold"
+            )
+            console.print()
+            console.print(
+                "[bold magenta]Set validation check [bright_black](requires --column and --set)[/bright_black]:[/bold magenta]"
+            )
+            console.print(
+                "  • [bold cyan]col-vals-in-set[/bold cyan]   Values must be in allowed set"
+            )
+            console.print()
+            console.print("[bold bright_yellow]Examples:[/bold bright_yellow]")
+            console.print(
+                f"  [bright_blue]pb validate {data_source} --check rows-distinct[/bright_blue]"
+            )
+            console.print(
+                f"  [bright_blue]pb validate {data_source} --check col-vals-not-null --column price[/bright_blue]"
+            )
+            console.print(
+                f"  [bright_blue]pb validate {data_source} --check col-vals-gt --column age --value 18[/bright_blue]"
+            )
+            import sys
+
+            sys.exit(0)
+
         # Check if --check option was explicitly provided by the user
         # If --check is not in the command line args, it means we're using the default
         import sys
@@ -2157,24 +2220,25 @@ def validate(
         if is_using_default_check:
             console.print()
             console.print("[bold blue]ℹ️  Information:[/bold blue] Using default validation method")
-            console.print("[dim]To specify a different validation, use the --check option.[/dim]")
+            console.print("To specify a different validation, use the --check option.")
             console.print()
-            console.print("[dim]Common validation options:[/dim]")
+            console.print("[bold magenta]Common validation options:[/bold magenta]")
             console.print(
-                "[dim]  • [cyan]--check rows-complete[/cyan]        Check for rows with missing values[/dim]"
+                "  • [bold cyan]--check rows-complete[/bold cyan]        Check for rows with missing values"
             )
             console.print(
-                "[dim]  • [cyan]--check col-vals-not-null[/cyan]   Check for null values in a column (requires --column)[/dim]"
+                "  • [bold cyan]--check col-vals-not-null[/bold cyan]   Check for null values in a column [bright_black](requires --column)[/bright_black]"
             )
             console.print(
-                "[dim]  • [cyan]--check col-exists[/cyan]          Check if a column exists (requires --column)[/dim]"
+                "  • [bold cyan]--check col-exists[/bold cyan]          Check if a column exists [bright_black](requires --column)[/bright_black]"
             )
             console.print()
+            console.print("[bold bright_yellow]Examples:[/bold bright_yellow]")
             console.print(
-                f"[dim]Example: [cyan]pb validate {data_source} --check rows-complete[/cyan][/dim]"
+                f"  [bright_blue]pb validate {data_source} --check rows-complete[/bright_blue]"
             )
             console.print(
-                f"[dim]         [cyan]pb validate {data_source} --check col-vals-not-null --column price[/cyan][/dim]"
+                f"  [bright_blue]pb validate {data_source} --check col-vals-not-null --column price[/bright_blue]"
             )
 
         # Exit with appropriate code if requested

--- a/pointblank/cli.py
+++ b/pointblank/cli.py
@@ -2179,9 +2179,7 @@ def validate(
 
                 # Add hint about --show-extract if not already used (except for col-exists which has no rows to show)
                 if not show_extract and check != "col-exists":
-                    failure_message += (
-                        "\n[dim]💡 Tip: Use --show-extract to see the failing rows[/dim]"
-                    )
+                    failure_message += "\n[bright_blue]💡 Tip:[/bright_blue] [cyan]Use --show-extract to see the failing rows[/cyan]"
 
                 console.print(
                     Panel(
@@ -2205,9 +2203,7 @@ def validate(
 
                 # Add hint about --show-extract if not already used
                 if not show_extract:
-                    failure_message += (
-                        "\n[dim]💡 Tip: Use --show-extract to see the failing rows[/dim]"
-                    )
+                    failure_message += "\n[bright_blue]💡 Tip:[/bright_blue] [cyan]Use --show-extract to see the failing rows[/cyan]"
 
                 console.print(
                     Panel(


### PR DESCRIPTION
This PR improves the message that appears when using only `pb validate <data>`.  It also adds a `--list-checks` option to display the available validation checks (along with descriptions).