### PR TITLE
ci: pin `duckdb` dependency to stable versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ docs = [
     "polars>=1.17.1",
     "pyspark==3.5.6",
     "openpyxl>=3.0.0",
+    "duckdb>=1.2.0,<1.3.3",  # Pin to stable versions avoiding 1.4.0+ RecordBatchReader issues
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ docs = [
 [dependency-groups]
 dev = [
     "chatlas>=0.6.1",
-    "duckdb>=1.1.3",
+    "duckdb>=1.2.0,<1.3.3",  # Pin to stable versions avoiding 1.4.0+ RecordBatchReader issues
     "griffe==0.38.1",
     "hypothesis>=6.129.2",
     "ibis-framework[duckdb,mysql,postgres,sqlite]>=9.5.0",


### PR DESCRIPTION
This PR updates the `duckdb` dependency version constraint in the development dependencies to avoid compatibility issues with versions `1.4.0` and above. We now require versions `>=1.2.0` and `<1.3.3`. Added a comment explaining that this pinning to stable versions avoids `RecordBatchReader` issues present in `1.4.0` and later.