### PR TITLE
fix: permission error with `pb.load_dataset()` for duckdb on Windows

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -564,7 +564,10 @@ def load_dataset(
 
             data_path = f"{tmp}/{dataset}.ddb"
 
-            dataset = ibis.connect(f"duckdb://{data_path}").table(dataset)
+            # Create connection and get table, then close connection
+            conn = ibis.connect(f"duckdb://{data_path}")
+            dataset = conn.table(dataset)
+            conn.disconnect()  # Explicitly close the connection
 
     return dataset
 


### PR DESCRIPTION
# Summary

There was an error with loading temporary file for duckdb on Windows.
I changed the code to explicitly close the Ibis connection, and that seems to have resolved the problem.

# Related GitHub Issues and PRs

- Ref: #244 
