### PR TITLE
Add percentage null assertion

### DIFF
--- a/pointblank/_constants.py
+++ b/pointblank/_constants.py
@@ -22,7 +22,8 @@ COMPATIBLE_DTYPES = {
     "not_null": ["str", "numeric", "bool", "datetime", "duration"],
 }
 
-ASSERTION_TYPE_METHOD_MAP = {
+ASSERTION_TYPE_METHOD_MAP: dict[str, str] = {
+    "col_vals_pct_null": "pct_null",
     "col_vals_gt": "gt",
     "col_vals_lt": "lt",
     "col_vals_eq": "eq",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import polars as pl
+import pytest
+
+
+@pytest.fixture
+def half_null_ser() -> pl.Series:
+    """A 1k element half null series. Exists to get around rounding issues."""
+    data = [None if i % 2 == 0 else i for i in range(1000)]
+    return pl.Series("half_null", data)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5839,9 +5839,6 @@ def test_row_count_example_tol() -> None:
         )
 
 
-test_row_count_example_tol()
-
-
 @pytest.mark.parametrize(
     ("nrows", "target_count", "tol", "should_pass"),
     [
@@ -17144,3 +17141,124 @@ def test_original_table_never_modified_without_pre(request, tbl_fixture):
     n_values = [vi.n for vi in validation.validation_info]
     expected_rows = tbl.shape[0]
     assert all(n == expected_rows for n in n_values)
+
+
+def test_pct_null_simple() -> None:
+    """Test col_vals_pct_null() with simple data."""
+    data = pl.DataFrame({"a": [1, None, 3, None], "b": [None, None, 3, 4]})
+    validation = Validate(data).col_vals_pct_null(columns=["a", "b"], p=0.5).interrogate()
+
+    validation.assert_passing()
+    validation.assert_below_threshold()
+
+    info = validation.validation_info
+
+    assert len(info) == 2
+
+
+def test_pct_null_simple_fail() -> None:
+    """Test col_vals_pct_null() with simple data."""
+    data = pl.DataFrame({"a": [1, None, 3, None], "b": [None, None, 3, 4]})
+    validation = (
+        Validate(data)
+        .col_vals_pct_null(columns=["a", "b"], p=0.1, tol=0.0001, thresholds=1)
+        .interrogate()
+    )
+
+    with pytest.raises(AssertionError):
+        validation.assert_passing()
+
+    with pytest.raises(AssertionError):
+        validation.assert_below_threshold()
+
+    info = validation.validation_info
+
+    assert len(info) == 2
+
+
+@pytest.mark.xfail(reason="No SVG for pct null?")
+def test_pct_null_simple_report() -> None:
+    """Test col_vals_pct_null() with simple data."""
+    data = pl.DataFrame({"a": [1, None, 3, None], "b": [None, None, 3, 4]})
+    validation = (
+        Validate(data)
+        .col_vals_pct_null(columns=["a", "b"], p=0.1, tol=0.0001, thresholds=1)
+        .interrogate()
+    )
+
+    validation.get_tabular_report()
+
+
+def test_pct_null_exact_match_with_tol() -> None:
+    """Should pass if pct null matches exactly, even with tol."""
+    data = pl.DataFrame({"a": [None, 1, 2, 3]})  # 25% nulls
+    validation = Validate(data).col_vals_pct_null(columns=["a"], p=0.25, tol=0.0).interrogate()
+    validation.assert_passing()
+
+
+def test_pct_null_within_tol_pass() -> None:
+    """Should pass if pct null is within tolerance margin."""
+    data = pl.DataFrame({"a": [None, None, 1, 2]})  # 50% nulls
+    # Allow tolerance of 0.1 around 0.4 -> [0.3, 0.5]
+    validation = Validate(data).col_vals_pct_null(columns=["a"], p=0.4, tol=0.1).interrogate()
+    validation.assert_passing()
+
+
+def test_pct_null_outside_tol_fail(half_null_ser: pl.Series) -> None:
+    """Should fail if pct null is outside tolerance margin."""
+    data = pl.DataFrame({"a": half_null_ser})  # 50% nulls
+    validation = Validate(data).col_vals_pct_null(columns=["a"], p=0.4, tol=0.05).interrogate()
+    with pytest.raises(AssertionError):
+        validation.assert_passing()
+
+
+def test_pct_null_lower_bound_edge() -> None:
+    """Should pass exactly at lower bound of tolerance range."""
+    data = pl.DataFrame({"a": [None, None, 1, 2]})  # 50% nulls
+    # Expect 0.55 ± 0.05 => [0.5, 0.6]
+    validation = Validate(data).col_vals_pct_null(columns=["a"], p=0.55, tol=0.0).interrogate()
+    validation.assert_passing()
+
+
+def test_pct_null_upper_bound_edge() -> None:
+    """Should pass exactly at upper bound of tolerance range."""
+    data = pl.DataFrame({"a": [None, 1, 2, 3]})  # 25% nulls
+    # Expect 0.2 ± 0.05 => [0.15, 0.25]
+    validation = Validate(data).col_vals_pct_null(columns=["a"], p=0.2, tol=0.05).interrogate()
+    validation.assert_passing()
+
+
+def test_pct_null_multiple_columns_with_tol() -> None:
+    """Should check multiple columns with tolerance."""
+    data = pl.DataFrame(
+        {
+            "a": [None, None, 1, 2],  # 50%
+            "b": [1, None, 2, None],  # 50%
+            "c": [1, 2, 3, 4],  # 0%
+        }
+    )
+    validation = (
+        Validate(data).col_vals_pct_null(columns=["a", "b", "c"], p=0.5, tol=0.01).interrogate()
+    )
+    # "a" and "b" should pass, "c" should fail
+    with pytest.raises(AssertionError):
+        validation.assert_passing()
+
+
+def test_pct_null_low_tol(half_null_ser: pl.Series) -> None:
+    """Tolerance is subject to rounding, and always relative to the total dataset."""
+    data = pl.DataFrame({"a": [None, None, 2, 3]})  # 50% null
+    validation = Validate(data).col_vals_pct_null(columns=["a"], p=0.501, tol=0.0).interrogate()
+    validation.assert_passing()  # the reason this passes is because of rounding
+
+    data = pl.DataFrame({"a": half_null_ser})
+    validation = Validate(data).col_vals_pct_null(columns=["a"], p=0.501, tol=0.0).interrogate()
+    with pytest.raises(AssertionError):
+        validation.assert_passing()  # now fails because no rounding issues
+
+
+def test_pct_null_high_tol_always_pass() -> None:
+    """Large tolerance should allow big differences."""
+    data = pl.DataFrame({"a": [None, None, None, 1]})  # 75% null
+    validation = Validate(data).col_vals_pct_null(columns=["a"], p=0.25, tol=10).interrogate()
+    validation.assert_passing()


### PR DESCRIPTION
# Summary

This method checks the percentage of null values against a column in a dataset. I added some tests and documentation. I'm seeking review, since navigating tolerance is can be confusing.

I can add examples for doctests, if you guys use those?

The big thing missing is the icon, which prohibits usage with `get_tabular_report`. See the xfail test I added which will pass once the icon is ok. Is there some software you use to generate those. Thanks.

# Related GitHub Issues and PRs

# Checklist

- [x ] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x ] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ x] I have added **pytest** unit tests for any new functionality.
