### PR TITLE
docs: show validation report notes output in examples

### DIFF
--- a/docs/user-guide/actions.qmd
+++ b/docs/user-guide/actions.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 Actions transform data validation from passive reporting to active response by automatically

--- a/docs/user-guide/assertions.qmd
+++ b/docs/user-guide/assertions.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 In addition to validation steps that create reports, Pointblank provides **assertions**. This is a

--- a/docs/user-guide/briefs.qmd
+++ b/docs/user-guide/briefs.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 When validating data with Pointblank, it's often helpful to have descriptive labels for each

--- a/docs/user-guide/column-selection-patterns.qmd
+++ b/docs/user-guide/column-selection-patterns.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_header=False, report_incl_footer=False)
+pb.config(report_incl_header=False, report_incl_footer_timings=False)
 ```
 
 Data validation often requires working with columns in flexible ways. Pointblank offers two powerful

--- a/docs/user-guide/expressions.qmd
+++ b/docs/user-guide/expressions.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 While Pointblank offers many specialized validation functions for common data quality checks,

--- a/docs/user-guide/extracts.qmd
+++ b/docs/user-guide/extracts.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_header=False, report_incl_footer=False)
+pb.config(report_incl_header=False, report_incl_footer_timings=False)
 ```
 
 When validating data, identifying exactly which rows failed is critical for diagnosing and resolving

--- a/docs/user-guide/langs.qmd
+++ b/docs/user-guide/langs.qmd
@@ -8,7 +8,7 @@ html-table-processing: none
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_header=False, report_incl_footer=False)
+pb.config(report_incl_header=False, report_incl_footer_timings=False)
 ```
 
 It's possible to generate reporting in various spoken languages. We do this via the `lang=`

--- a/docs/user-guide/preprocessing.qmd
+++ b/docs/user-guide/preprocessing.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 While the available validation methods can do a lot for you, there's likewise a lot of things you

--- a/docs/user-guide/quickstart.qmd
+++ b/docs/user-guide/quickstart.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 The Pointblank library is all about assessing the state of data quality for a table. You provide the

--- a/docs/user-guide/schema-validation.qmd
+++ b/docs/user-guide/schema-validation.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 Schema validation in Pointblank allows you to verify that your data conforms to an expected

--- a/docs/user-guide/segmentation.qmd
+++ b/docs/user-guide/segmentation.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 When validating data, you often need to analyze specific subsets or segments of your data

--- a/docs/user-guide/step-reports.qmd
+++ b/docs/user-guide/step-reports.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 While validation reports provide a comprehensive overview of all validation steps, sometimes you

--- a/docs/user-guide/sundering.qmd
+++ b/docs/user-guide/sundering.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_header=False, report_incl_footer=False)
+pb.config(report_incl_header=False, report_incl_footer_timings=False)
 ```
 
 Sundering data? First off, let's get the correct meaning across here. Sundering is really just

--- a/docs/user-guide/test-data-generation.qmd
+++ b/docs/user-guide/test-data-generation.qmd
@@ -9,7 +9,7 @@ html-table-processing: none
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 Pointblank provides a built-in test data generation system that creates realistic, locale-aware

--- a/docs/user-guide/thresholds.qmd
+++ b/docs/user-guide/thresholds.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 Thresholds are a key concept in Pointblank that allow you to define acceptable limits for failing

--- a/docs/user-guide/validation-methods.qmd
+++ b/docs/user-guide/validation-methods.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_header=False, report_incl_footer=False)
+pb.config(report_incl_header=False, report_incl_footer_timings=False)
 ```
 
 Pointblank provides a comprehensive suite of validation methods to verify different aspects of your

--- a/docs/user-guide/validation-overview.qmd
+++ b/docs/user-guide/validation-overview.qmd
@@ -10,7 +10,7 @@ bread-crumbs: true
 #| echo: false
 #| output: false
 import pointblank as pb
-pb.config(report_incl_footer=False)
+pb.config(report_incl_footer_timings=False)
 ```
 
 This article provides a quick overview of the data validation features in Pointblank. It introduces

