### PR TITLE
Add "test-core" target for quick and dirty local CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,19 @@ test:
 		--reruns 3 \
 		--reruns-delay 1
 
+.PHONY: test-core
+test-core: ## Run core libraries only; useful for local CI
+	@SKIP_PYSPARK_TESTS=1 \
+		SKIP_SQLITE_TESTS=1 \
+		SKIP_PARQUET_TESTS=1 \
+		uv run pytest \
+		--cov=pointblank \
+		--cov-report=term-missing \
+		--randomly-seed 123 \
+		-n auto \
+		--durations=10
+
+
 test-update:
 	pytest --snapshot-update
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -78,8 +78,10 @@ except ImportError:
 ## If we specifically disable tests in pytest set the availability to False
 if os.environ.get("SKIP_PYSPARK_TESTS", "").lower() in ("true", "1", "yes"):
     PYSPARK_AVAILABLE = False
+SQLITE_AVAILABLE = True
 if os.environ.get("SKIP_SQLITE_TESTS", "").lower() in ("true", "1", "yes"):
     SQLITE_AVAILABLE = False
+PARQUET_AVAILABLE = True
 if os.environ.get("SKIP_PARQUET_TESTS", "").lower() in ("true", "1", "yes"):
     PARQUET_AVAILABLE = False
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -75,6 +75,13 @@ try:
 except ImportError:
     PYSPARK_AVAILABLE = False
 
+## If we specifically disable tests in pytest set the availability to False
+if os.environ.get("SKIP_PYSPARK_TESTS", "").lower() in ("true", "1", "yes"):
+    PYSPARK_AVAILABLE = False
+if os.environ.get("SKIP_SQLITE_TESTS", "").lower() in ("true", "1", "yes"):
+    SQLITE_AVAILABLE = False
+if os.environ.get("SKIP_PARQUET_TESTS", "").lower() in ("true", "1", "yes"):
+    PARQUET_AVAILABLE = False
 
 from great_tables import vals
 import great_tables as GT
@@ -180,12 +187,15 @@ TEST_DATA_DIR = Path("tests") / "tbl_files"
 TBL_LIST = [
     "tbl_pd",
     "tbl_pl",
-    "tbl_parquet",
     "tbl_duckdb",
-    "tbl_sqlite",
 ]
 
-# Add PySpark to lists if available
+if PARQUET_AVAILABLE:
+    TBL_LIST.append("tbl_parquet")
+
+if SQLITE_AVAILABLE:
+    TBL_LIST.append("tbl_sqlite")
+
 if PYSPARK_AVAILABLE:
     TBL_LIST.append("tbl_pyspark")
 


### PR DESCRIPTION
# Summary

I've noticed the spark tests run very long (pass --durations 10 to pytest) and instead of refactoring the fixture scheme, I just added a `test-core` target that removes spark, sqllite and parquet based tests. This is useful for very quickly running tests when you make smaller changes locally, it speeds up development cycles.

2 Alternatives to this: 1) Refactoring pyspark fictures and 2) Don't test as much

I think 1) could be reasonable eventually but 2) is off limits for me, I like to run tests early and often, even if it's limited.

Let me know what you think :)
