### PR TITLE
feat: allow Pointblank CLI to run YAML validation via `pb run`

### DIFF
--- a/pointblank/cli.py
+++ b/pointblank/cli.py
@@ -3958,7 +3958,7 @@ steps:
   # Check string patterns (uncomment and modify as needed)
   # - col_vals_regex:
   #     columns: email
-  #     pattern: "^[\\\\w\\\\.-]+@[\\\\w\\\\.-]+\\\\.[a-zA-Z]{2,}$"
+  #     pattern: "^[\\w\\.-]+@[\\w\\.-]+\\.[a-zA-Z]{2,}$"
 
   # Check for unique values (uncomment and modify as needed)
   # - col_vals_unique:


### PR DESCRIPTION
This PR updates the `pointblank` CLI to support YAML configuration files in addition to Python scripts for data validation (in `pb run`). Now users can define validation steps declaratively in YAML, while maintaining Python script functionality in the CLI. 

The `pb make-template` command can now also generate YAML configuration templates, with examples for validation rules, data sources, and thresholds. The template type is determined by the file extension (`.py` for Python scripts, `.yaml/.yml` for YAML configs).

Help messages and examples were also updated to reflect the new YAML file functionality.