### PR TITLE
Add reference data as a default for aggregation comparison values

### DIFF
--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -20,6 +20,7 @@ from pointblank.column import (
     first_n,
     last_n,
     matches,
+    ref,
     starts_with,
 )
 from pointblank.datascan import DataScan, col_summary_tbl
@@ -59,6 +60,7 @@ __all__ = [
     "DataScan",
     "DraftValidation",
     "col",
+    "ref",
     "expr_col",
     "col_summary_tbl",
     "starts_with",

--- a/pointblank/column.py
+++ b/pointblank/column.py
@@ -8,6 +8,7 @@ from narwhals.typing import IntoDataFrame
 
 __all__ = [
     "col",
+    "ref",
     "starts_with",
     "ends_with",
     "contains",
@@ -190,6 +191,22 @@ class ColumnLiteral(Column):
 
     def __repr__(self):
         return self.exprs
+
+
+@dataclass
+class ReferenceColumn:
+    """
+    A class to represent a column from the reference data.
+
+    This is used with aggregate validation methods (like `col_sum_eq`, `col_avg_gt`, etc.)
+    to compare the aggregate value of a column in the main data against the aggregate
+    value of a column in the reference data.
+    """
+
+    column_name: str
+
+    def __repr__(self):
+        return f"ref({self.column_name!r})"
 
 
 @dataclass
@@ -520,6 +537,83 @@ def col(
         return ColumnSelectorNarwhals(exprs=exprs)
 
     raise TypeError(f"Unsupported type: {type(exprs)}")  # pragma: no cover
+
+
+def ref(column_name: str) -> ReferenceColumn:
+    """
+    Reference a column from the reference data for aggregate comparisons.
+
+    This function is used with aggregate validation methods (like `col_sum_eq`, `col_avg_gt`, etc.)
+    to compare the aggregate value of a column in the main data against the aggregate value of
+    a column in the reference data.
+
+    To use this function, you must first set the reference data on the `Validate` object using
+    the `reference=` parameter in the constructor.
+
+    Parameters
+    ----------
+    column_name
+        The name of the column in the reference data to compute the aggregate from.
+
+    Returns
+    -------
+    ReferenceColumn
+        A reference column marker that indicates the value should be computed from the
+        reference data.
+
+    Examples
+    --------
+    ```{python}
+    #| echo: false
+    #| output: false
+    import pointblank as pb
+    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    ```
+
+    Suppose we have two DataFrames: a current data table and a reference (historical) table.
+    We want to validate that the sum of a column in the current data matches the sum of the
+    same column in the reference data.
+
+    ```{python}
+    import pointblank as pb
+    import polars as pl
+
+    # Current data
+    current_data = pl.DataFrame({"sales": [100, 200, 300]})
+
+    # Reference (historical) data
+    reference_data = pl.DataFrame({"sales": [100, 200, 300]})
+
+    validation = (
+        pb.Validate(data=current_data, reference=reference_data)
+        .col_sum_eq("sales", pb.ref("sales"))
+        .interrogate()
+    )
+
+    validation
+    ```
+
+    You can also compare different columns or use tolerance:
+
+    ```{python}
+    current_data = pl.DataFrame({"revenue": [105, 205, 305]})
+    reference_data = pl.DataFrame({"sales": [100, 200, 300]})
+
+    # Check if revenue sum is within 10% of sales sum
+    validation = (
+        pb.Validate(data=current_data, reference=reference_data)
+        .col_sum_eq("revenue", pb.ref("sales"), tol=0.1)
+        .interrogate()
+    )
+
+    validation
+    ```
+
+    See Also
+    --------
+    The [`col()`](`pointblank.col`) function for referencing columns within the same table.
+    """
+    return ReferenceColumn(column_name=column_name)
 
 
 def starts_with(text: str, case_sensitive: bool = False) -> StartsWith:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -4898,9 +4898,63 @@ class Validate:
         actions=None,
         active=True,
     ):
-        # For each column and assertion, create a validation info object and add it to
-        # the plan. This is used by all aggregation-based column validation methods and
-        # relies heavily on the `_ValidationInfo.from_agg_validator()` class method.
+        """
+        Add an aggregation-based validation step to the validation plan.
+
+        This internal method is used by all aggregation-based column validation methods
+        (e.g., `col_sum_eq`, `col_avg_gt`, `col_sd_le`) to create and register validation
+        steps. It relies heavily on the `_ValidationInfo.from_agg_validator()` class method.
+
+        Automatic Reference Inference
+        -----------------------------
+        When `value` is None and reference data has been set on the Validate object,
+        this method automatically creates a `ReferenceColumn` pointing to the same
+        column name in the reference data. This enables a convenient shorthand:
+
+        .. code-block:: python
+
+            # Instead of writing:
+            Validate(data=df, reference=ref_df).col_sum_eq("a", ref("a"))
+
+            # You can simply write:
+            Validate(data=df, reference=ref_df).col_sum_eq("a")
+
+        If `value` is None and no reference data is set, a `ValueError` is raised
+        immediately to provide clear feedback to the user.
+
+        Parameters
+        ----------
+        assertion_type
+            The type of assertion (e.g., "col_sum_eq", "col_avg_gt").
+        columns
+            Column name or collection of column names to validate.
+        value
+            The target value to compare against. Can be:
+            - A numeric literal (int or float)
+            - A `Column` object for cross-column comparison
+            - A `ReferenceColumn` object for reference data comparison
+            - None to automatically use `ref(column)` when reference data is set
+        tol
+            Tolerance for the comparison. Defaults to 0.
+        thresholds
+            Custom thresholds for the validation step.
+        brief
+            Brief description or auto-generate flag.
+        actions
+            Actions to take based on validation results.
+        active
+            Whether this validation step is active.
+
+        Returns
+        -------
+        Validate
+            The Validate instance for method chaining.
+
+        Raises
+        ------
+        ValueError
+            If `value` is None and no reference data is set on the Validate object.
+        """
         if isinstance(columns, str):
             columns = [columns]
         for column in columns:

--- a/scripts/generate_agg_validate_pyi.py
+++ b/scripts/generate_agg_validate_pyi.py
@@ -17,7 +17,7 @@ VALIDATE_PYI_PATH = Path("pointblank/validate.pyi")
 SIGNATURE = """
         self,
         columns: _PBUnresolvedColumn,
-        value: float | Column,
+        value: float | Column | ReferenceColumn | None = None,
         tol: Tolerance = 0,
         thresholds: float | bool | tuple | dict | Thresholds | None = None,
         brief: str | bool = False,
@@ -28,7 +28,9 @@ SIGNATURE = """
 DOCSTRING = """
         Args:
             columns (_PBUnresolvedColumn): Column or collection of columns to validate.
-            value (float | Column): Target value to validate against.
+            value (float | Column | ReferenceColumn | None): Target value to validate against.
+                If None and reference data is set on the Validate object, defaults to
+                ref(column) to compare against the same column in the reference data.
             tol (Tolerance, optional): Tolerance for validation distance to target. Defaults to 0.
             thresholds (float | bool | tuple | dict | Thresholds | None, optional): Custom thresholds for
                 the bounds. See examples for usage. Defaults to None.
@@ -47,7 +49,7 @@ CLS = "Validate"
 IMPORT_HEADER = """
 from pointblank import Actions, Thresholds
 from pointblank._utils import _PBUnresolvedColumn
-from pointblank.column import Column
+from pointblank.column import Column, ReferenceColumn
 from pointblank._typing import Tolerance
 """
 


### PR DESCRIPTION
# Summary

This PR allows the use of a reference to another dataset for the value comparison. Users pass an optional reference dataset to validate and for aggregation stats, if they leave the `value` empty, it will compare it to whatever is in the reference data. The use case would be tracking changes in composition across some interval. This would be personally incredibly useful.

# Checklist

- [ x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [ x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ x] I have added **pytest** unit tests for any new functionality.
