### PR TITLE
feat: add Enum support to `col_vals_in_set()` and `col_vals_not_in_set()`

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -6882,6 +6882,12 @@ class Validate:
             DELETED = "deleted"
             ARCHIVED = "archived"
 
+        # Create a table with status data
+        status_table = pl.DataFrame({
+            "product": ["widget", "gadget", "tool", "device"],
+            "status": ["active", "pending", "deleted", "active"]
+        })
+
         # Validate that no values are in the invalid status set
         validation = (
             pb.Validate(data=status_table)
@@ -6891,6 +6897,9 @@ class Validate:
 
         validation
         ```
+
+        This validation fails for the `"deleted"` value since it matches one of the invalid statuses
+        in the `InvalidStatus` enum.
         """
 
         assertion_type = _get_fn_name()

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10,6 +10,7 @@ import re
 import tempfile
 import threading
 from dataclasses import dataclass
+from enum import Enum
 from importlib.metadata import version
 from typing import TYPE_CHECKING, Any, Callable, Literal
 from zipfile import ZipFile
@@ -2648,6 +2649,48 @@ def get_column_count(data: FrameT | Any) -> int:
             return data.shape[1]  # pragma: no cover
         else:
             raise ValueError("The input table type supplied in `data=` is not supported.")
+
+
+def _extract_enum_values(set_values: Any) -> list[Any]:
+    """
+    Extract values from Enum classes or collections containing Enum instances.
+
+    This helper function handles:
+    1. Enum classes: extracts all enum values
+    2. Collections containing Enum instances: extracts their values
+    3. Regular collections: returns as-is
+
+    Parameters
+    ----------
+    set_values
+        The input collection that may contain Enum class or Enum instances.
+
+    Returns
+    -------
+    list[Any]
+        A list of extracted values
+    """
+    from collections.abc import Collection
+
+    # Check if set_values is an Enum class (not an instance)
+    if inspect.isclass(set_values) and issubclass(set_values, Enum):
+        # Extract all values from the Enum class
+        return [enum_member.value for enum_member in set_values]
+
+    # Check if set_values is a collection
+    if isinstance(set_values, Collection) and not isinstance(set_values, (str, bytes)):
+        extracted_values = []
+        for item in set_values:
+            if isinstance(item, Enum):
+                # If item is an Enum instance, extract its value
+                extracted_values.append(item.value)
+            else:
+                # If item is not an Enum instance, keep as-is
+                extracted_values.append(item)
+        return extracted_values
+
+    # If set_values is neither an Enum class nor a collection, return as list
+    return [set_values]
 
 
 def get_row_count(data: FrameT | Any) -> int:
@@ -6332,7 +6375,10 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         set
-            A list of values to compare against.
+            A collection of values to compare against. Can be a list of values, a Python Enum
+            class, or a collection containing Enum instances. When an Enum class is provided,
+            all enum values will be used. When a collection contains Enum instances, their
+            values will be extracted automatically.
         pre
             An optional preprocessing function or lambda to apply to the data table during
             interrogation. This function should take a table as input and return a modified table.
@@ -6509,11 +6555,65 @@ class Validate:
 
         The validation table reports two failing test units. The specific failing cases are for the
         column `b` values of `8` and `1`, which are not in the set of `[2, 3, 4, 5, 6]`.
+
+        **Using Python Enums**
+
+        The `col_vals_in_set()` method also supports Python Enum classes and instances, which can
+        make validations more readable and maintainable:
+
+        ```{python}
+        from enum import Enum
+
+        class Color(Enum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+
+        # Create a table with color data
+        tbl_colors = pl.DataFrame({
+            "product": ["shirt", "pants", "hat", "shoes"],
+            "color": ["red", "blue", "green", "yellow"]
+        })
+
+        # Validate using an Enum class (all enum values are allowed)
+        validation = (
+            pb.Validate(data=tbl_colors)
+            .col_vals_in_set(columns="color", set=Color)
+            .interrogate()
+        )
+
+        validation
+        ```
+
+        This validation will fail for the `"yellow"` value since it's not in the `Color` enum.
+
+        You can also use specific Enum instances or mix them with regular values:
+
+        ```{python}
+        # Validate using specific Enum instances
+        validation = (
+            pb.Validate(data=tbl_colors)
+            .col_vals_in_set(columns="color", set=[Color.RED, Color.BLUE])
+            .interrogate()
+        )
+
+        # Mix Enum instances with regular values
+        validation = (
+            pb.Validate(data=tbl_colors)
+            .col_vals_in_set(columns="color", set=[Color.RED, Color.BLUE, "yellow"])
+            .interrogate()
+        )
+
+        validation
+        ```
         """
 
         assertion_type = _get_fn_name()
 
         _check_column(column=columns)
+
+        # Extract values from Enum classes or Enum instances if present
+        set = _extract_enum_values(set)
 
         for val in set:
             if val is None:
@@ -6565,7 +6665,7 @@ class Validate:
     def col_vals_not_in_set(
         self,
         columns: str | list[str] | Column | ColumnSelector | ColumnSelectorNarwhals,
-        set: list[float | int],
+        set: Collection[Any],
         pre: Callable | None = None,
         segments: SegmentSpec | None = None,
         thresholds: int | float | bool | tuple | dict | Thresholds = None,
@@ -6589,7 +6689,10 @@ class Validate:
             multiple columns are supplied or resolved, there will be a separate validation step
             generated for each column.
         set
-            A list of values to compare against.
+            A collection of values to compare against. Can be a list of values, a Python Enum
+            class, or a collection containing Enum instances. When an Enum class is provided,
+            all enum values will be used. When a collection contains Enum instances, their
+            values will be extracted automatically.
         pre
             An optional preprocessing function or lambda to apply to the data table during
             interrogation. This function should take a table as input and return a modified table.
@@ -6767,11 +6870,36 @@ class Validate:
 
         The validation table reports two failing test units. The specific failing cases are for the
         column `b` values of `2` and `6`, both of which are in the set of `[2, 3, 4, 5, 6]`.
+
+        **Using Python Enums**
+
+        Like `col_vals_in_set()`, this method also supports Python Enum classes and instances:
+
+        ```{python}
+        from enum import Enum
+
+        class InvalidStatus(Enum):
+            DELETED = "deleted"
+            ARCHIVED = "archived"
+
+        # Validate that no values are in the invalid status set
+        validation = (
+            pb.Validate(data=status_table)
+            .col_vals_not_in_set(columns="status", set=InvalidStatus)
+            .interrogate()
+        )
+
+        validation
+        ```
         """
 
         assertion_type = _get_fn_name()
 
         _check_column(column=columns)
+
+        # Extract values from Enum classes or Enum instances if present
+        set = _extract_enum_values(set)
+
         _check_set_types(set=set)
         _check_pre(pre=pre)
         # TODO: add check for segments

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -16,7 +16,16 @@ from pathlib import Path
 from functools import partial
 import contextlib
 import datetime
-from enum import Enum, IntEnum, StrEnum
+from enum import Enum, IntEnum
+
+# StrEnum was introduced in Python 3.11, so we use regular Enum for compatibility
+try:
+    from enum import StrEnum
+except ImportError:
+    # For Python < 3.11, create a StrEnum-like class
+    class StrEnum(str, Enum):
+        pass
+
 
 import pandas as pd
 import polars as pl

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from functools import partial
 import contextlib
 import datetime
+from enum import Enum, IntEnum, StrEnum
 
 import pandas as pd
 import polars as pl
@@ -16164,3 +16165,263 @@ def test_format_single_float_with_gt_custom_df_lib_selection():
     # Test that the function works when df_lib is not specified (uses auto-detection)
     result = _format_single_float_with_gt_custom(value=42.0)
     assert result is not None
+
+
+#
+# Define test Enums
+#
+
+
+class Color(Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+
+class Priority(IntEnum):
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+
+
+class Status(StrEnum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    PENDING = "pending"
+
+
+class MixedEnum(Enum):
+    STRING_VAL = "string_value"
+    INT_VAL = 42
+    FLOAT_VAL = 3.14
+
+
+# Test fixtures for enum tests
+@pytest.fixture
+def sample_data_polars():
+    """Create sample Polars DataFrame for testing."""
+    return pl.DataFrame(
+        {
+            "colors": ["red", "green", "blue", "red", "yellow"],
+            "priorities": [1, 2, 3, 1, 4],
+            "statuses": ["active", "inactive", "pending", "active", "deleted"],
+        }
+    )
+
+
+@pytest.fixture
+def sample_data_pandas():
+    """Create sample Pandas DataFrame for testing."""
+    return pd.DataFrame(
+        {
+            "colors": ["red", "green", "blue", "red", "yellow"],
+            "priorities": [1, 2, 3, 1, 4],
+            "statuses": ["active", "inactive", "pending", "active", "deleted"],
+        }
+    )
+
+
+def test_col_vals_in_set_with_enum_class_polars(sample_data_polars):
+    """Test col_vals_in_set() with Enum class using Polars."""
+    validation = (
+        Validate(sample_data_polars).col_vals_in_set(columns="colors", set=Color).interrogate()
+    )
+
+    # Should have 1 failure (yellow is not in Color enum)
+    assert validation.n_passed()[1] == 4
+    assert validation.n_failed()[1] == 1
+    assert not validation.all_passed()
+
+
+def test_col_vals_in_set_with_enum_class_pandas(sample_data_pandas):
+    """Test col_vals_in_set() with Enum class using Pandas."""
+    validation = (
+        Validate(sample_data_pandas).col_vals_in_set(columns="colors", set=Color).interrogate()
+    )
+
+    # Should have 1 failure (yellow is not in Color enum)
+    assert validation.n_passed()[1] == 4
+    assert validation.n_failed()[1] == 1
+    assert not validation.all_passed()
+
+
+def test_col_vals_in_set_with_int_enum(sample_data_polars):
+    """Test col_vals_in_set() with IntEnum."""
+    validation = (
+        Validate(sample_data_polars)
+        .col_vals_in_set(columns="priorities", set=Priority)
+        .interrogate()
+    )
+
+    # Should have 1 failure (4 is not in Priority enum)
+    assert validation.n_passed()[1] == 4
+    assert validation.n_failed()[1] == 1
+    assert not validation.all_passed()
+
+
+def test_col_vals_in_set_with_str_enum(sample_data_polars):
+    """Test col_vals_in_set() with StrEnum."""
+    validation = (
+        Validate(sample_data_polars).col_vals_in_set(columns="statuses", set=Status).interrogate()
+    )
+
+    # Should have 1 failure (deleted is not in Status enum)
+    assert validation.n_passed()[1] == 4
+    assert validation.n_failed()[1] == 1
+    assert not validation.all_passed()
+
+
+def test_col_vals_in_set_with_enum_instances_list(sample_data_polars):
+    """Test col_vals_in_set() with a list of Enum instances."""
+    validation = (
+        Validate(sample_data_polars)
+        .col_vals_in_set(columns="colors", set=[Color.RED, Color.GREEN])
+        .interrogate()
+    )
+
+    # Should have 2 failures: blue and yellow are not red or green
+    # red appears twice (passes), green appears once (passes)
+    assert validation.n_passed()[1] == 3
+    assert validation.n_failed()[1] == 2
+    assert not validation.all_passed()
+
+
+def test_col_vals_in_set_with_mixed_enum_and_values(sample_data_polars):
+    """Test col_vals_in_set() with mixed Enum instances and regular values."""
+    validation = (
+        Validate(sample_data_polars)
+        .col_vals_in_set(columns="colors", set=[Color.RED, Color.GREEN, "yellow"])
+        .interrogate()
+    )
+
+    # Should have 1 failure (blue is not in the set)
+    assert validation.n_passed()[1] == 4
+    assert validation.n_failed()[1] == 1
+    assert not validation.all_passed()
+
+
+def test_col_vals_not_in_set_with_enum_class(sample_data_polars):
+    """Test col_vals_not_in_set() with Enum class."""
+    validation = (
+        Validate(sample_data_polars).col_vals_not_in_set(columns="colors", set=Color).interrogate()
+    )
+
+    # Should have 4 failures (red appears twice, green once, blue once; all in Color enum)
+    assert validation.n_passed()[1] == 1  # Only yellow passes (not in Color enum)
+    assert validation.n_failed()[1] == 4
+    assert not validation.all_passed()
+
+
+def test_col_vals_not_in_set_with_enum_instances_list(sample_data_polars):
+    """Test col_vals_not_in_set() with a list of Enum instances."""
+    validation = (
+        Validate(sample_data_polars)
+        .col_vals_not_in_set(columns="colors", set=[Color.RED, Color.GREEN])
+        .interrogate()
+    )
+
+    # Should have 3 failures (red appears twice, green appears once; all in the prohibited set)
+    assert validation.n_passed()[1] == 2  # blue and yellow pass (not red or green)
+    assert validation.n_failed()[1] == 3
+    assert not validation.all_passed()
+
+
+def test_col_vals_in_set_all_pass_with_enum():
+    """Test col_vals_in_set() where all values pass with Enum."""
+    # Create data where all colors are in the enum
+    data = pl.DataFrame({"colors": ["red", "green", "blue", "red", "green"]})
+
+    validation = Validate(data).col_vals_in_set(columns="colors", set=Color).interrogate()
+
+    # Should have no failures
+    assert validation.n_passed()[1] == 5
+    assert validation.n_failed()[1] == 0
+    assert validation.all_passed()
+
+
+def test_col_vals_not_in_set_all_pass_with_enum():
+    """Test col_vals_not_in_set() where all values pass with Enum."""
+    # Create data where no colors are in the enum
+    data = pl.DataFrame({"colors": ["yellow", "orange", "purple", "pink", "cyan"]})
+
+    validation = Validate(data).col_vals_not_in_set(columns="colors", set=Color).interrogate()
+
+    # Should have no failures
+    assert validation.n_passed()[1] == 5
+    assert validation.n_failed()[1] == 0
+    assert validation.all_passed()
+
+
+def test_enum_extraction_helper_function():
+    """Test the _extract_enum_values() helper function directly."""
+    from pointblank.validate import _extract_enum_values
+
+    # Test with Enum class
+    values = _extract_enum_values(Color)
+    assert set(values) == {"red", "green", "blue"}
+
+    # Test with list of Enum instances
+    values = _extract_enum_values([Color.RED, Color.GREEN])
+    assert values == ["red", "green"]
+
+    # Test with mixed list
+    values = _extract_enum_values([Color.RED, "yellow", Color.GREEN])
+    assert values == ["red", "yellow", "green"]
+
+    # Test with regular list
+    values = _extract_enum_values(["red", "yellow", "green"])
+    assert values == ["red", "yellow", "green"]
+
+    # Test with single value
+    values = _extract_enum_values("red")
+    assert values == ["red"]
+
+    # Test with list containing instances from different Enum classes
+    values = _extract_enum_values([Color.RED, Priority.LOW, Status.ACTIVE])
+    assert values == ["red", 1, "active"]
+
+
+def test_col_vals_in_set_with_mixed_enum_classes():
+    """Test col_vals_in_set with a mix of different Enum class instances."""
+    # Create data that has all string values for Polars compatibility
+    data = pl.DataFrame({"mixed_values": ["red", "active", "green", "pending", "blue", "inactive"]})
+
+    # Test with instances from different Enum classes
+    # This tests whether our _extract_enum_values can handle different Enum types
+    validation = (
+        Validate(data)
+        .col_vals_in_set(
+            columns="mixed_values", set=[Color.RED, Color.GREEN, Status.ACTIVE, Status.PENDING]
+        )
+        .interrogate()
+    )
+
+    # Should have 4 passes: "red", "green", "active", "pending" are in the set
+    # Should have 2 failures: "blue", "inactive" are not in the set
+    assert validation.n_passed()[1] == 4
+    assert validation.n_failed()[1] == 2
+    assert not validation.all_passed()
+
+
+def test_col_vals_not_in_set_with_mixed_enum_classes():
+    """Test col_vals_not_in_set with a mix of different Enum class instances."""
+    # Create data that has all string values for Polars compatibility
+    data = pl.DataFrame(
+        {"mixed_values": ["red", "active", "yellow", "deleted", "orange", "archived"]}
+    )
+
+    # Test with instances from different Enum classes
+    # This tests whether our _extract_enum_values can handle different Enum types
+    validation = (
+        Validate(data)
+        .col_vals_not_in_set(
+            columns="mixed_values", set=[Color.RED, Color.GREEN, Status.ACTIVE, Status.PENDING]
+        )
+        .interrogate()
+    )
+
+    # Should have 4 passes: "yellow", "deleted", "orange", "archived" are NOT in the prohibited set
+    # Should have 2 failures: "red", "active" ARE in the prohibited set
+    assert validation.n_passed()[1] == 4
+    assert validation.n_failed()[1] == 2
+    assert not validation.all_passed()


### PR DESCRIPTION
This adds direct support for using Enums in the `col_vals_in_set()` and `col_vals_not_in_set()` validation methods.

Fixes: https://github.com/posit-dev/pointblank/issues/153