### PR TITLE
fix: add inline styles to `<p>` tags in briefs for HTML reports

### DIFF
--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -16407,6 +16407,14 @@ def _transform_assertion_str(
         # Use Markdown-to-HTML conversion to format the `brief_str` text
         brief_str = [commonmark.commonmark(x) for x in brief_str]
 
+        # Add inline styles to <p> tags for proper rendering in all environments
+        # In some sandboxed HTML environments (e.g., Streamlit), <p> tags don't inherit
+        # font-size from parent divs, so we add inline styles directly to the <p> tags
+        brief_str = [
+            re.sub(r"<p>", r'<p style="font-size: inherit; margin: 0;">', x) if x.strip() else x
+            for x in brief_str
+        ]
+
     # Obtain the number of characters contained in the assertion
     # string; this is important for sizing components appropriately
     assertion_type_nchar = [len(x) for x in assertion_str]

--- a/tests/snapshots/test_validate/test_validation_report_briefs_global_local_html/validation_report_briefs_global_local.html
+++ b/tests/snapshots/test_validate/test_validation_report_briefs_global_local_html/validation_report_briefs_global_local.html
@@ -111,7 +111,7 @@
         <div style="font-family: 'IBM Plex Mono', monospace, courier; color: black; font-size: 11px; display: inline-block; vertical-align: middle;">
             <div>col_vals_eq()</div>
         </div>
-        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p><strong>Global Brief</strong>: Expect that values in <code>a</code> should be == <code>3</code>.</p>
+        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p style="font-size: inherit; margin: 0;"><strong>Global Brief</strong>: Expect that values in <code>a</code> should be == <code>3</code>.</p>
 </div>
         </td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;" class="gt_row gt_left">a</td>
@@ -194,7 +194,7 @@
         <div style="font-family: 'IBM Plex Mono', monospace, courier; color: black; font-size: 11px; display: inline-block; vertical-align: middle;">
             <div>col_vals_gt()</div>
         </div>
-        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p>Expect that values in <code>d</code> should be &gt; <code>100</code>.</p>
+        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p style="font-size: inherit; margin: 0;">Expect that values in <code>d</code> should be &gt; <code>100</code>.</p>
 </div>
         </td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;" class="gt_row gt_left">d</td>
@@ -236,7 +236,7 @@
         <div style="font-family: 'IBM Plex Mono', monospace, courier; color: black; font-size: 11px; display: inline-block; vertical-align: middle;">
             <div>col_vals_le()</div>
         </div>
-        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p>This is a custom local brief for the assertion</p>
+        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p style="font-size: inherit; margin: 0;">This is a custom local brief for the assertion</p>
 </div>
         </td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;" class="gt_row gt_left">a</td>
@@ -278,7 +278,7 @@
         <div style="font-family: 'IBM Plex Mono', monospace, courier; color: black; font-size: 11px; display: inline-block; vertical-align: middle;">
             <div>col_vals_ge()</div>
         </div>
-        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p><strong>Step</strong> 5: Expect that values in <code>d</code> should be &gt;= <code>500</code>.</p>
+        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p style="font-size: inherit; margin: 0;"><strong>Step</strong> 5: Expect that values in <code>d</code> should be &gt;= <code>500</code>.</p>
 </div>
         </td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;" class="gt_row gt_left">d</td>

--- a/tests/snapshots/test_validate/test_validation_report_briefs_html/validation_report_with_briefs.html
+++ b/tests/snapshots/test_validate/test_validation_report_briefs_html/validation_report_with_briefs.html
@@ -193,7 +193,7 @@
         <div style="font-family: 'IBM Plex Mono', monospace, courier; color: black; font-size: 11px; display: inline-block; vertical-align: middle;">
             <div>col_vals_gt()</div>
         </div>
-        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p>Expect that values in <code>d</code> should be &gt; <code>100</code>.</p>
+        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p style="font-size: inherit; margin: 0;">Expect that values in <code>d</code> should be &gt; <code>100</code>.</p>
 </div>
         </td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;" class="gt_row gt_left">d</td>
@@ -235,7 +235,7 @@
         <div style="font-family: 'IBM Plex Mono', monospace, courier; color: black; font-size: 11px; display: inline-block; vertical-align: middle;">
             <div>col_vals_le()</div>
         </div>
-        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p>This is a custom brief for the assertion</p>
+        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p style="font-size: inherit; margin: 0;">This is a custom brief for the assertion</p>
 </div>
         </td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;" class="gt_row gt_left">a</td>
@@ -277,7 +277,7 @@
         <div style="font-family: 'IBM Plex Mono', monospace, courier; color: black; font-size: 11px; display: inline-block; vertical-align: middle;">
             <div>col_vals_ge()</div>
         </div>
-        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p><strong>Step</strong> 5: {brief}</p>
+        <div style="font-size: 9px; font-family: 'IBM Plex Sans'; text-wrap: balance; margin-top: 3px;"><p style="font-size: inherit; margin: 0;"><strong>Step</strong> 5: {brief}</p>
 </div>
         </td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5; white-space: nowrap; text-overflow: ellipsis; overflow: hidden;" class="gt_row gt_left">d</td>


### PR DESCRIPTION
Validation report brief text was reportedly displaying at incorrect sizes in Streamlit applications. The CommonMark Markdown parser generates `<p>` tags without inline styles, and in Streamlit's sandboxed HTML environment, these tags don't inherit `font-size` from parent divs, causing them to render at the browser's default size (~16px) instead of the intended 9px.

To fix this, I added regex post-processing after this Markdown conversion to inject inline styles (`font-size: inherit; margin: 0;`) directly into all `<p>` tags of the briefs. This is a general fix for ensuring brief text displays correctly across all environments, including Streamlit, while maintaining backward compatibility with standard browsers.

Fixes: https://github.com/posit-dev/pointblank/issues/156