### PR TITLE
feat: add ability to include owner, consumers, and version metadata to validations

### DIFF
--- a/docs/user-guide/validation-reports.qmd
+++ b/docs/user-guide/validation-reports.qmd
@@ -82,9 +82,48 @@ especially when sharing reports with stakeholders or reviewing historical valida
 
 #### Report Footer
 
-The report footer contains a timestamp showing when the interrogation was performed. This timestamp
-helps track when data quality checks were executed, which is especially useful when archiving
-reports or monitoring data quality over time.
+The report footer contains several pieces of information that provide context and traceability:
+
+**Timestamps**: The footer shows when the interrogation was performed, including the start time,
+duration, and end time. This helps track when data quality checks were executed, which is especially
+useful when archiving reports or monitoring data quality over time.
+
+**Governance Metadata**: When you provide governance parameters to `Validate`, they are displayed
+in the footer as well. This metadata helps document data ownership and dependencies:
+
+- **Owner**: who is responsible for the data quality (e.g., `"data-platform-team"`)
+- **Consumers**: who depends on this data (e.g., `["ml-team", "analytics"]`)
+- **Version**: the version of the validation plan or data contract (e.g., `"2.1.0"`)
+
+Here's an example showing governance metadata in a validation report:
+
+```{python}
+# Example with governance metadata
+governance_validation = (
+    pb.Validate(
+        data=data,
+        tbl_name="sales_data",
+        label="Sales data validation",
+        owner="data-platform-team",
+        consumers=["ml-team", "analytics", "finance"],
+        version="1.2.0",
+    )
+    .col_vals_gt(columns="value", value=0)
+    .col_vals_in_set(columns="category", set=["A", "B", "C", "D", "E"])
+    .interrogate()
+)
+
+governance_validation
+```
+
+The governance metadata appears below the timestamps in the footer, making it easy to identify who
+owns the data, who depends on it, and which version of the validation rules are being applied.
+
+::: {.callout-tip}
+Governance metadata is particularly useful in enterprise environments where data lineage and
+accountability are important. By including `owner`, `consumers`, and `version` in your validations,
+you create self-documenting reports that can be easily understood by anyone reviewing them.
+:::
 
 ::: {.callout-note}
 Throughout this documentation, the footer is hidden in example reports for brevity. This is
@@ -486,7 +525,25 @@ validation = pb.Validate(
 )
 ```
 
-#### 2. Add Brief Messages for Stakeholder Reports
+#### 2. Include Governance Metadata for Accountability
+
+Add ownership and dependency information for enterprise data governance:
+
+```python
+validation = pb.Validate(
+    data=sales_df,
+    tbl_name="Q3_2025_sales",
+    label="Quarterly sales data validation",
+    owner="data-platform-team",
+    consumers=["ml-team", "analytics", "finance"],
+    version="2.1.0"
+)
+```
+
+This creates a clear record of who is responsible for the data, who depends on it, and which version
+of the validation rules are being applied.
+
+#### 3. Add Brief Messages for Stakeholder Reports
 
 When sharing reports with non-technical stakeholders, always include briefs:
 
@@ -498,7 +555,7 @@ When sharing reports with non-technical stakeholders, always include briefs:
 )
 ```
 
-#### 3. Set Appropriate Thresholds
+#### 4. Set Appropriate Thresholds
 
 Configure thresholds that align with your data quality requirements:
 
