### PR TITLE
enh: for `pb validate` allow `--column` to use column index

### DIFF
--- a/pointblank/cli.py
+++ b/pointblank/cli.py
@@ -1554,7 +1554,7 @@ def validate(
     Examples:
 
     \b
-    pb validate data.csv                                              # Uses default validation (rows-distinct)
+    pb validate data.csv                                             # Uses default validation (rows-distinct)
     pb validate data.csv --list-checks                               # Show all available checks
     pb validate data.csv --check rows-distinct
     pb validate data.csv --check rows-distinct --show-extract


### PR DESCRIPTION
This PR allows any required column selection in `pb validate` to use `#N` notation following `--column`. This specifies a column by index.