--- a/docs/user-guide/validation-reports.qmd
+++ b/docs/user-guide/validation-reports.qmd
@@ -506,7 +506,7 @@ You can also set these preferences globally using `pb.config()`:
 
 ```python
 # Set global preferences
-pb.config(report_incl_header=True, report_incl_footer=False)
+pb.config(report_incl_header=True, report_incl_footer_timings=False)
 ```
 
 ## Best Practices for Validation Reports

--- a/pointblank/column.py
+++ b/pointblank/column.py
@@ -374,7 +374,7 @@ def col(
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Suppose we have a table with columns `a` and `b` and we'd like to validate that the values in
@@ -573,7 +573,7 @@ def ref(column_name: str) -> ReferenceColumn:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Suppose we have two DataFrames: a current data table and a reference (historical) table.
@@ -715,7 +715,7 @@ def starts_with(text: str, case_sensitive: bool = False) -> StartsWith:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Suppose we have a table with columns `name`, `paid_2021`, `paid_2022`, and `person_id` and
@@ -877,7 +877,7 @@ def ends_with(text: str, case_sensitive: bool = False) -> EndsWith:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Suppose we have a table with columns `name`, `2021_pay`, `2022_pay`, and `person_id` and
@@ -1040,7 +1040,7 @@ def contains(text: str, case_sensitive: bool = False) -> Contains:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Suppose we have a table with columns `name`, `2021_pay_total`, `2022_pay_total`, and `person_id`
@@ -1203,7 +1203,7 @@ def matches(pattern: str, case_sensitive: bool = False) -> Matches:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Suppose we have a table with columns `name`, `id_old`, `new_identifier`, and `pay_2021` and we'd
@@ -1348,7 +1348,7 @@ def everything() -> Everything:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Suppose we have a table with several numeric columns and we'd like to validate that all these
@@ -1503,7 +1503,7 @@ def first_n(n: int, offset: int = 0) -> FirstN:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Suppose we have a table with columns `paid_2021`, `paid_2022`, `paid_2023`, `paid_2024`, and
@@ -1662,7 +1662,7 @@ def last_n(n: int, offset: int = 0) -> LastN:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Suppose we have a table with columns `name`, `paid_2021`, `paid_2022`, `paid_2023`, and
@@ -2036,7 +2036,7 @@ def expr_col(column_name: str) -> ColumnExpression:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
     Let's say we have a table with three columns: `a`, `b`, and `c`. We want to validate that:
 

--- a/pointblank/inspect.py
+++ b/pointblank/inspect.py
@@ -44,7 +44,7 @@ def has_columns(*columns: str | list[str]) -> Callable[[Any], bool]:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Using `has_columns()` with the `active=` parameter to conditionally run a validation step:
@@ -203,7 +203,7 @@ def has_rows(
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Skip a validation step if the table is empty:

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -133,7 +133,7 @@ class Schema:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
     A schema can be constructed via the `Schema` class in multiple ways. Let's use the following
     Polars DataFrame as a basis for constructing a schema:

--- a/pointblank/segments.py
+++ b/pointblank/segments.py
@@ -76,7 +76,7 @@ def seg_group(values: list[Any]) -> Segment:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Let's say we're analyzing sales from our local bookstore, and want to check the number of books

--- a/pointblank/thresholds.py
+++ b/pointblank/thresholds.py
@@ -44,7 +44,7 @@ class Thresholds:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_footer=False)
+    pb.config(report_incl_footer_timings=False)
     ```
     In a data validation workflow, you can set thresholds for the number of failing test units at
     different levels. For example, you can set a threshold for the 'warning' level when the number
@@ -389,7 +389,7 @@ class Actions:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_footer=False)
+    pb.config(report_incl_footer_timings=False)
     ```
 
     Let's define both threshold values and actions for a data validation workflow. We'll set these

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -5086,7 +5086,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         We will first create two similar tables for our future validation plans.
 
@@ -5361,7 +5361,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -5650,7 +5650,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -5946,7 +5946,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -6242,7 +6242,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -6536,7 +6536,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -6833,7 +6833,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -7144,7 +7144,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -7469,7 +7469,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -7753,7 +7753,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -8075,7 +8075,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -8299,7 +8299,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
 
         For the examples here, we'll use a simple Polars DataFrame with a numeric column (`a`). The
@@ -8492,7 +8492,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
 
         For the examples here, we'll use a simple Polars DataFrame with a numeric column (`a`). The
@@ -8748,7 +8748,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -8996,7 +8996,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two numeric columns (`a` and
         `b`). The table is shown below:
@@ -9256,7 +9256,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with two string columns (`a` and
         `b`). The table is shown below:
@@ -9559,7 +9559,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
 
         For the examples here, we'll use a simple Polars DataFrame with an email column. The table
@@ -9802,7 +9802,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three columns (`a`, `b`, and
         `c`). The table is shown below:
@@ -9961,7 +9961,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with a string columns (`a`) and a
         numeric column (`b`). The table is shown below:
@@ -10178,7 +10178,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three columns (`a`, `b`,
         and `c`) that have different percentages of Null values. The table is shown below:
@@ -10508,7 +10508,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three string columns
         (`col_1`, `col_2`, and `col_3`). The table is shown below:
@@ -10754,7 +10754,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three string columns
         (`col_1`, `col_2`, and `col_3`). The table is shown below:
@@ -11099,7 +11099,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         The following examples demonstrate how to use AI validation for different types of data
         quality checks. These examples show both basic usage and more advanced configurations with
@@ -11377,7 +11377,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
 
         For the examples here, we'll use a simple Polars DataFrame with three columns (string,
@@ -11596,7 +11596,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False)
         ```
 
         For the examples here, we'll use the built in dataset `"small_table"`. The table can be
@@ -11902,7 +11902,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False)
         ```
 
         The simplest use of `data_freshness()` requires just two arguments: the `column=` containing
