### PR TITLE
feat: validate Spark DFs without using Ibis

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -24,11 +24,21 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Set up Java for PySpark
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "11"
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: pytest unit tests
         run: |
           make test
+        env:
+          # Optimize PySpark for CI environment
+          PYSPARK_DRIVER_MEMORY: 1g
+          PYSPARK_EXECUTOR_MEMORY: 1g
+          SPARK_LOCAL_IP: 127.0.0.1
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/pointblank/_constants.py
+++ b/pointblank/_constants.py
@@ -118,7 +118,6 @@ IBIS_BACKENDS = [
     "mysql",
     "parquet",
     "postgres",
-    "pyspark",
     "snowflake",
     "sqlite",
 ]

--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -2158,6 +2158,8 @@ class ConjointlyValidation:
             return self._get_pandas_results()
         elif "duckdb" in self.tbl_type or "ibis" in self.tbl_type:
             return self._get_ibis_results()
+        elif "pyspark" in self.tbl_type:
+            return self._get_pyspark_results()
         else:  # pragma: no cover
             raise NotImplementedError(f"Support for {self.tbl_type} is not yet implemented")
 

--- a/pointblank/_utils.py
+++ b/pointblank/_utils.py
@@ -166,7 +166,7 @@ def _check_any_df_lib(method_used: str) -> None:
 def _is_value_a_df(value: Any) -> bool:
     try:
         ns = nw.get_native_namespace(value)
-        if "polars" in str(ns) or "pandas" in str(ns):
+        if "polars" in str(ns) or "pandas" in str(ns) or "pyspark" in str(ns):
             return True
         else:  # pragma: no cover
             return False

--- a/pointblank/_utils.py
+++ b/pointblank/_utils.py
@@ -66,11 +66,13 @@ def _get_tbl_type(data: FrameT | Any) -> str:
         except Exception as e:
             raise TypeError("The `data` object is not a DataFrame or Ibis Table.") from e
 
-        # Detect through regex if the table is a polars or pandas DataFrame
+        # Detect through regex if the table is a polars, pandas, or Spark DataFrame
         if re.search(r"polars", df_ns_str, re.IGNORECASE):
             return "polars"
         elif re.search(r"pandas", df_ns_str, re.IGNORECASE):
             return "pandas"
+        elif re.search(r"pyspark", df_ns_str, re.IGNORECASE):
+            return "pyspark"
 
     # If ibis is present, then get the table's backend name
     ibis_present = _is_lib_present(lib_name="ibis")