@@ -514,7 +571,7 @@ validation = pb.Validate(
 )
 ```
 
-#### 4. Customize for Your Audience
+#### 5. Customize for Your Audience
 
 Tailor the report presentation to your audience:
 
@@ -522,7 +579,7 @@ Tailor the report presentation to your audience:
 - **Management**: hide technical columns, emphasize status indicators
 - **Data stewards**: include extract download buttons, detailed briefs
 
-#### 5. Combine with Other Reporting Tools
+#### 6. Combine with Other Reporting Tools
 
 Use validation reports alongside other Pointblank features:
 
@@ -530,7 +587,7 @@ Use validation reports alongside other Pointblank features:
 - **Extracts**: use `get_data_extracts()` to get all failing data for analysis
 - **Sundered data**: use `get_sundered_data()` to split data into passing/failing sets
 
-#### 6. Archive Reports for Trend Analysis
+#### 7. Archive Reports for Trend Analysis
 
 Save validation reports over time to track data quality trends:
 

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -16604,6 +16604,15 @@ class Validate:
             if incl_footer_timings:
                 gt_tbl = gt_tbl.tab_source_note(source_note=html(table_time))
 
+            # Add governance metadata as source note if any metadata is present
+            governance_html = _create_governance_metadata_html(
+                owner=self.owner,
+                consumers=self.consumers,
+                version=self.version,
+            )
+            if governance_html:
+                gt_tbl = gt_tbl.tab_source_note(source_note=html(governance_html))
+
             # Create notes markdown from validation steps and add as separate source note if enabled
             if incl_footer_notes:
                 notes_markdown = _create_notes_html(self.validation_info)
@@ -18914,6 +18923,71 @@ def _extract_pre_argument(source: str) -> str:
     pre_arg = source[pre_start + len("pre=") : pre_end].strip()
 
     return pre_arg
+
+
+def _create_governance_metadata_html(
+    owner: str | None,
+    consumers: list[str] | None,
+    version: str | None,
+) -> str:
+    """
+    Create HTML for governance metadata display in the report footer.
+
+    Parameters
+    ----------
+    owner
+        The owner of the data being validated.
+    consumers
+        List of consumers who depend on the data.
+    version
+        The version of the validation plan.
+
+    Returns
+    -------
+    str
+        HTML string containing formatted governance metadata, or empty string if no metadata.
+    """
+    if owner is None and consumers is None and version is None:
+        return ""
+
+    metadata_parts = []
+
+    # Common style for the metadata badges (similar to timing style but slightly smaller font)
+    badge_style = (
+        "background-color: #FFF; color: #444; padding: 0.5em 0.5em; position: inherit; "
+        "margin-right: 5px; border: solid 1px #999999; font-variant-numeric: tabular-nums; "
+        "border-radius: 0; padding: 2px 10px 2px 10px; font-size: 11px;"
+    )
+    label_style = (
+        "color: #777; font-weight: bold; font-size: 9px; text-transform: uppercase; "
+        "margin-right: 3px;"
+    )
+
+    if owner is not None:
+        metadata_parts.append(
+            f"<span style='{badge_style}'><span style='{label_style}'>Owner:</span> {owner}</span>"
+        )
+
+    if consumers is not None and len(consumers) > 0:
+        consumers_str = ", ".join(consumers)
+        metadata_parts.append(
+            f"<span style='{badge_style}'>"
+            f"<span style='{label_style}'>Consumers:</span> {consumers_str}"
+            f"</span>"
+        )
+
+    if version is not None:
+        metadata_parts.append(
+            f"<span style='{badge_style}'>"
+            f"<span style='{label_style}'>Version:</span> {version}"
+            f"</span>"
+        )
+
+    return (
+        f"<div style='margin-top: 5px; margin-bottom: 5px; margin-left: 10px;'>"
+        f"{''.join(metadata_parts)}"
+        f"</div>"
+    )
 
 
 def _create_table_time_html(

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -4350,6 +4350,18 @@ class Validate:
         locale's rules. Examples include `"en-US"` for English (United States) and `"fr-FR"` for
         French (France). More simply, this can be a language identifier without a designation of
         territory, like `"es"` for Spanish.
+    owner
+        An optional string identifying the owner of the data being validated. This is useful for
+        governance purposes, indicating who is responsible for the quality and maintenance of the
+        data. For example, `"data-platform-team"` or `"analytics-engineering"`.
+    consumers
+        An optional string or list of strings identifying who depends on or consumes this data.
+        This helps document data dependencies and can be useful for impact analysis when data
+        quality issues are detected. For example, `"ml-team"` or `["ml-team", "analytics"]`.
+    version
+        An optional string representing the version of the validation plan or data contract. This
+        supports semantic versioning (e.g., `"1.0.0"`, `"2.1.0"`) and is useful for tracking changes
+        to validation rules over time and for organizational governance.
 
     Returns
     -------
@@ -4836,6 +4848,9 @@ class Validate:
     brief: str | bool | None = None
     lang: str | None = None
     locale: str | None = None
+    owner: str | None = None
+    consumers: str | list[str] | None = None
+    version: str | None = None
 
     def __post_init__(self):
         # Process data through the centralized data processing pipeline
@@ -4879,6 +4894,36 @@ class Validate:
 
         # Transform any shorthands of `brief` to string representations
         self.brief = _transform_auto_brief(brief=self.brief)
+
+        # Validate and normalize the `owner` parameter
+        if self.owner is not None and not isinstance(self.owner, str):
+            raise TypeError(
+                "The `owner=` parameter must be a string representing the owner of the data. "
+                f"Received type: {type(self.owner).__name__}"
+            )
+
+        # Validate and normalize the `consumers` parameter
+        if self.consumers is not None:
+            if isinstance(self.consumers, str):
+                self.consumers = [self.consumers]
+            elif isinstance(self.consumers, list):
+                if not all(isinstance(c, str) for c in self.consumers):
+                    raise TypeError(
+                        "The `consumers=` parameter must be a string or a list of strings. "
+                        "All elements in the list must be strings."
+                    )
+            else:
+                raise TypeError(
+                    "The `consumers=` parameter must be a string or a list of strings. "
+                    f"Received type: {type(self.consumers).__name__}"
+                )
+
+        # Validate the `version` parameter
+        if self.version is not None and not isinstance(self.version, str):
+            raise TypeError(
+                "The `version=` parameter must be a string representing the version. "
+                f"Received type: {type(self.version).__name__}"
+            )
 
         # TODO: Add functionality to obtain the column names and types from the table
         self.col_names = None

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -606,6 +606,47 @@ def test_validate_class_governance_params():
         Validate(tbl_pd, version=1.0)
 
 
+def test_validate_governance_params_in_report(tbl_pd):
+    """Test that governance metadata is displayed in the validation report."""
+    validate = (
+        Validate(
+            tbl_pd,
+            owner="data-platform-team",
+            consumers=["ml-team", "analytics"],
+            version="2.1.0",
+        )
+        .col_vals_gt(columns="x", value=0)
+        .interrogate()
+    )
+
+    # Get the tabular report HTML
+    report = validate.get_tabular_report()
+    report_html = report.as_raw_html()
+
+    # Check that governance metadata appears in the report
+    assert "data-platform-team" in report_html
+    assert "ml-team" in report_html
+    assert "analytics" in report_html
+    assert "2.1.0" in report_html
+    assert "Owner:" in report_html
+    assert "Consumers:" in report_html
+    assert "Version:" in report_html
+
+
+def test_validate_governance_params_not_in_report_when_none(tbl_pd):
+    """Test that governance metadata is not displayed when all values are None."""
+    validate = Validate(tbl_pd).col_vals_gt(columns="x", value=0).interrogate()
+
+    # Get the tabular report HTML
+    report = validate.get_tabular_report()
+    report_html = report.as_raw_html()
+
+    # Check that governance labels don't appear when no metadata is set
+    assert "Owner:" not in report_html
+    assert "Consumers:" not in report_html
+    assert "Version:" not in report_html
+
+
 @pytest.mark.parametrize(
     "data",
     (

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -562,6 +562,50 @@ def test_validate_class_lang_locale():
         Validate(tbl_pd, lang="invalid")
 
 
+def test_validate_class_governance_params():
+    """Test the governance parameters: owner, consumers, version."""
+    # Test with all governance parameters
+    validate = Validate(
+        tbl_pd,
+        owner="data-platform-team",
+        consumers=["ml-team", "analytics"],
+        version="2.1.0",
+    )
+
+    assert validate.owner == "data-platform-team"
+    assert validate.consumers == ["ml-team", "analytics"]
+    assert validate.version == "2.1.0"
+
+    # Test with single consumer string (should be converted to list)
+    validate_single_consumer = Validate(
+        tbl_pd,
+        consumers="ml-team",
+    )
+    assert validate_single_consumer.consumers == ["ml-team"]
+
+    # Test with None values (defaults)
+    validate_defaults = Validate(tbl_pd)
+    assert validate_defaults.owner is None
+    assert validate_defaults.consumers is None
+    assert validate_defaults.version is None
+
+    # Test invalid owner type
+    with pytest.raises(TypeError, match="owner="):
+        Validate(tbl_pd, owner=123)
+
+    # Test invalid consumers type
+    with pytest.raises(TypeError, match="consumers="):
+        Validate(tbl_pd, consumers=123)
+
+    # Test invalid consumers list with non-string elements
+    with pytest.raises(TypeError, match="consumers="):
+        Validate(tbl_pd, consumers=["ml-team", 123])
+
+    # Test invalid version type
+    with pytest.raises(TypeError, match="version="):
+        Validate(tbl_pd, version=1.0)
+
+
 @pytest.mark.parametrize(
     "data",
     (


### PR DESCRIPTION
This PR adds support for governance metadata in the `Validate` class, allowing users to specify `owner`, `consumers`, and `version` parameters for data validation. These parameters are validated, normalized, and, if present, displayed in the generated validation report. Tests are included to ensure correct handling and display of these new parameters.