@@ -12179,7 +12179,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False)
         ```
 
         For the examples here, we'll use the built in dataset `"game_revenue"`. The table can be
@@ -12424,7 +12424,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False)
         ```
 
         For the examples here, we'll create two simple tables to demonstrate the `tbl_match()`
@@ -12633,7 +12633,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         For the examples here, we'll use a simple Polars DataFrame with three numeric columns (`a`,
         `b`, and `c`). The table is shown below:
@@ -12901,7 +12901,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         The `specially()` method offers maximum flexibility for validation, allowing you to create
         custom validation logic that fits your specific needs. The following examples demonstrate
@@ -14706,7 +14706,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         Below are some examples of how to use the `assert_below_threshold()` method. First, we'll
         create a simple Polars DataFrame with two columns (`a` and `b`).
@@ -14864,7 +14864,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         Below are some examples of how to use the `above_threshold()` method. First, we'll create a
         simple Polars DataFrame with a single column (`values`).
@@ -17543,7 +17543,7 @@ class Validate:
         #| echo: false
         #| output: false
         import pointblank as pb
-        pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+        pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
         ```
         Let's create a validation plan with a few validation steps and interrogate the data. With
         that, we'll have a look at the validation reporting table for the entire collection of
@@ -22947,7 +22947,7 @@ def _generate_agg_docstring(name: str) -> str:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
     For the examples, we'll use a simple Polars DataFrame with numeric columns. The table is
     shown below:

--- a/pointblank/yaml.py
+++ b/pointblank/yaml.py
@@ -910,7 +910,7 @@ def yaml_interrogate(
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
     For the examples here, we'll use YAML configurations to define validation workflows. Let's start
     with a basic YAML workflow that validates the built-in `small_table` dataset.
@@ -1112,7 +1112,7 @@ def validate_yaml(yaml: Union[str, Path]) -> None:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
     For the examples here, we'll demonstrate how to validate YAML configurations before using them
     with validation workflows. This is particularly useful for building robust data validation
@@ -1278,7 +1278,7 @@ def yaml_to_python(yaml: Union[str, Path]) -> str:
     #| echo: false
     #| output: false
     import pointblank as pb
-    pb.config(report_incl_header=False, report_incl_footer=False, preview_incl_header=False)
+    pb.config(report_incl_header=False, report_incl_footer_timings=False, preview_incl_header=False)
     ```
 
     Convert a basic YAML configuration to Python code:


### PR DESCRIPTION
This PR ensures that any validation table notes produced in examples are shown to the reader in the project website. This is done by setting `report_incl_footer_timings=False` instead of `report_incl_footer=False`.