--- a/pointblank/assistant.py
+++ b/pointblank/assistant.py
@@ -138,10 +138,15 @@ def assistant(
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
     - SQLite table (`"sqlite"`)*
+    - Microsoft SQL Server table (`"mssql"`)*
+    - Snowflake table (`"snowflake"`)*
+    - Databricks table (`"databricks"`)*
+    - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
     - Parquet files (string path, `pathlib.Path` object, glob pattern, directory with `.parquet`
@@ -152,6 +157,10 @@ def assistant(
     `ibis.expr.types.relations.Table`). Furthermore, using `assistant()` with these types of tables
     requires the Ibis library (`v9.5.0` or above) to be installed. If the input table is a Polars or
     Pandas DataFrame, the availability of Ibis is not needed.
+
+    To use a CSV file, ensure that a string or `pathlib.Path` object with a `.csv` extension is
+    provided. The file will be automatically detected and loaded using the best available DataFrame
+    library. The loading preference is Polars first, then Pandas as a fallback.
     """
 
     # Check that the chatlas package is installed

--- a/pointblank/data/api-docs.txt
+++ b/pointblank/data/api-docs.txt
@@ -111,6 +111,7 @@ Validate(data: 'FrameT | Any', tbl_name: 'str | None' = None, label: 'str | None
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -118,7 +119,6 @@ Validate(data: 'FrameT | Any', tbl_name: 'str | None' = None, label: 'str | None
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
@@ -950,10 +950,15 @@ Definition of a schema object.
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
     - SQLite table (`"sqlite"`)*
+    - Microsoft SQL Server table (`"mssql"`)*
+    - Snowflake table (`"snowflake"`)*
+    - Databricks table (`"databricks"`)*
+    - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
 
     The table types marked with an asterisk need to be prepared as Ibis tables (with type of
@@ -9085,6 +9090,7 @@ preview(data: 'FrameT | Any', columns_subset: 'str | list[str] | Column | None' 
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -9092,7 +9098,6 @@ preview(data: 'FrameT | Any', columns_subset: 'str | list[str] | Column | None' 
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
@@ -9319,6 +9324,7 @@ missing_vals_tbl(data: 'FrameT | Any') -> 'GT'
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -9326,7 +9332,6 @@ missing_vals_tbl(data: 'FrameT | Any') -> 'GT'
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
@@ -9486,10 +9491,15 @@ assistant(model: 'str', data: 'FrameT | Any | None' = None, tbl_name: 'str | Non
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
     - SQLite table (`"sqlite"`)*
+    - Microsoft SQL Server table (`"mssql"`)*
+    - Snowflake table (`"snowflake"`)*
+    - Databricks table (`"databricks"`)*
+    - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
     - Parquet files (string path, `pathlib.Path` object, glob pattern, directory with `.parquet`
@@ -9500,6 +9510,10 @@ assistant(model: 'str', data: 'FrameT | Any | None' = None, tbl_name: 'str | Non
     `ibis.expr.types.relations.Table`). Furthermore, using `assistant()` with these types of tables
     requires the Ibis library (`v9.5.0` or above) to be installed. If the input table is a Polars or
     Pandas DataFrame, the availability of Ibis is not needed.
+
+    To use a CSV file, ensure that a string or `pathlib.Path` object with a `.csv` extension is
+    provided. The file will be automatically detected and loaded using the best available DataFrame
+    library. The loading preference is Polars first, then Pandas as a fallback.
     
 
 load_dataset(dataset: "Literal['small_table', 'game_revenue', 'nycflights', 'global_sales']" = 'small_table', tbl_type: "Literal['polars', 'pandas', 'duckdb']" = 'polars') -> 'FrameT | Any'
@@ -10097,6 +10111,7 @@ get_column_count(data: 'FrameT | Any') -> 'int'
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -10104,7 +10119,6 @@ get_column_count(data: 'FrameT | Any') -> 'int'
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
@@ -10212,6 +10226,7 @@ get_row_count(data: 'FrameT | Any') -> 'int'
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -10219,7 +10234,6 @@ get_row_count(data: 'FrameT | Any') -> 'int'
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -61,10 +61,15 @@ class Schema:
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
     - SQLite table (`"sqlite"`)*
+    - Microsoft SQL Server table (`"mssql"`)*
+    - Snowflake table (`"snowflake"`)*
+    - Databricks table (`"databricks"`)*
+    - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
 
     The table types marked with an asterisk need to be prepared as Ibis tables (with type of

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import copy
 from dataclasses import dataclass
 
+import narwhals as nw
+
 from pointblank._constants import IBIS_BACKENDS
 from pointblank._utils import _get_tbl_type, _is_lazy_frame, _is_lib_present, _is_narwhals_table
 
@@ -333,6 +335,16 @@ class Schema:
                 schema_dict = dict(self.tbl.collect_schema())
             else:
                 schema_dict = dict(self.tbl.schema.items())
+            schema_dict = {k: str(v) for k, v in schema_dict.items()}
+            self.columns = list(schema_dict.items())
+
+        elif table_type == "pyspark":
+            # Convert PySpark DataFrame to Narwhals to get schema
+            nw_df = nw.from_native(self.tbl)
+            if _is_lazy_frame(data=nw_df):
+                schema_dict = dict(nw_df.collect_schema())
+            else:
+                schema_dict = dict(nw_df.schema.items())
             schema_dict = {k: str(v) for k, v in schema_dict.items()}
             self.columns = list(schema_dict.items())
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -1195,6 +1195,7 @@ def preview(
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -1202,7 +1203,6 @@ def preview(
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
@@ -1798,6 +1798,7 @@ def missing_vals_tbl(data: FrameT | Any) -> GT:
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -1805,7 +1806,6 @@ def missing_vals_tbl(data: FrameT | Any) -> GT:
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
@@ -2346,6 +2346,7 @@ def get_column_count(data: FrameT | Any) -> int:
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -2353,7 +2354,6 @@ def get_column_count(data: FrameT | Any) -> int:
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
@@ -2517,6 +2517,7 @@ def get_row_count(data: FrameT | Any) -> int:
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -2524,7 +2525,6 @@ def get_row_count(data: FrameT | Any) -> int:
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)
@@ -3117,6 +3117,7 @@ class Validate:
 
     - Polars DataFrame (`"polars"`)
     - Pandas DataFrame (`"pandas"`)
+    - PySpark table (`"pyspark"`)
     - DuckDB table (`"duckdb"`)*
     - MySQL table (`"mysql"`)*
     - PostgreSQL table (`"postgresql"`)*
@@ -3124,7 +3125,6 @@ class Validate:
     - Microsoft SQL Server table (`"mssql"`)*
     - Snowflake table (`"snowflake"`)*
     - Databricks table (`"databricks"`)*
-    - PySpark table (`"pyspark"`)*
     - BigQuery table (`"bigquery"`)*
     - Parquet table (`"parquet"`)*
     - CSV files (string path or `pathlib.Path` object with `.csv` extension)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -12339,8 +12339,12 @@ class Validate:
             # Transform to Narwhals DataFrame
             extract_nw = nw.from_native(extract)
 
-            # Get the number of rows in the extract
-            n_rows = len(extract_nw)
+            # Get the number of rows in the extract (safe for LazyFrames)
+            try:
+                n_rows = len(extract_nw)
+            except TypeError:
+                # For LazyFrames, collect() first to get length
+                n_rows = len(extract_nw.collect()) if hasattr(extract_nw, "collect") else 0
 
             # If the number of rows is zero, then produce an em dash then go to the next iteration
             if n_rows == 0:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10015,9 +10015,9 @@ class Validate:
                         name="_row_num_", order_by=first_col
                     )
 
-                validation_extract_nw = validation_extract_nw.filter(
-                    ~nw.col("pb_is_good_")
-                ).drop("pb_is_good_")  # noqa
+                validation_extract_nw = validation_extract_nw.filter(~nw.col("pb_is_good_")).drop(
+                    "pb_is_good_"
+                )  # noqa
 
                 # Add 1 to the row numbers to make them 1-indexed
                 validation_extract_nw = validation_extract_nw.with_columns(nw.col("_row_num_") + 1)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10016,7 +10016,7 @@ class Validate:
                     )
 
                 validation_extract_nw = validation_extract_nw.filter(
-                    nw.col("pb_is_good_") == False
+                    ~nw.col("pb_is_good_")
                 ).drop("pb_is_good_")  # noqa
 
                 # Add 1 to the row numbers to make them 1-indexed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,19 +38,19 @@ dependencies = [
     "commonmark>=0.9.1",
     "importlib-metadata",
     "great_tables>=0.17.0",
-    "narwhals>=1.45.0",
+    "narwhals>=2.0.1",
     "typing_extensions>=3.10.0.0",
     "requests>=2.31.0",
     "click>=8.0.0",
     "rich>=13.0.0",
     "pyyaml>=6.0.0",
-    "pyspark>=3.5.6",
 ]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]
 pd = ["pandas>=2.2.3"]
 pl = ["polars>=1.24.0"]
+pyspark = ["pyspark>=3.5.6"]
 generate = [
     "chatlas>=0.3.0",
     "anthropic[bedrock]>=0.45.2",
@@ -63,7 +63,6 @@ duckdb = ["ibis-framework[duckdb]>=9.5.0"]
 mysql = ["ibis-framework[mysql]>=9.5.0"]
 mssql = ["ibis-framework[mssql]>=9.5.0"]
 postgres = ["ibis-framework[postgres]>=9.5.0"]
-pyspark = ["ibis-framework[pyspark]>=9.5.0"]
 snowflake = ["ibis-framework[snowflake]>=9.5.0"]
 sqlite = ["ibis-framework[sqlite]>=9.5.0"]
 docs = [
@@ -73,6 +72,7 @@ docs = [
     "quartodoc>=0.8.1; python_version >= '3.9'",
     "pandas>=2.2.3",
     "polars>=1.17.1",
+    "pyspark>=3.5.6",
 ]
 
 [dependency-groups]
@@ -90,6 +90,7 @@ dev = [
     "pre-commit==2.15.0",
     "pyarrow",
     "pyarrow-stubs>=19.4",
+    "pyspark>=3.5.6",
     "pytest>=3",
     "pytest-cov",
     "pytest-randomly>=3.16.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "click>=8.0.0",
     "rich>=13.0.0",
     "pyyaml>=6.0.0",
+    "pyspark>=3.5.6",
 ]
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ requires-python = ">=3.10"
 [project.optional-dependencies]
 pd = ["pandas>=2.2.3"]
 pl = ["polars>=1.24.0"]
-pyspark = ["pyspark>=3.5.6"]
+pyspark = ["pyspark==3.5.6"]
 generate = [
     "chatlas>=0.3.0",
     "anthropic[bedrock]>=0.45.2",
@@ -72,7 +72,7 @@ docs = [
     "quartodoc>=0.8.1; python_version >= '3.9'",
     "pandas>=2.2.3",
     "polars>=1.17.1",
-    "pyspark>=3.5.6",
+    "pyspark==3.5.6",
 ]
 
 [dependency-groups]
@@ -90,7 +90,7 @@ dev = [
     "pre-commit==2.15.0",
     "pyarrow",
     "pyarrow-stubs>=19.4",
-    "pyspark>=3.5.6",
+    "pyspark==3.5.6",
     "pytest>=3",
     "pytest-cov",
     "pytest-randomly>=3.16.0",

--- a/tests/snapshots/test_validate/test_comprehensive_validation_report_html_snap/comprehensive_validation_report.html
+++ b/tests/snapshots/test_validate/test_comprehensive_validation_report_html_snap/comprehensive_validation_report.html
@@ -1073,7 +1073,7 @@
 </svg></td>
     <td style="height: 40px; background-color: #FCFCFC; border-right: 1px solid #D3D3D3;" class="gt_row gt_center"><span style="color:#4CA64C;">&check;</span></td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px;" class="gt_row gt_right">13</td>
-    <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">11<br />0.85</td>
+    <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">9<br />0.69</td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">2<br />0.15</td>
     <td style="height: 40px; background-color: #FCFCFC; border-left: 1px solid #D3D3D3;" class="gt_row gt_center"><span style="color: #AAAAAA;">&#9679;</span></td>
     <td style="height: 40px; background-color: #FCFCFC;" class="gt_row gt_center"><span style="color: #EBBC14;">&cir;</span></td>
@@ -1118,7 +1118,7 @@
 </svg></td>
     <td style="height: 40px; background-color: #FCFCFC; border-right: 1px solid #D3D3D3;" class="gt_row gt_center"><span style="color:#4CA64C;">&check;</span></td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px;" class="gt_row gt_right">13</td>
-    <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">11<br />0.85</td>
+    <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">9<br />0.69</td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">2<br />0.15</td>
     <td style="height: 40px; background-color: #FCFCFC; border-left: 1px solid #D3D3D3;" class="gt_row gt_center"><span style="color: #AAAAAA;">&#9679;</span></td>
     <td style="height: 40px; background-color: #FCFCFC;" class="gt_row gt_center"><span style="color: #EBBC14;">&cir;</span></td>

--- a/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_pyspark/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_interrogate_snap/tbl_pyspark/validation_report.json
@@ -1,0 +1,26 @@
+[
+    {
+        "i": 1,
+        "i_o": 1,
+        "assertion_type": "col_vals_gt",
+        "column": "x",
+        "values": 0,
+        "inclusive": null,
+        "na_pass": false,
+        "pre": null,
+        "segments": null,
+        "thresholds": "Thresholds(warning=None, error=None, critical=None)",
+        "label": null,
+        "brief": null,
+        "active": true,
+        "all_passed": true,
+        "n": 4,
+        "n_passed": 4,
+        "n_failed": 0,
+        "f_passed": 1.0,
+        "f_failed": 0.0,
+        "warning": null,
+        "error": null,
+        "critical": null
+    }
+]

--- a/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_pyspark/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_no_interrogate_snap/tbl_pyspark/validation_report.json
@@ -1,0 +1,26 @@
+[
+    {
+        "i": null,
+        "i_o": 1,
+        "assertion_type": "col_vals_gt",
+        "column": "x",
+        "values": 0,
+        "inclusive": null,
+        "na_pass": false,
+        "pre": null,
+        "segments": null,
+        "thresholds": "Thresholds(warning=None, error=None, critical=None)",
+        "label": null,
+        "brief": null,
+        "active": true,
+        "all_passed": null,
+        "n": null,
+        "n_passed": null,
+        "n_failed": null,
+        "f_passed": null,
+        "f_failed": null,
+        "warning": null,
+        "error": null,
+        "critical": null
+    }
+]

--- a/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_pyspark/validation_report.json
+++ b/tests/snapshots/test_validate/test_validation_report_use_fields_snap/tbl_pyspark/validation_report.json
@@ -1,0 +1,10 @@
+[
+    {
+        "i": null,
+        "assertion_type": "col_vals_gt",
+        "all_passed": null,
+        "n": null,
+        "f_passed": null,
+        "f_failed": null
+    }
+]

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -595,7 +595,7 @@ def test_col_vals_all_passing(request, tbl_fixture):
 
     v = Validate(tbl).col_vals_gt(columns="x", value=0).interrogate()
 
-    if tbl_fixture not in ["tbl_parquet", "tbl_duckdb", "tbl_sqlite"]:
+    if tbl_fixture not in ["tbl_parquet", "tbl_duckdb", "tbl_sqlite", "tbl_pyspark"]:
         assert v.data.shape == (4, 3)
         assert str(v.data["x"].dtype).lower() == "int64"
         assert str(v.data["y"].dtype).lower() == "int64"
@@ -6935,7 +6935,11 @@ def test_interrogate_first_n(request, tbl_fixture):
 
         # Expect that the extracts table has 2 entries out of 3 failures
         assert validation.n_failed(i=1, scalar=True) == 3
-        assert len(nw.from_native(validation.get_data_extracts(i=1, frame=True)).rows()) == 2
+        extract_df = nw.from_native(validation.get_data_extracts(i=1, frame=True))
+        # For LazyFrames, need to collect first, then get length
+        if hasattr(extract_df, "collect"):
+            extract_df = extract_df.collect()
+        assert len(extract_df) == 2
         assert len(nw.from_native(validation.get_data_extracts(i=1, frame=True)).columns) == 4
 
 


### PR DESCRIPTION
This pull request adds support for PySpark DataFrames throughout the codebase, improving compatibility and handling for PySpark in schema detection, validation, and DataFrame interrogation. It introduces a new utility for safely handling datetime comparisons across DataFrame types (esp. for LazyFrames), and refactors several functions to use this new utility. Additionally, it updates the CI workflow to ensure Java is available for PySpark tests.

I modified CI workflow to set up Java (using Temurin 11) for PySpark tests and optimized PySpark memory settings for the CI environment. If PySpark tests end up becoming flaky in CI, we can temporarily disable them by setting:

```yaml
env:
  SKIP_PYSPARK_TESTS: "true"
```

Fixes: https://github.com/posit-dev/pointblank/issues/253