### PR TITLE
docs: improve `generate_dataset()` and `*_field()` docstrings

### DIFF
--- a/pointblank/field.py
+++ b/pointblank/field.py
@@ -343,7 +343,8 @@ def int_field(
 
     Examples
     --------
-    Use `min_val=` and `max_val=` to constrain ranges, and `allowed=` for categorical integers:
+    The `min_val=` and `max_val=` parameters constrain generated ranges, while `allowed=`
+    restricts values to a specific set:
 
     ```{python}
     import pointblank as pb
@@ -357,8 +358,8 @@ def int_field(
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Use `nullable=True` together with `null_probability=` to introduce missing values, and
-    select a smaller dtype with `dtype=`:
+    It's possible to introduce missing values with `nullable=True` and `null_probability=`,
+    and to select a smaller dtype with `dtype=`:
 
     ```{python}
     schema = pb.Schema(
@@ -372,7 +373,8 @@ def int_field(
     pb.preview(pb.generate_dataset(schema, n=50, seed=42))
     ```
 
-    Use `unique=True` to produce distinct identifiers within a range:
+    We can also enforce uniqueness with `unique=True` to produce distinct identifiers within
+    a range:
 
     ```{python}
     schema = pb.Schema(
@@ -383,7 +385,7 @@ def int_field(
     pb.preview(pb.generate_dataset(schema, n=30, seed=10))
     ```
 
-    Provide a custom `generator=` callable to control value generation directly:
+    For complete control, a custom `generator=` callable can be provided:
 
     ```{python}
     import random
@@ -564,7 +566,7 @@ def float_field(
 
     Examples
     --------
-    Use `min_val=` and `max_val=` to define value ranges for different columns:
+    The `min_val=` and `max_val=` parameters define the generated value ranges:
 
     ```{python}
     import pointblank as pb
@@ -578,8 +580,8 @@ def float_field(
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Use `allowed=` to restrict to discrete float values, useful for fixed pricing tiers or
-    measurement levels:
+    It's also possible to restrict values to a discrete set with `allowed=`, which is useful
+    for fixed pricing tiers or measurement levels:
 
     ```{python}
     schema = pb.Schema(
@@ -590,7 +592,7 @@ def float_field(
     pb.preview(pb.generate_dataset(schema, n=50, seed=42))
     ```
 
-    Introduce null values to simulate missing measurements:
+    We can simulate missing measurements by introducing null values:
 
     ```{python}
     schema = pb.Schema(
@@ -604,7 +606,8 @@ def float_field(
     pb.preview(pb.generate_dataset(schema, n=30, seed=7))
     ```
 
-    Use `dtype="Float32"` for reduced precision and a custom `generator=` for full control:
+    Setting `dtype="Float32"` gives reduced precision, and a custom `generator=` provides
+    full control over value generation:
 
     ```{python}
     import random, math
@@ -871,7 +874,8 @@ def string_field(
 
     Examples
     --------
-    Use `preset=` to generate realistic personal data and `allowed=` for categorical values:
+    The `preset=` parameter generates realistic personal data, while `allowed=` restricts
+    values to a categorical set:
 
     ```{python}
     import pointblank as pb
@@ -885,8 +889,8 @@ def string_field(
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Use `pattern=` to generate strings matching a regular expression (e.g., product codes,
-    identifiers):
+    We can also generate strings that match a regular expression with `pattern=` (e.g.,
+    product codes, identifiers):
 
     ```{python}
     schema = pb.Schema(
@@ -898,8 +902,8 @@ def string_field(
     pb.preview(pb.generate_dataset(schema, n=30, seed=42))
     ```
 
-    Use `min_length=` and `max_length=` for random alphanumeric strings, with `nullable=True`
-    to introduce missing values:
+    For random alphanumeric strings, `min_length=` and `max_length=` control the length.
+    Adding `nullable=True` introduces missing values:
 
     ```{python}
     schema = pb.Schema(
@@ -913,7 +917,7 @@ def string_field(
     pb.preview(pb.generate_dataset(schema, n=30, seed=7))
     ```
 
-    Combine business and internet presets to generate a company directory:
+    It's possible to combine business and internet presets to build a company directory:
 
     ```{python}
     schema = pb.Schema(
@@ -1055,7 +1059,8 @@ def bool_field(
 
     Examples
     --------
-    Use `p_true=` to control the distribution of `True`/`False` values:
+    The `p_true=` parameter controls the distribution of `True`/`False` values, allowing
+    you to simulate different probabilities:
 
     ```{python}
     import pointblank as pb
@@ -1069,7 +1074,8 @@ def bool_field(
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Use `nullable=True` with `null_probability=` to simulate optional boolean flags:
+    Optional boolean flags can be simulated by combining `nullable=True` with
+    `null_probability=`:
 
     ```{python}
     schema = pb.Schema(
@@ -1083,7 +1089,7 @@ def bool_field(
     pb.preview(pb.generate_dataset(schema, n=50, seed=42))
     ```
 
-    Combine with other field types in a realistic schema:
+    Boolean fields can be combined with other field types in a realistic schema:
 
     ```{python}
     schema = pb.Schema(
@@ -1254,7 +1260,8 @@ def date_field(
 
     Examples
     --------
-    Use `min_date=` and `max_date=` with `datetime.date` objects to define date ranges:
+    The `min_date=` and `max_date=` parameters accept `datetime.date` objects to define date
+    ranges:
 
     ```{python}
     import pointblank as pb
@@ -1274,7 +1281,7 @@ def date_field(
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Use ISO format strings instead of `date` objects for convenience:
+    For convenience, ISO format strings can be used instead of `date` objects:
 
     ```{python}
     schema = pb.Schema(
@@ -1285,7 +1292,8 @@ def date_field(
     pb.preview(pb.generate_dataset(schema, n=50, seed=42))
     ```
 
-    Use `nullable=True` to introduce missing dates and `unique=True` for distinct values:
+    We can introduce missing dates with `nullable=True` and enforce distinct values using
+    `unique=True`:
 
     ```{python}
     schema = pb.Schema(
@@ -1464,7 +1472,8 @@ def datetime_field(
 
     Examples
     --------
-    Use `min_date=` and `max_date=` with `datetime` objects:
+    The `min_date=` and `max_date=` parameters accept `datetime` objects for precise range
+    definitions:
 
     ```{python}
     import pointblank as pb
@@ -1484,7 +1493,7 @@ def datetime_field(
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Use ISO format strings for a quick setup:
+    For a quick setup, ISO format strings work just as well:
 
     ```{python}
     schema = pb.Schema(
@@ -1497,7 +1506,8 @@ def datetime_field(
     pb.preview(pb.generate_dataset(schema, n=30, seed=42))
     ```
 
-    Use `nullable=True` for optional timestamps and combine with other field types:
+    Optional timestamps can be simulated with `nullable=True`, and datetime fields work
+    nicely alongside other field types:
 
     ```{python}
     schema = pb.Schema(
@@ -1671,7 +1681,8 @@ def time_field(
 
     Examples
     --------
-    Use `min_time=` and `max_time=` with `datetime.time` objects to define business hours:
+    The `min_time=` and `max_time=` parameters accept `datetime.time` objects, making it
+    easy to define business-hours ranges:
 
     ```{python}
     import pointblank as pb
@@ -1691,7 +1702,7 @@ def time_field(
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Use ISO format strings for convenience:
+    ISO format strings can also be used for convenience:
 
     ```{python}
     schema = pb.Schema(
@@ -1702,7 +1713,8 @@ def time_field(
     pb.preview(pb.generate_dataset(schema, n=30, seed=42))
     ```
 
-    Use `nullable=True` for optional time values and combine with other field types:
+    It's possible to introduce optional time values with `nullable=True` and combine them
+    with other field types:
 
     ```{python}
     schema = pb.Schema(
@@ -1887,7 +1899,8 @@ def duration_field(
 
     Examples
     --------
-    Use `min_duration=` and `max_duration=` with `timedelta` objects:
+    The `min_duration=` and `max_duration=` parameters accept `timedelta` objects for
+    defining duration ranges:
 
     ```{python}
     import pointblank as pb
@@ -1907,7 +1920,7 @@ def duration_field(
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Use colon-separated string format for quick duration definitions:
+    Colon-separated strings can also be used for quick duration definitions:
 
     ```{python}
     schema = pb.Schema(
@@ -1918,7 +1931,8 @@ def duration_field(
     pb.preview(pb.generate_dataset(schema, n=30, seed=42))
     ```
 
-    Use `nullable=True` for optional durations and combine with other field types:
+    Optional durations can be created with `nullable=True`, and duration fields work well
+    alongside other field types:
 
     ```{python}
     schema = pb.Schema(

--- a/pointblank/field.py
+++ b/pointblank/field.py
@@ -290,54 +290,112 @@ def int_field(
     dtype: str = "Int64",
 ) -> IntField:
     """
-    Create an integer column specification.
+    Create an integer column specification for use in a schema.
+
+    The `int_field()` function defines the constraints and behavior for an integer column when
+    generating synthetic data with `generate_dataset()`. You can control the range of values
+    with `min_val=` and `max_val=`, restrict values to a specific set with `allowed=`, enforce
+    uniqueness with `unique=True`, and introduce null values with `nullable=True` and
+    `null_probability=`. The `dtype=` parameter lets you choose the specific integer type (e.g.,
+    `"Int8"`, `"UInt16"`, `"Int64"`), which also determines the valid range of values.
+
+    When no constraints are specified, values are drawn uniformly from the full range of the
+    chosen integer dtype. If both `min_val=` and `max_val=` are provided, values are drawn
+    uniformly from that range. If `allowed=` is provided, values are sampled from that specific
+    list.
 
     Parameters
     ----------
     min_val
-        Minimum value (inclusive). Default is `None` (no minimum).
+        Minimum value (inclusive). Default is `None` (no minimum, uses dtype lower bound).
     max_val
-        Maximum value (inclusive). Default is `None` (no maximum).
+        Maximum value (inclusive). Default is `None` (no maximum, uses dtype upper bound).
     allowed
-        List of allowed values (categorical constraint). When provided,
-        values are sampled from this list.
+        List of allowed values (categorical constraint). When provided, values are sampled from
+        this list. Cannot be combined with `min_val=`/`max_val=`.
     nullable
         Whether the column can contain null values. Default is `False`.
     null_probability
-        Probability of generating null when `nullable=True`. Default is `0.0`.
+        Probability of generating a null value for each row when `nullable=True`. Must be
+        between `0.0` and `1.0`. Default is `0.0`.
     unique
-        Whether all values must be unique. Default is `False`.
+        Whether all values must be unique. Default is `False`. When `True`, the generator will
+        retry until it produces `n` distinct values (subject to retry limits).
     generator
-        Custom callable that generates values. Overrides other settings.
+        Custom callable that generates values. When provided, this overrides all other
+        constraints (`min_val=`, `max_val=`, `allowed=`, etc.). The callable should take no
+        arguments and return a single integer value.
     dtype
-        Integer dtype. Default is `"Int64"`. Options: `"Int8"`, `"Int16"`,
-        `"Int32"`, `"Int64"`, `"UInt8"`, `"UInt16"`, `"UInt32"`, `"UInt64"`.
+        Integer dtype. Default is `"Int64"`. Options: `"Int8"`, `"Int16"`, `"Int32"`,
+        `"Int64"`, `"UInt8"`, `"UInt16"`, `"UInt32"`, `"UInt64"`.
 
     Returns
     -------
     IntField
-        An integer field specification.
+        An integer field specification that can be passed to `Schema()`.
+
+    Raises
+    ------
+    ValueError
+        If `min_val` is greater than `max_val`, if `allowed` is an empty list, if
+        `null_probability` is not between `0.0` and `1.0`, or if `dtype` is not a valid
+        integer type.
 
     Examples
     --------
-    Define a schema with integer fields and generate test data:
+    Use `min_val=` and `max_val=` to constrain ranges, and `allowed=` for categorical integers:
 
     ```{python}
     import pointblank as pb
 
-    # Define a schema with integer field specifications
     schema = pb.Schema(
         user_id=pb.int_field(min_val=1, unique=True),
         age=pb.int_field(min_val=0, max_val=120),
         rating=pb.int_field(allowed=[1, 2, 3, 4, 5]),
     )
 
-    # Generate 100 rows of test data
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    The generated data will have unique user IDs starting from `1`, ages between `0`-`120`,
-    and ratings sampled from the allowed values.
+    Use `nullable=True` together with `null_probability=` to introduce missing values, and
+    select a smaller dtype with `dtype=`:
+
+    ```{python}
+    schema = pb.Schema(
+        score=pb.int_field(min_val=0, max_val=255, dtype="UInt8"),
+        optional_val=pb.int_field(
+            min_val=1, max_val=50,
+            nullable=True, null_probability=0.3,
+        ),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=50, seed=42))
+    ```
+
+    Use `unique=True` to produce distinct identifiers within a range:
+
+    ```{python}
+    schema = pb.Schema(
+        record_id=pb.int_field(min_val=1000, max_val=9999, unique=True),
+        priority=pb.int_field(allowed=[1, 2, 3]),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=10))
+    ```
+
+    Provide a custom `generator=` callable to control value generation directly:
+
+    ```{python}
+    import random
+
+    rng = random.Random(0)
+
+    schema = pb.Schema(
+        even_numbers=pb.int_field(generator=lambda: rng.choice(range(0, 100, 2))),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=20, seed=5))
+    ```
     """
     return IntField(
         min_val=min_val,
@@ -456,7 +514,18 @@ def float_field(
     dtype: str = "Float64",
 ) -> FloatField:
     """
-    Create a floating-point column specification.
+    Create a floating-point column specification for use in a schema.
+
+    The `float_field()` function defines the constraints and behavior for a floating-point column
+    when generating synthetic data with `generate_dataset()`. You can control the range of values
+    with `min_val=` and `max_val=`, restrict values to a specific set with `allowed=`, enforce
+    uniqueness with `unique=True`, and introduce null values with `nullable=True` and
+    `null_probability=`. The `dtype=` parameter lets you choose between `"Float32"` and
+    `"Float64"` precision.
+
+    When both `min_val=` and `max_val=` are provided, values are drawn from a uniform
+    distribution across that range. If neither is specified, values are drawn uniformly from a
+    large default range. If `allowed=` is provided, values are sampled from that specific list.
 
     Parameters
     ----------
@@ -465,43 +534,90 @@ def float_field(
     max_val
         Maximum value (inclusive). Default is `None` (no maximum).
     allowed
-        List of allowed values (categorical constraint). When provided,
-        values are sampled from this list.
+        List of allowed values (categorical constraint). When provided, values are sampled from
+        this list. Cannot be combined with `min_val=`/`max_val=`.
     nullable
         Whether the column can contain null values. Default is `False`.
     null_probability
-        Probability of generating null when `nullable=True`. Default is `0.0`.
+        Probability of generating a null value for each row when `nullable=True`. Must be
+        between `0.0` and `1.0`. Default is `0.0`.
     unique
-        Whether all values must be unique. Default is `False`.
+        Whether all values must be unique. Default is `False`. When `True`, the generator will
+        retry until it produces `n` distinct values.
     generator
-        Custom callable that generates values. Overrides other settings.
+        Custom callable that generates values. When provided, this overrides all other
+        constraints. The callable should take no arguments and return a single float value.
     dtype
         Float dtype. Default is `"Float64"`. Options: `"Float32"`, `"Float64"`.
 
     Returns
     -------
     FloatField
-        A float field specification.
+        A float field specification that can be passed to `Schema()`.
+
+    Raises
+    ------
+    ValueError
+        If `min_val` is greater than `max_val`, if `allowed` is an empty list, if
+        `null_probability` is not between `0.0` and `1.0`, or if `dtype` is not a valid
+        float type.
 
     Examples
     --------
-    Define a schema with float fields and generate test data:
+    Use `min_val=` and `max_val=` to define value ranges for different columns:
 
     ```{python}
     import pointblank as pb
 
-    # Define a schema with float field specifications
     schema = pb.Schema(
         price=pb.float_field(min_val=0.01, max_val=9999.99),
         probability=pb.float_field(min_val=0.0, max_val=1.0),
         temperature=pb.float_field(min_val=-40.0, max_val=50.0),
     )
 
-    # Generate 100 rows of test data
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Values are uniformly distributed across the specified ranges.
+    Use `allowed=` to restrict to discrete float values, useful for fixed pricing tiers or
+    measurement levels:
+
+    ```{python}
+    schema = pb.Schema(
+        discount=pb.float_field(allowed=[0.05, 0.10, 0.15, 0.20, 0.25]),
+        weight_kg=pb.float_field(min_val=0.5, max_val=100.0),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=50, seed=42))
+    ```
+
+    Introduce null values to simulate missing measurements:
+
+    ```{python}
+    schema = pb.Schema(
+        reading=pb.float_field(
+            min_val=0.0, max_val=500.0,
+            nullable=True, null_probability=0.2,
+        ),
+        calibration=pb.float_field(min_val=0.9, max_val=1.1),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=7))
+    ```
+
+    Use `dtype="Float32"` for reduced precision and a custom `generator=` for full control:
+
+    ```{python}
+    import random, math
+
+    rng = random.Random(0)
+
+    schema = pb.Schema(
+        sensor_value=pb.float_field(min_val=-10.0, max_val=10.0, dtype="Float32"),
+        log_value=pb.float_field(generator=lambda: math.log(rng.uniform(1, 1000))),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=20, seed=99))
+    ```
     """
     return FloatField(
         min_val=min_val,
@@ -659,55 +775,155 @@ def string_field(
     generator: Callable[[], Any] | None = None,
 ) -> StringField:
     """
-    Create a string column specification.
+    Create a string column specification for use in a schema.
+
+    The `string_field()` function defines the constraints and behavior for a string column when
+    generating synthetic data with `generate_dataset()`. It provides three main modes of string
+    generation: (1) controlled random strings with `min_length=`/`max_length=`, (2) strings
+    matching a regular expression via `pattern=`, or (3) realistic data using `preset=` (e.g.,
+    `"email"`, `"name"`, `"address"`). You can also restrict values to a fixed set with
+    `allowed=`. Only one of `preset=`, `pattern=`, or `allowed=` can be specified at a time.
+
+    When no special mode is selected, random alphanumeric strings are generated with lengths
+    between `min_length=` and `max_length=` (defaulting to 1--20 characters).
 
     Parameters
     ----------
     min_length
-        Minimum string length. Default is `None` (no minimum).
+        Minimum string length (for random string generation). Default is `None` (defaults to
+        `1`). Only applies when `preset=`, `pattern=`, and `allowed=` are all `None`.
     max_length
-        Maximum string length. Default is `None` (no maximum).
+        Maximum string length (for random string generation). Default is `None` (defaults to
+        `20`). Only applies when `preset=`, `pattern=`, and `allowed=` are all `None`.
     pattern
-        Regular expression pattern for generated strings.
+        Regular expression pattern that generated strings must match. Supports character
+        classes (e.g., `[A-Z]`, `[0-9]`), quantifiers (e.g., `{3}`, `{2,5}`), alternation,
+        and groups. Cannot be combined with `preset=` or `allowed=`.
     preset
-        Preset for realistic data (e.g., `"email"`, `"name"`, `"phone_number"`).
+        Preset name for generating realistic data. When specified, values are produced using
+        locale-aware data generation, and the `country=` parameter of `generate_dataset()`
+        controls the locale. Cannot be combined with `pattern=` or `allowed=`. See the
+        **Available Presets** section below for the full list.
     allowed
-        List of allowed values (categorical constraint).
+        List of allowed string values (categorical constraint). Values are sampled uniformly
+        from this list. Cannot be combined with `preset=` or `pattern=`.
     nullable
         Whether the column can contain null values. Default is `False`.
     null_probability
-        Probability of generating null when `nullable=True`. Default is `0.0`.
+        Probability of generating a null value for each row when `nullable=True`. Must be
+        between `0.0` and `1.0`. Default is `0.0`.
     unique
-        Whether all values must be unique. Default is `False`.
+        Whether all values must be unique. Default is `False`. When `True`, the generator will
+        retry until it produces `n` distinct values.
     generator
-        Custom callable that generates values. Overrides other settings.
+        Custom callable that generates values. When provided, this overrides all other
+        constraints. The callable should take no arguments and return a single string value.
 
     Returns
     -------
     StringField
-        A string field specification.
+        A string field specification that can be passed to `Schema()`.
+
+    Raises
+    ------
+    ValueError
+        If more than one of `preset=`, `pattern=`, or `allowed=` is specified; if `allowed=`
+        is an empty list; if `min_length` or `max_length` is negative; if `min_length` exceeds
+        `max_length`; or if `preset` is not a recognized preset name.
+
+    Available Presets
+    -----------------
+    The `preset=` parameter accepts one of the following preset names, organized by category.
+    When a preset is used, the `country=` parameter of `generate_dataset()` controls the locale
+    for region-specific formatting (e.g., address formats, phone number patterns).
+
+    **Personal:** `"name"` (first + last name), `"name_full"` (full name with possible prefix
+    or suffix), `"first_name"`, `"last_name"`, `"email"` (realistic email address),
+    `"phone_number"`, `"address"` (full street address), `"city"`, `"state"`, `"country"`,
+    `"postcode"`, `"latitude"`, `"longitude"`
+
+    **Business:** `"company"` (company name), `"job"` (job title), `"catch_phrase"`
+
+    **Internet:** `"url"`, `"domain_name"`, `"ipv4"`, `"ipv6"`, `"user_name"`, `"password"`
+
+    **Text:** `"text"` (paragraph of text), `"sentence"`, `"paragraph"`, `"word"`
+
+    **Financial:** `"credit_card_number"`, `"iban"`, `"currency_code"`
+
+    **Identifiers:** `"uuid4"`, `"ssn"` (social security number), `"license_plate"`
+
+    **Date/Time (as strings):** `"date_this_year"`, `"date_this_decade"`, `"time"`
+
+    **Miscellaneous:** `"color_name"`, `"file_name"`, `"file_extension"`, `"mime_type"`
+
+    Coherent Data Generation
+    ------------------------
+    When multiple columns in the same schema use related presets, the generated data will be
+    coherent across those columns within each row. Specifically:
+
+    - **Person-related presets** (`"name"`, `"name_full"`, `"first_name"`, `"last_name"`,
+      `"email"`, `"user_name"`): the email and username will be derived from the person's name.
+    - **Address-related presets** (`"address"`, `"city"`, `"state"`, `"postcode"`,
+      `"phone_number"`, `"latitude"`, `"longitude"`): the city, state, and postcode will
+      correspond to the same location within the address.
+
+    This coherence is automatic and requires no additional configuration.
 
     Examples
     --------
-    Define a schema with string fields and generate test data:
+    Use `preset=` to generate realistic personal data and `allowed=` for categorical values:
 
     ```{python}
     import pointblank as pb
 
-    # Define a schema with string field specifications
     schema = pb.Schema(
         name=pb.string_field(preset="name"),
         email=pb.string_field(preset="email", unique=True),
         status=pb.string_field(allowed=["active", "pending", "inactive"]),
-        code=pb.string_field(pattern=r"[A-Z]{3}-[0-9]{4}"),
     )
 
-    # Generate 100 rows of test data
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    The generated data will have coherent names and emails (derived from the name),
-    statuses sampled from the allowed values, and codes matching the regex pattern.
+    Use `pattern=` to generate strings matching a regular expression (e.g., product codes,
+    identifiers):
+
+    ```{python}
+    schema = pb.Schema(
+        product_code=pb.string_field(pattern=r"[A-Z]{3}-[0-9]{4}"),
+        batch_id=pb.string_field(pattern=r"BATCH-[A-Z][0-9]{3}"),
+        sku=pb.string_field(pattern=r"[A-Z]{2}[0-9]{6}"),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=42))
+    ```
+
+    Use `min_length=` and `max_length=` for random alphanumeric strings, with `nullable=True`
+    to introduce missing values:
+
+    ```{python}
+    schema = pb.Schema(
+        short_code=pb.string_field(min_length=3, max_length=5),
+        notes=pb.string_field(
+            min_length=10, max_length=50,
+            nullable=True, null_probability=0.4,
+        ),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=7))
+    ```
+
+    Combine business and internet presets to generate a company directory:
+
+    ```{python}
+    schema = pb.Schema(
+        company=pb.string_field(preset="company"),
+        domain=pb.string_field(preset="domain_name"),
+        industry_tag=pb.string_field(allowed=["tech", "finance", "health", "retail"]),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=20, seed=55))
+    ```
     """
     return StringField(
         min_length=min_length,
@@ -798,48 +1014,87 @@ def bool_field(
     generator: Callable[[], Any] | None = None,
 ) -> BoolField:
     """
-    Create a boolean column specification.
+    Create a boolean column specification for use in a schema.
+
+    The `bool_field()` function defines the constraints and behavior for a boolean column when
+    generating synthetic data with `generate_dataset()`. The `p_true=` parameter controls the
+    probability of generating `True` values, which is useful for simulating real-world
+    distributions where events may be rare or common (e.g., 5% fraud rate, 80% active users).
+
+    By default, `True` and `False` are equally likely (`p_true=0.5`). Setting `p_true=0.0`
+    produces all `False` values, and `p_true=1.0` produces all `True` values.
 
     Parameters
     ----------
     p_true
         Probability of generating `True`. Default is `0.5` (equal probability).
-        Must be between 0.0 and 1.0.
+        Must be between `0.0` and `1.0`.
     nullable
         Whether the column can contain null values. Default is `False`.
     null_probability
-        Probability of generating null when `nullable=True`. Default is `0.0`.
+        Probability of generating a null value for each row when `nullable=True`. Must be
+        between `0.0` and `1.0`. Default is `0.0`.
     unique
-        Whether all values must be unique. Default is `False`.
-        Note: Boolean can only have 2 unique non-null values.
+        Whether all values must be unique. Default is `False`. Note that boolean columns can
+        only have 2 unique non-null values, so `n` must be `<= 2` when `unique=True` (or
+        `<= 3` with `nullable=True`).
     generator
-        Custom callable that generates values. Overrides other settings.
+        Custom callable that generates values. When provided, this overrides all other
+        constraints. The callable should take no arguments and return a single boolean value.
 
     Returns
     -------
     BoolField
-        A boolean field specification.
+        A boolean field specification that can be passed to `Schema()`.
+
+    Raises
+    ------
+    ValueError
+        If `p_true` is not between `0.0` and `1.0`, or if `null_probability` is not between
+        `0.0` and `1.0`.
 
     Examples
     --------
-    Define a schema with boolean fields and generate test data:
+    Use `p_true=` to control the distribution of `True`/`False` values:
 
     ```{python}
     import pointblank as pb
 
-    # Define a schema with boolean field specifications
     schema = pb.Schema(
-        is_active=pb.bool_field(p_true=0.8),      # 80% True
-        is_premium=pb.bool_field(p_true=0.2),     # 20% True
-        is_verified=pb.bool_field(),              # 50% True (default)
+        is_active=pb.bool_field(p_true=0.8),
+        is_premium=pb.bool_field(p_true=0.2),
+        is_verified=pb.bool_field(),
     )
 
-    # Generate 100 rows of test data
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    The `p_true=` parameter controls the probability of generating `True` values,
-    which is helpful for simulating real-world distributions.
+    Use `nullable=True` with `null_probability=` to simulate optional boolean flags:
+
+    ```{python}
+    schema = pb.Schema(
+        opted_in=pb.bool_field(p_true=0.6),
+        has_referral=pb.bool_field(
+            p_true=0.3,
+            nullable=True, null_probability=0.25,
+        ),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=50, seed=42))
+    ```
+
+    Combine with other field types in a realistic schema:
+
+    ```{python}
+    schema = pb.Schema(
+        user_id=pb.int_field(min_val=1, unique=True),
+        name=pb.string_field(preset="name"),
+        email_verified=pb.bool_field(p_true=0.9),
+        is_admin=pb.bool_field(p_true=0.05),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=10))
+    ```
     """
     return BoolField(
         p_true=p_true,
@@ -954,53 +1209,98 @@ def date_field(
     generator: Callable[[], Any] | None = None,
 ) -> DateField:
     """
-    Create a date column specification.
+    Create a date column specification for use in a schema.
+
+    The `date_field()` function defines the constraints and behavior for a date column when
+    generating synthetic data with `generate_dataset()`. You can control the date range with
+    `min_date=` and `max_date=`, enforce uniqueness with `unique=True`, and introduce null
+    values with `nullable=True` and `null_probability=`.
+
+    Dates are generated uniformly within the specified range. If no range is provided, the
+    default range is 2000-01-01 to 2030-12-31. Both `min_date=` and `max_date=` accept either
+    `datetime.date` objects or ISO 8601 date strings (e.g., `"2024-06-15"`).
 
     Parameters
     ----------
     min_date
-        Minimum date (inclusive). Can be ISO string or `date` object.
+        Minimum date (inclusive). Can be an ISO format string (e.g., `"2020-01-01"`) or a
+        `datetime.date` object. Default is `None` (defaults to `2000-01-01`).
     max_date
-        Maximum date (inclusive). Can be ISO string or `date` object.
+        Maximum date (inclusive). Can be an ISO format string (e.g., `"2024-12-31"`) or a
+        `datetime.date` object. Default is `None` (defaults to `2030-12-31`).
     nullable
         Whether the column can contain null values. Default is `False`.
     null_probability
-        Probability of generating null when `nullable=True`. Default is `0.0`.
+        Probability of generating a null value for each row when `nullable=True`. Must be
+        between `0.0` and `1.0`. Default is `0.0`.
     unique
-        Whether all values must be unique. Default is `False`.
+        Whether all values must be unique. Default is `False`. When `True`, the generator will
+        retry until it produces `n` distinct dates. Ensure the date range is large enough to
+        accommodate the requested number of unique dates.
     generator
-        Custom callable that generates values. Overrides other settings.
+        Custom callable that generates values. When provided, this overrides all other
+        constraints. The callable should take no arguments and return a single `datetime.date`
+        value.
 
     Returns
     -------
     DateField
-        A date field specification.
+        A date field specification that can be passed to `Schema()`.
+
+    Raises
+    ------
+    ValueError
+        If `min_date` is later than `max_date`, or if a date string cannot be parsed.
 
     Examples
     --------
-    Define a schema with date fields and generate test data:
+    Use `min_date=` and `max_date=` with `datetime.date` objects to define date ranges:
 
     ```{python}
     import pointblank as pb
     from datetime import date
 
-    # Define a schema with date field specifications
     schema = pb.Schema(
         birth_date=pb.date_field(
             min_date=date(1960, 1, 1),
-            max_date=date(2005, 12, 31)
+            max_date=date(2005, 12, 31),
         ),
         hire_date=pb.date_field(
             min_date=date(2020, 1, 1),
-            max_date=date(2024, 12, 31)
+            max_date=date(2024, 12, 31),
         ),
     )
 
-    # Generate 100 rows of test data
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Date values are uniformly distributed within the specified range.
+    Use ISO format strings instead of `date` objects for convenience:
+
+    ```{python}
+    schema = pb.Schema(
+        event_date=pb.date_field(min_date="2024-01-01", max_date="2024-12-31"),
+        signup_date=pb.date_field(min_date="2023-06-01", max_date="2024-06-01"),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=50, seed=42))
+    ```
+
+    Use `nullable=True` to introduce missing dates and `unique=True` for distinct values:
+
+    ```{python}
+    schema = pb.Schema(
+        order_date=pb.date_field(
+            min_date="2024-01-01", max_date="2024-03-31",
+            unique=True,
+        ),
+        cancel_date=pb.date_field(
+            min_date="2024-01-01", max_date="2024-12-31",
+            nullable=True, null_probability=0.5,
+        ),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=7))
+    ```
     """
     return DateField(
         min_date=min_date,
@@ -1117,53 +1417,104 @@ def datetime_field(
     generator: Callable[[], Any] | None = None,
 ) -> DatetimeField:
     """
-    Create a datetime column specification.
+    Create a datetime column specification for use in a schema.
+
+    The `datetime_field()` function defines the constraints and behavior for a datetime column
+    when generating synthetic data with `generate_dataset()`. You can control the datetime range
+    with `min_date=` and `max_date=`, enforce uniqueness with `unique=True`, and introduce null
+    values with `nullable=True` and `null_probability=`.
+
+    Datetime values are generated uniformly (at second-level resolution) within the specified
+    range. If no range is provided, the default range is 2000-01-01T00:00:00 to
+    2030-12-31T23:59:59. Both `min_date=` and `max_date=` accept `datetime` objects, `date`
+    objects (which are converted to datetimes at midnight), or ISO 8601 datetime strings.
 
     Parameters
     ----------
     min_date
-        Minimum datetime (inclusive). Can be ISO string or `datetime` object.
+        Minimum datetime (inclusive). Can be an ISO format string (e.g.,
+        `"2024-01-01T00:00:00"`), a `datetime.datetime` object, or a `datetime.date` object.
+        Default is `None` (defaults to `2000-01-01 00:00:00`).
     max_date
-        Maximum datetime (inclusive). Can be ISO string or `datetime` object.
+        Maximum datetime (inclusive). Can be an ISO format string, a `datetime.datetime`
+        object, or a `datetime.date` object. Default is `None` (defaults to
+        `2030-12-31 23:59:59`).
     nullable
         Whether the column can contain null values. Default is `False`.
     null_probability
-        Probability of generating null when `nullable=True`. Default is `0.0`.
+        Probability of generating a null value for each row when `nullable=True`. Must be
+        between `0.0` and `1.0`. Default is `0.0`.
     unique
-        Whether all values must be unique. Default is `False`.
+        Whether all values must be unique. Default is `False`. With second-level resolution
+        over a wide range, collisions are unlikely for moderate dataset sizes.
     generator
-        Custom callable that generates values. Overrides other settings.
+        Custom callable that generates values. When provided, this overrides all other
+        constraints. The callable should take no arguments and return a single
+        `datetime.datetime` value.
 
     Returns
     -------
     DatetimeField
-        A datetime field specification.
+        A datetime field specification that can be passed to `Schema()`.
+
+    Raises
+    ------
+    ValueError
+        If `min_date` is later than `max_date`, or if a datetime string cannot be parsed.
 
     Examples
     --------
-    Define a schema with datetime fields and generate test data:
+    Use `min_date=` and `max_date=` with `datetime` objects:
 
     ```{python}
     import pointblank as pb
     from datetime import datetime
 
-    # Define a schema with datetime field specifications
     schema = pb.Schema(
         created_at=pb.datetime_field(
             min_date=datetime(2024, 1, 1),
-            max_date=datetime(2024, 12, 31)
+            max_date=datetime(2024, 12, 31),
         ),
         updated_at=pb.datetime_field(
             min_date=datetime(2024, 6, 1),
-            max_date=datetime(2024, 12, 31)
+            max_date=datetime(2024, 12, 31),
         ),
     )
 
-    # Generate 100 rows of test data
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Datetime values are uniformly distributed within the specified range.
+    Use ISO format strings for a quick setup:
+
+    ```{python}
+    schema = pb.Schema(
+        event_time=pb.datetime_field(
+            min_date="2024-03-01T08:00:00",
+            max_date="2024-03-01T18:00:00",
+        ),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=42))
+    ```
+
+    Use `nullable=True` for optional timestamps and combine with other field types:
+
+    ```{python}
+    schema = pb.Schema(
+        order_id=pb.int_field(min_val=1000, max_val=9999, unique=True),
+        placed_at=pb.datetime_field(
+            min_date=datetime(2024, 1, 1),
+            max_date=datetime(2024, 12, 31),
+        ),
+        shipped_at=pb.datetime_field(
+            min_date=datetime(2024, 1, 2),
+            max_date=datetime(2025, 1, 15),
+            nullable=True, null_probability=0.3,
+        ),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=7))
+    ```
     """
     return DatetimeField(
         min_date=min_date,
@@ -1277,53 +1628,94 @@ def time_field(
     generator: Callable[[], Any] | None = None,
 ) -> TimeField:
     """
-    Create a time column specification.
+    Create a time column specification for use in a schema.
+
+    The `time_field()` function defines the constraints and behavior for a time-of-day column
+    when generating synthetic data with `generate_dataset()`. You can control the time range
+    with `min_time=` and `max_time=`, enforce uniqueness with `unique=True`, and introduce null
+    values with `nullable=True` and `null_probability=`.
+
+    Time values are generated uniformly (at second-level resolution) within the specified range.
+    If no range is provided, the default range is 00:00:00 to 23:59:59. Both `min_time=` and
+    `max_time=` accept `datetime.time` objects or ISO format time strings (e.g., `"09:30:00"`).
 
     Parameters
     ----------
     min_time
-        Minimum time (inclusive). Can be ISO string or `time` object.
+        Minimum time (inclusive). Can be an ISO format string (e.g., `"08:00:00"`) or a
+        `datetime.time` object. Default is `None` (defaults to `00:00:00`).
     max_time
-        Maximum time (inclusive). Can be ISO string or `time` object.
+        Maximum time (inclusive). Can be an ISO format string (e.g., `"17:30:00"`) or a
+        `datetime.time` object. Default is `None` (defaults to `23:59:59`).
     nullable
         Whether the column can contain null values. Default is `False`.
     null_probability
-        Probability of generating null when `nullable=True`. Default is `0.0`.
+        Probability of generating a null value for each row when `nullable=True`. Must be
+        between `0.0` and `1.0`. Default is `0.0`.
     unique
-        Whether all values must be unique. Default is `False`.
+        Whether all values must be unique. Default is `False`. With second-level resolution
+        within a time range, uniqueness is feasible for moderate dataset sizes.
     generator
-        Custom callable that generates values. Overrides other settings.
+        Custom callable that generates values. When provided, this overrides all other
+        constraints. The callable should take no arguments and return a single value.
 
     Returns
     -------
     TimeField
-        A time field specification.
+        A time field specification that can be passed to `Schema()`.
+
+    Raises
+    ------
+    ValueError
+        If `min_time` is later than `max_time`, or if a time string cannot be parsed.
 
     Examples
     --------
-    Define a schema with time fields and generate test data:
+    Use `min_time=` and `max_time=` with `datetime.time` objects to define business hours:
 
     ```{python}
     import pointblank as pb
     from datetime import time
 
-    # Define a schema with time field specifications
     schema = pb.Schema(
         start_time=pb.time_field(
             min_time=time(9, 0, 0),
-            max_time=time(12, 0, 0)
+            max_time=time(12, 0, 0),
         ),
         end_time=pb.time_field(
             min_time=time(13, 0, 0),
-            max_time=time(17, 0, 0)
+            max_time=time(17, 0, 0),
         ),
     )
 
-    # Generate 100 rows of test data
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Time values are uniformly distributed within the specified range.
+    Use ISO format strings for convenience:
+
+    ```{python}
+    schema = pb.Schema(
+        login_time=pb.time_field(min_time="06:00:00", max_time="23:59:59"),
+        alarm_time=pb.time_field(min_time="05:00:00", max_time="09:00:00"),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=42))
+    ```
+
+    Use `nullable=True` for optional time values and combine with other field types:
+
+    ```{python}
+    schema = pb.Schema(
+        employee_id=pb.int_field(min_val=100, max_val=999, unique=True),
+        check_in=pb.time_field(min_time="07:00:00", max_time="10:00:00"),
+        check_out=pb.time_field(
+            min_time="16:00:00", max_time="20:00:00",
+            nullable=True, null_probability=0.15,
+        ),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=7))
+    ```
     """
     return TimeField(
         min_time=min_time,
@@ -1449,53 +1841,101 @@ def duration_field(
     generator: Callable[[], Any] | None = None,
 ) -> DurationField:
     """
-    Create a duration column specification.
+    Create a duration column specification for use in a schema.
+
+    The `duration_field()` function defines the constraints and behavior for a duration
+    (timedelta) column when generating synthetic data with `generate_dataset()`. You can
+    control the duration range with `min_duration=` and `max_duration=`, enforce uniqueness
+    with `unique=True`, and introduce null values with `nullable=True` and `null_probability=`.
+
+    Duration values are generated uniformly (at second-level resolution) within the specified
+    range. If no range is provided, the default range is 0 seconds to 30 days. Both
+    `min_duration=` and `max_duration=` accept `datetime.timedelta` objects or colon-separated
+    strings in `"HH:MM:SS"` or `"MM:SS"` format.
 
     Parameters
     ----------
     min_duration
-        Minimum duration (inclusive). Can be string or `timedelta` object.
+        Minimum duration (inclusive). Can be a `"HH:MM:SS"` or `"MM:SS"` string, or a
+        `datetime.timedelta` object. Default is `None` (defaults to 0 seconds).
     max_duration
-        Maximum duration (inclusive). Can be string or `timedelta` object.
+        Maximum duration (inclusive). Can be a `"HH:MM:SS"` or `"MM:SS"` string, or a
+        `datetime.timedelta` object. Default is `None` (defaults to 30 days).
     nullable
         Whether the column can contain null values. Default is `False`.
     null_probability
-        Probability of generating null when `nullable=True`. Default is `0.0`.
+        Probability of generating a null value for each row when `nullable=True`. Must be
+        between `0.0` and `1.0`. Default is `0.0`.
     unique
-        Whether all values must be unique. Default is `False`.
+        Whether all values must be unique. Default is `False`. With second-level resolution
+        within a duration range, uniqueness is feasible for moderate dataset sizes.
     generator
-        Custom callable that generates values. Overrides other settings.
+        Custom callable that generates values. When provided, this overrides all other
+        constraints. The callable should take no arguments and return a single
+        `datetime.timedelta` value.
 
     Returns
     -------
     DurationField
-        A duration field specification.
+        A duration field specification that can be passed to `Schema()`.
+
+    Raises
+    ------
+    ValueError
+        If `min_duration` is greater than `max_duration`, or if a duration string cannot be
+        parsed.
 
     Examples
     --------
-    Define a schema with duration fields and generate test data:
+    Use `min_duration=` and `max_duration=` with `timedelta` objects:
 
     ```{python}
     import pointblank as pb
     from datetime import timedelta
 
-    # Define a schema with duration field specifications
     schema = pb.Schema(
         session_length=pb.duration_field(
             min_duration=timedelta(minutes=5),
-            max_duration=timedelta(hours=2)
+            max_duration=timedelta(hours=2),
         ),
         wait_time=pb.duration_field(
             min_duration=timedelta(seconds=30),
-            max_duration=timedelta(minutes=15)
+            max_duration=timedelta(minutes=15),
         ),
     )
 
-    # Generate 100 rows of test data
-    pb.generate_dataset(schema, n=100, seed=23)
+    pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Duration values are uniformly distributed within the specified range.
+    Use colon-separated string format for quick duration definitions:
+
+    ```{python}
+    schema = pb.Schema(
+        call_duration=pb.duration_field(min_duration="0:01:00", max_duration="1:30:00"),
+        break_time=pb.duration_field(min_duration="0:05:00", max_duration="0:30:00"),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=42))
+    ```
+
+    Use `nullable=True` for optional durations and combine with other field types:
+
+    ```{python}
+    schema = pb.Schema(
+        task_id=pb.int_field(min_val=1, max_val=500, unique=True),
+        time_spent=pb.duration_field(
+            min_duration=timedelta(minutes=1),
+            max_duration=timedelta(hours=8),
+        ),
+        overtime=pb.duration_field(
+            min_duration=timedelta(0),
+            max_duration=timedelta(hours=4),
+            nullable=True, null_probability=0.6,
+        ),
+    )
+
+    pb.preview(pb.generate_dataset(schema, n=30, seed=7))
+    ```
     """
     return DurationField(
         min_duration=min_duration,

--- a/pointblank/field.py
+++ b/pointblank/field.py
@@ -1917,7 +1917,7 @@ def duration_field(
         ),
     )
 
-    pb.preview(pb.generate_dataset(schema, n=100, seed=23))
+    pb.generate_dataset(schema, n=100, seed=23)
     ```
 
     Colon-separated strings can also be used for quick duration definitions:
@@ -1928,7 +1928,7 @@ def duration_field(
         break_time=pb.duration_field(min_duration="0:05:00", max_duration="0:30:00"),
     )
 
-    pb.preview(pb.generate_dataset(schema, n=30, seed=42))
+    pb.generate_dataset(schema, n=30, seed=42)
     ```
 
     Optional durations can be created with `nullable=True`, and duration fields work well
@@ -1948,7 +1948,7 @@ def duration_field(
         ),
     )
 
-    pb.preview(pb.generate_dataset(schema, n=30, seed=7))
+    pb.generate_dataset(schema, n=30, seed=7)
     ```
     """
     return DurationField(

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -1678,7 +1678,7 @@ def generate_dataset(
         ),
     )
 
-    pb.preview(pb.generate_dataset(schema, n=50, seed=23))
+    pb.generate_dataset(schema, n=50, seed=23)
     ```
     """
     return schema.generate(n=n, seed=seed, output=output, country=country)

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -1541,8 +1541,8 @@ def generate_dataset(
     Generate synthetic test data from a schema.
 
     This function generates random data that conforms to a schema's column definitions. When the
-    schema is defined using `Field` objects with constraints (e.g., `min_val`, `max_val`,
-    `pattern`, `preset`), the generated data will respect those constraints.
+    schema is defined using `Field` objects with constraints (e.g., `min_val=`, `max_val=`,
+    `pattern=`, `preset=`), the generated data will respect those constraints.
 
     Parameters
     ----------
@@ -1552,19 +1552,19 @@ def generate_dataset(
         `string_field()`) for fine-grained control, or as a simple dtype string (e.g.,
         `"Int64"`, `"String"`) for unconstrained generation.
     n
-        Number of rows to generate. Default is `100`.
+        Number of rows to generate. The default is `100`.
     seed
         Random seed for reproducibility. If provided, the same seed will produce
         the same data. Default is `None` (non-deterministic).
     output
-        Output format for the generated data. Options are: (1) `"polars"` (default) returns a
+        Output format for the generated data. Options are: (1) `"polars"` (the default) returns a
         Polars DataFrame, (2) `"pandas"` returns a Pandas DataFrame, and (3) `"dict"` returns
         a dictionary of lists.
     country
         Country code for locale-aware generation when using presets. Accepts ISO 3166-1 alpha-2
-        codes (e.g., `"US"`, `"DE"`, `"FR"`) or alpha-3 codes (e.g., `"USA"`, `"DEU"`,
-        `"FRA"`). This affects the format and content of preset-generated data such as
-        addresses, phone numbers, names, and postal codes. Default is `"US"`.
+        codes (e.g., `"US"`, `"DE"`, `"FR"`) or alpha-3 codes (e.g., `"USA"`, `"DEU"`, `"FRA"`).
+        This affects the format and content of preset-generated data such as addresses, phone
+        numbers, names, and postal codes. The default is `"US"`.
 
     Returns
     -------
@@ -1588,20 +1588,20 @@ def generate_dataset(
       and phone numbers formatted for the specified country. For example, `country="DE"` yields
       German street names and PLZ postal codes, while `country="JP"` yields Japanese addresses.
     - **Person-related presets** (`"name"`, `"name_full"`, `"first_name"`, `"last_name"`,
-      `"email"`, `"user_name"`): produce culturally appropriate names for the specified country.
+      `"email"`, `"user_name"`) produce culturally appropriate names for the specified country.
       For example, `country="FR"` produces French names, while `country="KR"` produces Korean
       names.
     - **Financial presets** (`"iban"`, `"ssn"`, `"license_plate"`): produce identifiers in the
       format used by the specified country.
 
     When multiple columns in the same schema use related presets, the generated data is
-    automatically coherent across those columns within each row. Person-related presets will
-    share the same identity (e.g., the email is derived from the name), and address-related
-    presets will share the same location (e.g., the city matches the address).
+    automatically coherent across those columns within each row. Person-related presets will share
+    the same identity (e.g., the email is derived from the name), and address-related presets will
+    share the same location (e.g., the city matches the address).
 
     Supported Countries
     -------------------
-    The `country=` parameter currently supports **50 countries** with full locale data:
+    The `country=` parameter currently supports 50 countries with full locale data:
 
     **Europe (32 countries):** Austria (`"AT"`), Belgium (`"BE"`), Bulgaria (`"BG"`),
     Croatia (`"HR"`), Cyprus (`"CY"`), Czech Republic (`"CZ"`), Denmark (`"DK"`),
@@ -1623,7 +1623,7 @@ def generate_dataset(
 
     Examples
     --------
-    Generate test data from a schema with field constraints:
+    Here we define a schema with field constraints and generate test data from it:
 
     ```{python}
     import pointblank as pb
@@ -1638,7 +1638,8 @@ def generate_dataset(
     pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
-    Generate data from a simple dtype-only schema as a Pandas DataFrame:
+    It's also possible to generate data from a simple, dtype-only schema. Setting
+    `output="pandas"` returns a Pandas DataFrame:
 
     ```{python}
     schema = pb.Schema(name="String", age="Int64", active="Boolean")
@@ -1646,7 +1647,8 @@ def generate_dataset(
     pb.preview(pb.generate_dataset(schema, n=50, seed=23, output="pandas"))
     ```
 
-    Generate data with German addresses and names by using `country="DE"`:
+    When using presets, the `country=` parameter controls the locale. Here, `country="DE"`
+    produces German names and addresses:
 
     ```{python}
     schema = pb.Schema(
@@ -1658,7 +1660,7 @@ def generate_dataset(
     pb.preview(pb.generate_dataset(schema, n=20, seed=23, country="DE"))
     ```
 
-    Generate a mixed-type dataset combining several field types with nullable columns:
+    We can combine several field types with nullable columns in a mixed-type dataset:
 
     ```{python}
     from datetime import date, timedelta
@@ -1676,7 +1678,7 @@ def generate_dataset(
         ),
     )
 
-    pb.preview(pb.generate_dataset(schema, n=50, seed=99))
+    pb.preview(pb.generate_dataset(schema, n=50, seed=23))
     ```
     """
     return schema.generate(n=n, seed=seed, output=output, country=country)


### PR DESCRIPTION
This PR improves the documentation for the `generate_dataset()` and the `*_field()` functions.