### PR TITLE
fix: specify `ignore_nulls=True` in `nw.all_horizontal`

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -11684,7 +11684,9 @@ class Validate:
         # Determine the rows that passed all validation steps by checking if all `pb_is_good_`
         # columns are `True`
         labeled_tbl_nw = (
-            labeled_tbl_nw.with_columns(pb_is_good_all=nw.all_horizontal(pb_is_good_cols, ignore_nulls=True))
+            labeled_tbl_nw.with_columns(
+                pb_is_good_all=nw.all_horizontal(pb_is_good_cols, ignore_nulls=True)
+            )
             .join(data_nw, on=index_name, how="left")
             .drop(index_name)
         )

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -11684,7 +11684,7 @@ class Validate:
         # Determine the rows that passed all validation steps by checking if all `pb_is_good_`
         # columns are `True`
         labeled_tbl_nw = (
-            labeled_tbl_nw.with_columns(pb_is_good_all=nw.all_horizontal(pb_is_good_cols))
+            labeled_tbl_nw.with_columns(pb_is_good_all=nw.all_horizontal(pb_is_good_cols, ignore_nulls=True))
             .join(data_nw, on=index_name, how="left")
             .drop(index_name)
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "commonmark>=0.9.1",
     "importlib-metadata",
     "great_tables>=0.17.0",
-    "narwhals>=1.41.0",
+    "narwhals>=1.45.0",
     "typing_extensions>=3.10.0.0",
     "requests>=2.31.0",
     "click>=8.0.0",


### PR DESCRIPTION
closes #250 

The minimum Narwhals in pointblank is 1.41 but `ignore_nulls=True` was only introduced in Narwhals 1.45.

I'd suggest:
- either, handling all Narwhals versions with an if-else block
- or (better, IMO) bump the minimum version to 1.45

# Summary

Thank you for contributing to Pointblank! To make this process easier for everyone, please explain the context and purpose of your contribution. Also, list the changes made to the existing code or documentation.

# Related GitHub Issues and PRs

- Ref: #

# Checklist

- [ ] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [ ] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ ] I have added **pytest** unit tests for any new functionality.
