### PR TITLE
docs: Include Posit badge in header of project website

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -6,6 +6,9 @@ project:
 
 format:
   html:
+    include-in-header:
+      - text: |
+          <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js"></script>
     theme: flatly
     css:
       - styles.css


### PR DESCRIPTION
This adds the 'Supported by Posit' badge in the header of the project website (https://posit-dev.github.io/supported-by-posit/).