### PR TITLE
fix broken contrib links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,7 +7,7 @@ labels: "Type: ☹︎ Bug"
 
 ## Prework
 
-- [ ] Read and agree to the [code of conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) and [contributing guidelines](https://github.com/posit-dev/pointblank/blob/main/.github/CONTRIBUTING.md).
+- [ ] Read and agree to the [code of conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) and [contributing guidelines](https://github.com/posit-dev/pointblank/blob/main/CONTRIBUTING.md).
 - [ ] If there is [already a relevant issue](https://github.com/posit-dev/pointblank/issues), whether open or closed, comment on the existing thread instead of posting a new issue.
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -7,7 +7,7 @@ labels: "Type: ★ Enhancement"
 
 ## Prework
 
-- [ ] Read and abide by the Pointblank [code of conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) and [contributing guidelines](https://github.com/posit-dev/pointblank/blob/main/.github/CONTRIBUTING.md).
+- [ ] Read and abide by the Pointblank [code of conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) and [contributing guidelines](https://github.com/posit-dev/pointblank/blob/main/CONTRIBUTING.md).
 - [ ] Search for duplicates among the [existing issues](https://github.com/posit-dev/pointblank/issues) (both open and closed).
 
 ## Proposal


### PR DESCRIPTION
# Summary

Thank you for contributing to Pointblank! To make this process easier for everyone, please explain the context and purpose of your contribution. Also, list the changes made to the existing code or documentation.

### The link to the contributing guide in:
-  ❌ [`.github/ISSUE_TEMPLATE/feature.md`](https://github.com/posit-dev/pointblank/blob/main/.github/ISSUE_TEMPLATE/feature.md) returns a 404 
-  ❌ [`.github/ISSUE_TEMPLATE/bug.md`](https://github.com/posit-dev/pointblank/blob/main/.github/ISSUE_TEMPLATE/bug.md) returns a 404.
-  ✅ [`.github/ISSUE_TEMPLATE/question.md`](https://github.com/posit-dev/pointblank/blob/main/.github/ISSUE_TEMPLATE/question.md) is valid.

The broken links **_currently_** point to: https://github.com/posit-dev/pointblank/blob/main/.github/CONTRIBUTING.md

But they **_should_** point to: https://github.com/posit-dev/pointblank/blob/main/CONTRIBUTING.md

I've updated these links to point to the correct page.

# Related GitHub Issues and PRs

- Fixes #317

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [-] I have added **pytest** unit tests for any new functionality.
