### PR TITLE
fix: have persons' professions match companies

### DIFF
--- a/pointblank/countries/__init__.py
+++ b/pointblank/countries/__init__.py
@@ -772,12 +772,276 @@ class LocaleGenerator:
             return f"{last} {first}"
         return f"{first} {last}"
 
+    # Maps job titles to the type of professional title they warrant.
+    # The type is then matched against available locale prefixes.
+    # Keys are lowercase job titles; values are title categories.
+    _TITLE_CATEGORY_DOCTOR = "doctor"
+    _TITLE_CATEGORY_PROFESSOR = "professor"
+    _TITLE_CATEGORY_ENGINEER = "engineer"
+    _TITLE_CATEGORY_LAWYER = "lawyer"
+    _TITLE_CATEGORY_ARCHITECT = "architect"
+
+    # Jobs that warrant a "Dr." (or locale equivalent) title
+    _DOCTOR_JOBS: set[str] = {
+        # English
+        "doctor",
+        "physician",
+        "dentist",
+        "pharmacist",
+        "veterinarian",
+        "psychologist",
+        "psychiatrist",
+        "surgeon",
+        # German
+        "arzt",
+        "zahnarzt",
+        "apotheker",
+        "tierarzt",
+        # Italian
+        "medico",
+        "farmacista",
+        "veterinario",
+        # Spanish
+        "médico",
+        "médica",
+        "dentista",
+        "farmacéutico",
+        "farmacéutica",
+        "veterinario",
+        "veterinaria",
+        "psicólogo",
+        "psicóloga",
+        # Portuguese
+        "médico",
+        "dentista",
+        "farmacêutico",
+        # French
+        "médecin",
+        "dentiste",
+        "pharmacien",
+        # Dutch
+        "arts",
+        # Danish
+        "læge",
+        "tandlæge",
+        # Norwegian
+        "lege",
+        # Swedish
+        "läkare",
+        "tandläkare",
+        # Finnish
+        "lääkäri",
+        "hammaslääkäri",
+        # Polish
+        "lekarz",
+        # Turkish
+        "doktor",
+        "diş hekimi",
+        # Hungarian
+        "orvos",
+        # Czech
+        "lékař",
+    }
+
+    # Jobs that warrant a "Prof." (or locale equivalent) title
+    _PROFESSOR_JOBS: set[str] = {
+        # English
+        "professor",
+        "lecturer",
+        "research scientist",
+        # German
+        "professor",
+        "forscher",
+        "wissenschaftler",
+        # Italian
+        "professore",
+        # Spanish
+        "profesor",
+        "profesora",
+        # Portuguese
+        "professor",
+        # Dutch
+        "hoogleraar",
+        # Danish
+        "professor",
+        # Swedish
+        "professor",
+        # Finnish
+        "professori",
+        # Polish
+        "profesor",
+    }
+
+    # Jobs that warrant an "Ing." (or locale equivalent) title — used in IT, AT, CZ, NL
+    _ENGINEER_JOBS: set[str] = {
+        # English
+        "engineer",
+        "mechanical engineer",
+        "electrical engineer",
+        "civil engineer",
+        "chemical engineer",
+        "environmental engineer",
+        "software engineer",
+        # German
+        "ingenieur",
+        # Italian
+        "ingegnere",
+        # Spanish
+        "ingeniero",
+        "ingeniera",
+        # Czech
+        "inženýr",
+    }
+
+    # Jobs that warrant an "Avv." title — Italian lawyers
+    _LAWYER_JOBS: set[str] = {
+        "avvocato",
+        "attorney",
+        "lawyer",
+        "solicitor",
+        "barrister",
+        "rechtsanwalt",
+        "advokat",
+        "advocaat",
+        "abogado",
+        "abogada",
+        "advogado",
+        "avocat",
+    }
+
+    # Jobs that warrant an "Arch." title — Italian architects
+    _ARCHITECT_JOBS: set[str] = {
+        "architetto",
+        "architekt",
+        "architect",
+        "arquitecto",
+        "arquitecta",
+        "arquiteto",
+        "architecte",
+        "arkkitehti",
+        "arkitekt",
+    }
+
+    # Maps title categories to the locale prefixes that represent them.
+    # Each entry is: category -> set of prefix strings that could represent it.
+    _TITLE_PREFIX_MAP: dict[str, set[str]] = {
+        "doctor": {
+            "Dr.",
+            "Dr",
+            "Dott.",
+            "Dott.ssa",
+            "Dra.",
+            "Prof. Dr.",
+            "Mr. dr.",
+            "Prof. dr.",
+            # German field-specific (CH prefix data)
+            "Dr. med.",
+            "Dr. med. dent.",
+            "Dr. med. vet.",
+            "Dr. rer. nat.",
+            "Dr. phil.",
+        },
+        "professor": {
+            "Prof.",
+            "Prof",
+            "Professor",
+            "Prof.ssa",
+            "Pr.",
+            "Prof. Dr.",
+            "Prof. dr.",
+        },
+        "engineer": {"Ing.", "DI", "Ir.", "Bc.", "Dr.-Ing."},
+        "lawyer": {"Avv.", "Lcdo.", "Lcda.", "lic. iur."},
+        "architect": {"Arch."},
+    }
+
+    # Countries where the common honorific (Herr/Frau) is stacked before the
+    # professional title: "Herr Dr. med. Ludwig Fröhlich"
+    _STACKING_COUNTRIES: set[str] = {"DE", "AT", "CH"}
+
+    # German field-specific doctoral-title expansions, keyed by job (lowercase).
+    # Maps specific jobs to the appropriate German doctoral discipline abbreviation.
+    _GERMAN_DOCTOR_FIELDS: dict[str, str] = {
+        # Medical doctors  →  Dr. med.
+        "arzt": "Dr. med.",
+        "doctor": "Dr. med.",
+        "physician": "Dr. med.",
+        "surgeon": "Dr. med.",
+        "psychiatrist": "Dr. med.",
+        "medico": "Dr. med.",
+        "médecin": "Dr. med.",
+        "médico": "Dr. med.",
+        "médica": "Dr. med.",
+        # Dentists  →  Dr. med. dent.
+        "zahnarzt": "Dr. med. dent.",
+        "dentist": "Dr. med. dent.",
+        "dentista": "Dr. med. dent.",
+        "dentiste": "Dr. med. dent.",
+        # Veterinarians  →  Dr. med. vet.
+        "tierarzt": "Dr. med. vet.",
+        "veterinarian": "Dr. med. vet.",
+        "veterinario": "Dr. med. vet.",
+        "veterinaria": "Dr. med. vet.",
+        # Pharmacists  →  Dr. rer. nat.
+        "apotheker": "Dr. rer. nat.",
+        "pharmacist": "Dr. rer. nat.",
+        "farmacista": "Dr. rer. nat.",
+        "farmacéutico": "Dr. rer. nat.",
+        "farmacéutica": "Dr. rer. nat.",
+        "farmacêutico": "Dr. rer. nat.",
+        "pharmacien": "Dr. rer. nat.",
+        # Psychologists  →  Dr. phil.
+        "psychologist": "Dr. phil.",
+        "psychologe": "Dr. phil.",
+        "psicólogo": "Dr. phil.",
+        "psicóloga": "Dr. phil.",
+    }
+
+    def _get_title_for_job(self, job: str, available_prefixes: list[str]) -> tuple[str, str] | None:
+        """Return the appropriate professional title prefix for a job, if available.
+
+        Checks if the current job maps to a title category (doctor, professor, etc.)
+        and whether the locale has a matching prefix in its prefix list.
+
+        Returns a ``(prefix, category)`` tuple, or ``None`` if no match (meaning the
+        caller should use default logic).
+        """
+        job_lower = job.lower()
+
+        # Determine which title category this job belongs to
+        category = None
+        if job_lower in self._DOCTOR_JOBS:
+            category = self._TITLE_CATEGORY_DOCTOR
+        elif job_lower in self._PROFESSOR_JOBS:
+            category = self._TITLE_CATEGORY_PROFESSOR
+        elif job_lower in self._ENGINEER_JOBS:
+            category = self._TITLE_CATEGORY_ENGINEER
+        elif job_lower in self._LAWYER_JOBS:
+            category = self._TITLE_CATEGORY_LAWYER
+        elif job_lower in self._ARCHITECT_JOBS:
+            category = self._TITLE_CATEGORY_ARCHITECT
+
+        if category is None:
+            return None
+
+        # Find matching prefixes from the locale's available prefix list
+        valid_prefixes = self._TITLE_PREFIX_MAP.get(category, set())
+        matches = [p for p in available_prefixes if p in valid_prefixes]
+
+        if matches:
+            return (self.rng.choice(matches), category)
+        return None
+
     def name_full(self, gender: str | None = None) -> str:
         """Generate a full name with optional prefix and rare suffix.
 
         Includes honorific prefixes with realistic frequencies:
         - Common honorifics (Mr., Ms., Mrs., etc.): ~95% of names
         - Professional titles (Dr., Prof., Rev., etc.): ~5% of names
+
+        When job/company coherence is active and the person's job warrants a
+        professional title (e.g., Doctor → Dr., Professor → Prof.), that title
+        is always used as the prefix.
 
         Suffixes (Jr., II, III) appear very rarely (~1 in 2000).
         """
@@ -794,16 +1058,43 @@ class LocaleGenerator:
         # These should appear infrequently
         professional_titles = {
             "Dr.",
+            "Dr",
             "Prof.",
+            "Prof",
             "Professor",
             "Rev.",
             "Pr.",
             "Prof. Dr.",
+            "Prof. dr.",
+            "Mr. dr.",
             "Rabbi",
             "Father",
             "Sister",
             "Pastor",
             "Elder",
+            # Locale-specific professional titles
+            "Dott.",
+            "Dott.ssa",
+            "Prof.ssa",
+            "Ing.",
+            "Avv.",
+            "Arch.",
+            "Mag.",
+            "DI",
+            "Ir.",
+            "Bc.",
+            "Mgr.",
+            "Dra.",
+            "Lcdo.",
+            "Lcda.",
+            # German field-specific doctoral titles (e.g. CH prefix data)
+            "Dr. med.",
+            "Dr. med. dent.",
+            "Dr. med. vet.",
+            "Dr. rer. nat.",
+            "Dr. phil.",
+            "Dr.-Ing.",
+            "lic. iur.",
         }
 
         # Get prefix based on gender from locale data
@@ -823,9 +1114,37 @@ class LocaleGenerator:
         locale_common = [p for p in prefix_list if p not in professional_titles]
         locale_professional = [p for p in prefix_list if p in professional_titles]
 
-        # Select prefix with realistic probabilities
-        # ~95% common honorific, ~5% professional title
-        if locale_professional and self.rng.random() < 0.05:
+        # Check if employer coherence is active and the job warrants a title
+        title_result = None
+        employer = self._get_current_employer()
+        current_job = ""
+        if employer is not None:
+            current_job = employer.get("job", "")
+            title_result = self._get_title_for_job(current_job, locale_professional)
+
+        # Select prefix
+        if title_result is not None:
+            job_title_prefix, title_category = title_result
+
+            # In German-speaking countries the common honorific (Herr/Frau) is
+            # stacked in front of the professional title, and doctor-category
+            # titles are expanded with their discipline: "Herr Dr. med. Ludwig"
+            if self.country_code in self._STACKING_COUNTRIES:
+                # Expand Dr. to field-specific variant for doctor-category titles
+                if title_category == self._TITLE_CATEGORY_DOCTOR:
+                    job_title_prefix = self._GERMAN_DOCTOR_FIELDS.get(
+                        current_job.lower(), job_title_prefix
+                    )
+                # Prepend the common honorific (Herr / Frau)
+                if locale_common:
+                    common = self.rng.choice(locale_common)
+                    prefix = f"{common} {job_title_prefix}"
+                else:
+                    prefix = job_title_prefix
+            else:
+                prefix = job_title_prefix
+        elif locale_professional and self.rng.random() < 0.05:
+            # Random professional title (~5% chance when no job coherence)
             prefix = self.rng.choice(locale_professional)
         elif locale_common:
             prefix = self.rng.choice(locale_common)

--- a/pointblank/countries/data/AE/company.json
+++ b/pointblank/countries/data/AE/company.json
@@ -281,5 +281,320 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sales Executive",
+        "HR Manager",
+        "Operations Manager"
+      ],
+      "well_known": [
+        "Emirates Group",
+        "Emaar Properties",
+        "DP World",
+        "Etisalat",
+        "du (Emirates Integrated Telecommunications)",
+        "Majid Al Futtaim",
+        "Al Futtaim Group",
+        "DAMAC Properties",
+        "Emirates NBD",
+        "Masdar",
+        "Abu Dhabi Ports",
+        "ENOC",
+        "Dubai Holding",
+        "Chalhoub Group",
+        "Al Habtoor Group"
+      ],
+      "company_suffixes": [
+        "LLC",
+        "PJSC",
+        "Group",
+        "Holdings",
+        "International"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Teacher"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Petroleum Engineer",
+        "Civil Engineer",
+        "Architect"
+      ],
+      "well_known": [
+        "Abu Dhabi National Oil Company"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "First Abu Dhabi Bank",
+        "Mubadala Investment Company"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Nurse"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.06,
+      "jobs": [
+        "Hospitality Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.04,
+      "jobs": [
+        "Pilot"
+      ],
+      "well_known": [
+        "Al Ghurair Group",
+        "Etihad Airways"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Real Estate Agent"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.2,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/AR/company.json
+++ b/pointblank/countries/data/AR/company.json
@@ -261,5 +261,233 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Banco Galicia",
+        "Banco Santander Río",
+        "Banco Macro",
+        "Telecom Argentina",
+        "Claro Argentina",
+        "Movistar Argentina",
+        "Aerolíneas Argentinas",
+        "Arcor",
+        "Molinos Río de la Plata",
+        "Quilmes",
+        "Tenaris",
+        "Ternium Argentina",
+        "Pampa Energía",
+        "Despegar",
+        "Grupo Clarín"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "S.R.L.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Agronomist",
+        "Industrial Engineer",
+        "Production Manager",
+        "Quality Manager"
+      ],
+      "well_known": [
+        "YPF",
+        "Pan American Energy"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Specialist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist",
+        "IT Administrator"
+      ],
+      "well_known": [
+        "Mercado Libre",
+        "Techint Group",
+        "Globant"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/AT/company.json
+++ b/pointblank/countries/data/AT/company.json
@@ -262,5 +262,327 @@
     "sichert",
     "fördert"
   ],
-  "catch_phrase_connector": "die"
+  "catch_phrase_connector": "die",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Berater",
+        "Projektleiter"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Verkäufer",
+        "Geschäftsführer",
+        "Polizist",
+        "Feuerwehrmann"
+      ],
+      "well_known": [
+        "Erste Group",
+        "Voestalpine",
+        "A1 Telekom Austria",
+        "BAWAG",
+        "Wienerberger",
+        "Andritz",
+        "Mayr-Melnhof",
+        "UNIQA",
+        "Lenzing",
+        "ÖBB",
+        "Austrian Airlines",
+        "Swarovski",
+        "Manner",
+        "SPAR Österreich",
+        "Strabag"
+      ],
+      "company_suffixes": [
+        "GmbH",
+        "AG",
+        "KG",
+        "Gruppe",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Lehrer"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Universität {city}",
+        "{city} Hochschule",
+        "Technische Universität {city}",
+        "{city} Gymnasium"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Ingenieur",
+        "Architekt"
+      ],
+      "well_known": [
+        "OMV",
+        "Verbund",
+        "Red Bull"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Buchhalter"
+      ],
+      "well_known": [
+        "Raiffeisen Bank International",
+        "Vienna Insurance Group"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Krankenschwester",
+        "Arzt",
+        "Zahnarzt",
+        "Physiotherapeut"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "Klinikum {city}",
+        "{city} Krankenhaus",
+        "{city} Universitätsklinik",
+        "{last_name} Medizin"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Koch",
+        "Kellner"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Hotel {city}",
+        "Restaurant {last_name}",
+        "Gasthof {last_name}",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Rechtsanwalt"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Kanzlei {last_name}",
+        "{last_name} & {last_name} Rechtsanwälte",
+        "{last_name} Rechtsberatung"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Journalist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Immobilienmakler"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Softwareentwickler"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Elektriker",
+        "Tischler",
+        "Mechaniker",
+        "Friseur"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Handwerk",
+        "{last_name} Elektrotechnik",
+        "{city} Haustechnik"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/AU/company.json
+++ b/pointblank/countries/data/AU/company.json
@@ -254,5 +254,327 @@
     "ensure",
     "promote"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Consultant",
+        "Project Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sales Representative",
+        "Director",
+        "Police Officer",
+        "Firefighter"
+      ],
+      "well_known": [
+        "CSL",
+        "Westpac",
+        "NAB",
+        "ANZ",
+        "Woolworths",
+        "Wesfarmers",
+        "Macquarie Group",
+        "Telstra",
+        "Woodside",
+        "Transurban",
+        "Coles",
+        "Qantas",
+        "Canva",
+        "Afterpay"
+      ],
+      "company_suffixes": [
+        "Pty Ltd",
+        "Ltd",
+        "Group",
+        "Holdings",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Teacher"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Engineer",
+        "Architect"
+      ],
+      "well_known": [
+        "BHP",
+        "Rio Tinto",
+        "Fortescue Metals",
+        "Bluescope Steel"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Accountant"
+      ],
+      "well_known": [
+        "Commonwealth Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Nurse",
+        "Doctor",
+        "Dentist",
+        "Physiotherapist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Chef",
+        "Waiter"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Lawyer"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Journalist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Real Estate Agent"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Software Developer"
+      ],
+      "well_known": [
+        "Atlassian"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Electrician",
+        "Carpenter",
+        "Mechanic",
+        "Hairdresser"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Plumbing",
+        "{last_name} Electric",
+        "{city} Home Services"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/BE/company.json
+++ b/pointblank/countries/data/BE/company.json
@@ -650,5 +650,402 @@
     "achieve",
     "exceed"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.08,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst",
+        "Consultant"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sales Representative",
+        "Human Resources Manager",
+        "Operations Manager",
+        "Administrative Assistant"
+      ],
+      "well_known": [
+        "Anheuser-Busch InBev",
+        "KBC Group",
+        "Proximus",
+        "Colruyt Group",
+        "UCB",
+        "Solvay",
+        "Umicore",
+        "Ageas",
+        "bpost",
+        "Telenet",
+        "Delhaize",
+        "Elia",
+        "Sofina",
+        "Ackermans & van Haaren",
+        "Groupe Bruxelles Lambert",
+        "D'Ieteren",
+        "Bekaert",
+        "Barco",
+        "Lotus Bakeries",
+        "Puratos",
+        "Barry Callebaut",
+        "Godiva",
+        "Leonidas",
+        "Neuhaus",
+        "Côte d'Or",
+        "Stella Artois",
+        "Jupiler",
+        "Duvel Moortgat",
+        "Chimay",
+        "Westmalle",
+        "Dexia",
+        "ING Belgium",
+        "BNP Paribas Fortis",
+        "Belfius",
+        "AXA Belgium",
+        "Ethias",
+        "SNCB/NMBS",
+        "Jan De Nul",
+        "DEME",
+        "Besix",
+        "CFE",
+        "Arcelor Mittal Belgium",
+        "BASF Antwerpen",
+        "GSK Belgium",
+        "Pfizer Belgium",
+        "Agfa-Gevaert",
+        "Atlas Copco Belgium",
+        "Volvo Cars Ghent",
+        "Audi Brussels",
+        "Van Hool",
+        "Recticel",
+        "Ontex",
+        "Melexis",
+        "Materialise",
+        "Collibra",
+        "Showpad",
+        "Teamleader",
+        "Cake",
+        "Cowboy",
+        "Deliverect",
+        "Odoo",
+        "Unleashed",
+        "Silverfin",
+        "Guardsquare",
+        "Skyline Communications",
+        "Lansweeper",
+        "Sibelco",
+        "Spadel",
+        "Vandemoortele"
+      ],
+      "company_suffixes": [
+        "Inc",
+        "LLC",
+        "Corp",
+        "Group",
+        "Enterprises"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Teacher",
+        "Professor"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Engineer",
+        "Architect",
+        "Construction Manager",
+        "Civil Engineer"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant",
+        "Bank Teller",
+        "Financial Advisor"
+      ],
+      "well_known": [
+        "AG Insurance"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.08,
+      "jobs": [
+        "Nurse",
+        "Physician",
+        "Pharmacist"
+      ],
+      "well_known": [
+        "Janssen Pharmaceutica"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Chef",
+        "Restaurant Manager",
+        "Hotel Manager"
+      ],
+      "well_known": [
+        "Agristo"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Attorney"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.04,
+      "jobs": [
+        "Supply Chain Manager",
+        "Logistics Coordinator",
+        "Buyer"
+      ],
+      "well_known": [
+        "Port of Antwerp-Bruges",
+        "Brussels Airlines"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.08,
+      "jobs": [
+        "Marketing Manager",
+        "Graphic Designer"
+      ],
+      "well_known": [
+        "EVS Broadcast Equipment",
+        "Mediagenix"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "Web Developer",
+        "DevOps Engineer",
+        "Quality Assurance Engineer",
+        "Technical Writer",
+        "UX Designer"
+      ],
+      "well_known": [
+        "Sabena Technics"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Electrician",
+        "Mechanic"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Plumbing",
+        "{last_name} Electric",
+        "{city} Home Services"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/BG/company.json
+++ b/pointblank/countries/data/BG/company.json
@@ -269,5 +269,234 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Bulgartabac Holding",
+        "Aurubis Bulgaria",
+        "Sopharma",
+        "M+S Hydraulic",
+        "Monbat",
+        "Eurohold Bulgaria",
+        "Overgas",
+        "Vivacom",
+        "A1 Bulgaria",
+        "Telenor Bulgaria",
+        "Lidl Bulgaria",
+        "Kaufland Bulgaria",
+        "Billa Bulgaria"
+      ],
+      "company_suffixes": [
+        "AD",
+        "OOD",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Production Manager",
+        "Quality Manager"
+      ],
+      "well_known": [
+        "Bulgarian Energy Holding",
+        "Lukoil Neftohim Burgas"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Fibank",
+        "UniCredit Bulbank",
+        "DSK Bank",
+        "Postbank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Specialist"
+      ],
+      "well_known": [
+        "Bulgaria Air"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist",
+        "IT Administrator"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/BR/company.json
+++ b/pointblank/countries/data/BR/company.json
@@ -257,5 +257,326 @@
     "garante",
     "promove"
   ],
-  "catch_phrase_connector": "que"
+  "catch_phrase_connector": "que",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Consultor",
+        "Gerente de Projeto"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Vendedor",
+        "Diretor",
+        "Policial",
+        "Bombeiro"
+      ],
+      "well_known": [
+        "Itaú Unibanco",
+        "Bradesco",
+        "Banco do Brasil",
+        "Ambev",
+        "JBS",
+        "Magazine Luiza",
+        "Natura",
+        "Embraer",
+        "Gerdau",
+        "BRF",
+        "Localiza",
+        "Weg",
+        "B3",
+        "Cielo",
+        "Suzano",
+        "Klabin"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "Lda.",
+        "Grupo",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Professor"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Universidade de {city}",
+        "Universidade {last_name}",
+        "Instituto {last_name}",
+        "Colégio {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Engenheiro",
+        "Arquiteto"
+      ],
+      "well_known": [
+        "Petrobras",
+        "Vale"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Contador"
+      ],
+      "well_known": [
+        "Nubank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Enfermeiro",
+        "Médico",
+        "Dentista",
+        "Fisioterapeuta"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "Hospital de {city}",
+        "Clínica {last_name}",
+        "Centro Médico {city}",
+        "Hospital Geral de {city}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Cozinheiro",
+        "Garçom"
+      ],
+      "well_known": [
+        "iFood"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Restaurante {last_name}",
+        "Hotel {city}",
+        "Pousada {last_name}"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Advogado"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Escritório {last_name}",
+        "{last_name} & {last_name} Advogados",
+        "{last_name} Advocacia"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Jornalista"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Corretor de Imóveis"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Programador"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Eletricista",
+        "Carpinteiro",
+        "Mecânico",
+        "Cabeleireiro"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Instalações",
+        "{last_name} Construções",
+        "Serviços {city}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/CA/company.json
+++ b/pointblank/countries/data/CA/company.json
@@ -620,5 +620,502 @@
     "integrate",
     "connect"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "technology",
+      "weight": 0.16,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "Web Developer",
+        "DevOps Engineer",
+        "Cloud Architect",
+        "Security Analyst",
+        "Data Scientist",
+        "Machine Learning Engineer",
+        "Quality Assurance Engineer",
+        "Network Administrator",
+        "Database Administrator",
+        "System Administrator"
+      ],
+      "well_known": [
+        "Shopify",
+        "BlackBerry",
+        "OpenText",
+        "CGI Group",
+        "Constellation Software",
+        "Electronic Arts",
+        "Ubisoft",
+        "Google",
+        "Amazon",
+        "Microsoft"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks",
+        "Security",
+        "Solutions"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.08,
+      "jobs": [
+        "Nurse",
+        "Physician",
+        "Pharmacist",
+        "Counsellor",
+        "Psychologist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Centre",
+        "{city} Regional Health",
+        "{state} Health Authority",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.12,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant",
+        "Bank Teller",
+        "Loan Officer",
+        "Financial Advisor",
+        "Investment Analyst"
+      ],
+      "well_known": [
+        "TD Bank",
+        "Royal Bank of Canada",
+        "Scotiabank",
+        "BMO Financial Group",
+        "CIBC",
+        "Manulife",
+        "Sun Life Financial",
+        "Brookfield Asset Management",
+        "Power Corporation"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Credit Union",
+        "{state} Community Bank"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Teacher",
+        "Professor",
+        "Librarian",
+        "Research Scientist"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {state}",
+        "{city} College",
+        "{city} Public Schools",
+        "{city} Academy",
+        "{state} Institute of Technology",
+        "{last_name} University"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Lawyer",
+        "Paralegal"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name}, {last_name} & Associates",
+        "{last_name} Law Group",
+        "{last_name} Legal Services"
+      ]
+    },
+    {
+      "name": "consulting",
+      "weight": 0.08,
+      "jobs": [
+        "Consultant",
+        "Business Analyst",
+        "Project Manager"
+      ],
+      "well_known": [
+        "Deloitte",
+        "PwC",
+        "EY",
+        "KPMG",
+        "Accenture",
+        "Thomson Reuters"
+      ],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.08,
+      "jobs": [
+        "Marketing Manager",
+        "Graphic Designer",
+        "UX Designer",
+        "UI Designer",
+        "Content Writer",
+        "Technical Writer"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Chef",
+        "Restaurant Manager",
+        "Hotel Manager",
+        "Event Coordinator"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel",
+        "{adjective} Catering {suffix}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.04,
+      "jobs": [
+        "Real Estate Agent",
+        "Insurance Agent"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance",
+        "Real Estate"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency",
+        "{adjective} {noun} {suffix}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.06,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Civil Engineer",
+        "Chemical Engineer",
+        "Environmental Engineer",
+        "Architect",
+        "Interior Designer",
+        "Construction Manager"
+      ],
+      "well_known": [
+        "Bombardier",
+        "CAE",
+        "Magna International"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.06,
+      "jobs": [
+        "Operations Manager",
+        "Administrative Assistant",
+        "Executive Assistant",
+        "Human Resources Manager",
+        "Sales Representative",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Loblaws",
+        "Canadian Tire",
+        "Couche-Tard",
+        "Dollarama",
+        "Hudson's Bay Company",
+        "George Weston Limited",
+        "Metro Inc."
+      ],
+      "company_suffixes": [
+        "Inc",
+        "Ltd",
+        "Corp",
+        "Group",
+        "Enterprises"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Plumber",
+        "Electrician",
+        "Carpenter",
+        "HVAC Technician"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Ltd"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Plumbing",
+        "{last_name} Electric",
+        "{last_name} Construction",
+        "{city} Plumbing & Heating",
+        "{last_name} HVAC Services"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.04,
+      "jobs": [
+        "Supply Chain Manager",
+        "Logistics Coordinator",
+        "Warehouse Manager",
+        "Buyer",
+        "Procurement Specialist"
+      ],
+      "well_known": [
+        "CN Rail",
+        "CP Rail"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "social_services",
+      "weight": 0.02,
+      "jobs": [
+        "Social Worker"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{city} Community Services",
+        "{city} Family Services",
+        "{state} Department of Social Services",
+        "{city} Youth and Family Centre"
+      ]
+    },
+    {
+      "name": "energy_telecom",
+      "weight": 0.03,
+      "jobs": [
+        "Mining Engineer",
+        "Oil Field Worker"
+      ],
+      "well_known": [
+        "Bell Canada",
+        "Rogers Communications",
+        "TELUS",
+        "Enbridge",
+        "Suncor Energy",
+        "Imperial Oil",
+        "Nutrien"
+      ],
+      "company_suffixes": [
+        "Energy",
+        "Resources",
+        "Communications",
+        "Networks"
+      ],
+      "company_nouns": [
+        "Energy",
+        "Resources",
+        "Communications",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}"
+      ]
+    },
+    {
+      "name": "transport",
+      "weight": 0.02,
+      "jobs": [
+        "Forestry Technician",
+        "Agricultural Specialist"
+      ],
+      "well_known": [
+        "Air Canada",
+        "WestJet"
+      ],
+      "company_suffixes": [
+        "Corp",
+        "Ltd",
+        "Services"
+      ],
+      "company_nouns": [
+        "Forestry",
+        "Agriculture",
+        "Resources"
+      ],
+      "company_formats": [
+        "{state} Forestry Services",
+        "{city} Agricultural Co-op",
+        "{last_name} {noun} {suffix}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/CH/company.json
+++ b/pointblank/countries/data/CH/company.json
@@ -614,5 +614,346 @@
     "verbessern",
     "verwirklichen"
   ],
-  "catch_phrase_connector": "die"
+  "catch_phrase_connector": "die",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Projektleiter",
+        "Berater",
+        "Analyst",
+        "Conseiller",
+        "Consulente"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.12,
+      "jobs": [
+        "Geschäftsführer",
+        "Direktor",
+        "Verwaltungsrat",
+        "Manager",
+        "Kundenberater",
+        "Sachbearbeiter",
+        "Kaufmann",
+        "Directeur",
+        "Gérant",
+        "Direttore"
+      ],
+      "well_known": [
+        "Nestlé",
+        "UBS",
+        "Swiss Re",
+        "ABB",
+        "Glencore",
+        "Richemont",
+        "Swatch Group",
+        "Rolex",
+        "Patek Philippe",
+        "Omega",
+        "TAG Heuer",
+        "Tissot",
+        "Longines",
+        "IWC Schaffhausen",
+        "Lindt & Sprüngli",
+        "Barry Callebaut",
+        "Emmi",
+        "Migros",
+        "Coop",
+        "Swisscom",
+        "Sunrise",
+        "Swiss International Air Lines",
+        "SBB CFF FFS",
+        "Swiss Post",
+        "Temenos",
+        "Geberit",
+        "Schindler",
+        "SGS",
+        "Givaudan",
+        "Firmenich",
+        "Clariant",
+        "Sika",
+        "LafargeHolcim",
+        "Swiss Life",
+        "Helvetia",
+        "Baloise",
+        "Julius Bär",
+        "Vontobel",
+        "Pictet",
+        "Lombard Odier",
+        "Partners Group",
+        "EFG International",
+        "Stadler Rail",
+        "Bobst",
+        "Georg Fischer",
+        "OC Oerlikon",
+        "Sulzer",
+        "Bühler",
+        "Kuehne + Nagel",
+        "Panalpina",
+        "DKSH",
+        "Victorinox",
+        "Mammut",
+        "On",
+        "Nespresso",
+        "Ricola",
+        "Toblerone",
+        "CERN"
+      ],
+      "company_suffixes": [
+        "GmbH",
+        "AG",
+        "KG",
+        "Gruppe",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Forscher",
+        "Professor",
+        "Lehrer",
+        "Wissenschaftler"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Universität {city}",
+        "{city} Hochschule",
+        "Technische Universität {city}",
+        "{city} Gymnasium"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.12,
+      "jobs": [
+        "Ingenieur",
+        "Architekt"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.12,
+      "jobs": [
+        "Finanzchef",
+        "Treuhänder",
+        "Revisor",
+        "Banker",
+        "Vermögensverwalter",
+        "Buchhalter",
+        "Commercialista"
+      ],
+      "well_known": [
+        "Credit Suisse",
+        "Zurich Insurance"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Arzt",
+        "Apotheker",
+        "Medico"
+      ],
+      "well_known": [
+        "Novartis",
+        "Roche",
+        "Lonza",
+        "Sonova",
+        "Straumann"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "Klinikum {city}",
+        "{city} Krankenhaus",
+        "{city} Universitätsklinik",
+        "{last_name} Medizin"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.05,
+      "jobs": [
+        "Rechtsanwalt",
+        "Avocat",
+        "Notaire",
+        "Avvocato"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Kanzlei {last_name}",
+        "{last_name} & {last_name} Rechtsanwälte",
+        "{last_name} Rechtsberatung"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Journalist",
+        "Redakteur"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.21,
+      "jobs": [
+        "Entwickler",
+        "Informatiker",
+        "Programmierer"
+      ],
+      "well_known": [
+        "Logitech"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.05,
+      "jobs": [
+        "Handwerker",
+        "Techniker",
+        "Elektriker",
+        "Mechaniker"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Handwerk",
+        "{last_name} Elektrotechnik",
+        "{city} Haustechnik"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/CL/company.json
+++ b/pointblank/countries/data/CL/company.json
@@ -254,5 +254,257 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.11,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.14,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Falabella",
+        "Cencosud",
+        "ENAP",
+        "Banco de Chile",
+        "BancoEstado",
+        "CMPC",
+        "SQM",
+        "Concha y Toro",
+        "Enel Chile",
+        "Entel Chile",
+        "VTR",
+        "Movistar Chile",
+        "CCU",
+        "Copec",
+        "Arauco",
+        "Sonda",
+        "NotCo",
+        "Cornershop"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "SpA",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.14,
+      "jobs": [
+        "Mining Engineer",
+        "Agronomist",
+        "Industrial Engineer",
+        "Production Manager",
+        "Geologist"
+      ],
+      "well_known": [
+        "Codelco"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.14,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.07,
+      "jobs": [
+        "Winemaker"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.05,
+      "jobs": [
+        "Logistics Coordinator"
+      ],
+      "well_known": [
+        "LATAM Airlines"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.11,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.25,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/CN/company.json
+++ b/pointblank/countries/data/CN/company.json
@@ -482,5 +482,239 @@
     "scale",
     "modernize"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.13,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst",
+        "Consultant"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.16,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Account Manager",
+        "Customer Service Representative",
+        "Administrative Assistant"
+      ],
+      "well_known": [
+        "Alibaba",
+        "Tencent",
+        "Baidu",
+        "JD.com",
+        "Xiaomi",
+        "ByteDance",
+        "Meituan",
+        "Pinduoduo",
+        "NetEase",
+        "DiDi",
+        "BYD",
+        "CATL",
+        "Geely",
+        "NIO",
+        "ICBC",
+        "China Mobile",
+        "Sinopec",
+        "PetroChina",
+        "State Grid",
+        "Midea",
+        "Haier",
+        "Gree Electric",
+        "Lenovo",
+        "ZTE",
+        "SMIC",
+        "Vanke",
+        "SF Express"
+      ],
+      "company_suffixes": [
+        "Group",
+        "Holdings",
+        "Corp",
+        "International",
+        "Ltd"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.09,
+      "jobs": [
+        "Research Scientist"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.16,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Supply Chain Manager"
+      ],
+      "well_known": [
+        "Air China"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.13,
+      "jobs": [
+        "Marketing Manager",
+        "Graphic Designer",
+        "Content Writer"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.28,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "QA Engineer",
+        "DevOps Engineer",
+        "Data Scientist",
+        "Machine Learning Engineer",
+        "Cloud Architect",
+        "Security Analyst",
+        "Technical Writer"
+      ],
+      "well_known": [
+        "Huawei",
+        "BOE Technology"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/CO/company.json
+++ b/pointblank/countries/data/CO/company.json
@@ -260,5 +260,233 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Grupo Aval",
+        "Bancolombia",
+        "Grupo Nutresa",
+        "Grupo Argos",
+        "ISA",
+        "Avianca",
+        "Claro Colombia",
+        "Movistar Colombia",
+        "Tigo",
+        "Grupo Éxito",
+        "Bavaria",
+        "Postobón",
+        "Davivienda",
+        "Grupo Sura",
+        "Colombina",
+        "Alpina",
+        "Corona"
+      ],
+      "company_suffixes": [
+        "S.A.S.",
+        "S.A.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Agronomist",
+        "Industrial Engineer",
+        "Production Manager",
+        "Quality Manager"
+      ],
+      "well_known": [
+        "Ecopetrol",
+        "Cementos Argos"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Specialist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist",
+        "IT Administrator"
+      ],
+      "well_known": [
+        "Rappi"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/CY/company.json
+++ b/pointblank/countries/data/CY/company.json
@@ -250,5 +250,258 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "CYTA",
+        "EAC",
+        "Petrolina",
+        "KEAN Soft Drinks",
+        "Laiki Sporting",
+        "Cyprus Cement",
+        "Vassiliko Cement Works",
+        "Columbia Shipmanagement",
+        "Interorient Navigation",
+        "Forthnet",
+        "Leptos Estates",
+        "Aristo Developers",
+        "Photos Photiades Group",
+        "KEO"
+      ],
+      "company_suffixes": [
+        "Ltd",
+        "Holdings",
+        "Group",
+        "International",
+        "plc"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant",
+        "Investment Analyst",
+        "Tax Consultant",
+        "Bank Manager"
+      ],
+      "well_known": [
+        "Bank of Cyprus",
+        "Hellenic Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.08,
+      "jobs": [
+        "Tourism Manager",
+        "Hotel Manager"
+      ],
+      "well_known": [
+        "Lordos Hotels",
+        "Louis Hotels"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Shipping Coordinator",
+        "Maritime Officer",
+        "Ship Captain",
+        "Pilot"
+      ],
+      "well_known": [
+        "Cyprus Airways",
+        "Hermes Airports"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.03,
+      "jobs": [
+        "Real Estate Agent",
+        "Insurance Agent",
+        "Property Developer"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.28,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/CZ/company.json
+++ b/pointblank/countries/data/CZ/company.json
@@ -281,5 +281,234 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "CEZ Group",
+        "Agrofert",
+        "Ceska sporitelna",
+        "CSOB",
+        "O2 Czech Republic",
+        "T-Mobile Czech Republic",
+        "Vodafone Czech Republic",
+        "Kofola",
+        "Zentiva",
+        "PPF Group",
+        "Energeticky a prumyslovy holding",
+        "Metrostav",
+        "Prazska energetika",
+        "Ceske drahy",
+        "Linet",
+        "Pilsner Urquell",
+        "Budejovicky Budvar"
+      ],
+      "company_suffixes": [
+        "a.s.",
+        "s.r.o.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Chemical Engineer",
+        "Production Manager",
+        "Quality Manager"
+      ],
+      "well_known": [
+        "Skoda Auto"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Komercni banka"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Specialist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "Avast Software"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/DE/company.json
+++ b/pointblank/countries/data/DE/company.json
@@ -503,5 +503,394 @@
     "digitalisiert",
     "entwickelt"
   ],
-  "catch_phrase_connector": "die"
+  "catch_phrase_connector": "die",
+  "industries": [
+    {
+      "name": "technology",
+      "weight": 0.18,
+      "jobs": [
+        "Softwareentwickler",
+        "Produktmanager",
+        "Datenanalyst",
+        "Webentwickler",
+        "DevOps-Ingenieur",
+        "Cloud-Architekt",
+        "Sicherheitsanalyst",
+        "Data Scientist",
+        "Qualitätsingenieur",
+        "Netzwerkadministrator",
+        "Datenbankadministrator",
+        "Systemadministrator"
+      ],
+      "well_known": [
+        "SAP",
+        "Siemens",
+        "Infineon",
+        "Zalando",
+        "Delivery Hero",
+        "HelloFresh",
+        "N26",
+        "Auto1 Group",
+        "Rocket Internet",
+        "Google",
+        "Amazon",
+        "Microsoft",
+        "Apple"
+      ],
+      "company_suffixes": [
+        "Technologien",
+        "Software",
+        "Lösungen",
+        "Digital",
+        "Systeme"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologie",
+        "Systeme",
+        "Daten",
+        "Analytik",
+        "Netzwerke",
+        "Sicherheit"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.1,
+      "jobs": [
+        "Arzt",
+        "Apotheker"
+      ],
+      "well_known": [
+        "Bayer",
+        "Fresenius"
+      ],
+      "company_suffixes": [
+        "Gesundheit",
+        "Medizin",
+        "Klinik"
+      ],
+      "company_nouns": [
+        "Gesundheit",
+        "Medizin",
+        "Klinik"
+      ],
+      "company_formats": [
+        "{city} Klinikum",
+        "{city} Universitätsklinikum",
+        "Klinikum {city}",
+        "{city} Krankenhaus",
+        "{last_name}-Klinik"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.1,
+      "jobs": [
+        "Finanzanalyst",
+        "Buchhalter",
+        "Bankangestellter",
+        "Finanzberater"
+      ],
+      "well_known": [
+        "Deutsche Bank",
+        "Commerzbank",
+        "Allianz",
+        "Munich Re"
+      ],
+      "company_suffixes": [
+        "Finanz",
+        "Kapital",
+        "Investitionen",
+        "Partner",
+        "Gruppe"
+      ],
+      "company_nouns": [
+        "Kapital",
+        "Investitionen",
+        "Finanz",
+        "Beratung"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} und {last_name}",
+        "{adjective} {noun} {suffix}",
+        "Sparkasse {city}",
+        "{city} Volksbank"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Lehrer",
+        "Professor"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Universität {city}",
+        "Technische Universität {city}",
+        "Hochschule {city}",
+        "Fachhochschule {city}",
+        "{city} Gymnasium",
+        "{city} Gesamtschule"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Rechtsanwalt"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Kanzlei {last_name} & {last_name}",
+        "{last_name} Rechtsanwälte",
+        "{last_name}, {last_name} & Partner"
+      ]
+    },
+    {
+      "name": "consulting",
+      "weight": 0.08,
+      "jobs": [
+        "Berater",
+        "Business Analyst",
+        "Projektmanager"
+      ],
+      "well_known": [
+        "McKinsey & Company",
+        "Boston Consulting Group",
+        "Deloitte",
+        "PwC",
+        "EY",
+        "KPMG"
+      ],
+      "company_suffixes": [
+        "Beratung",
+        "Gruppe",
+        "Partner",
+        "Consulting"
+      ],
+      "company_nouns": [
+        "Beratung",
+        "Management",
+        "Strategie"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} und {last_name}"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.06,
+      "jobs": [
+        "Marketing-Manager",
+        "Grafikdesigner",
+        "UX-Designer",
+        "Technischer Redakteur"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Medien",
+        "Kreativ",
+        "Studios",
+        "Kommunikation",
+        "Gruppe"
+      ],
+      "company_nouns": [
+        "Medien",
+        "Kreativ",
+        "Kommunikation",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} und {last_name}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Koch",
+        "Hotelmanager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Gastronomie",
+        "Gruppe",
+        "Hotels"
+      ],
+      "company_nouns": [
+        "Gastronomie",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "{last_name}s Restaurant",
+        "Hotel {city}",
+        "{adjective} Catering {suffix}",
+        "{city} Kongresszentrum"
+      ]
+    },
+    {
+      "name": "real_estate",
+      "weight": 0.04,
+      "jobs": [
+        "Immobilienmakler"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Immobilien",
+        "Grundstücke",
+        "Gruppe"
+      ],
+      "company_nouns": [
+        "Immobilien",
+        "Grundstücke"
+      ],
+      "company_formats": [
+        "{last_name} Immobilien",
+        "{city} Immobilien",
+        "{adjective} {noun} {suffix}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.1,
+      "jobs": [
+        "Maschinenbauingenieur",
+        "Elektroingenieur",
+        "Bauingenieur",
+        "Architekt",
+        "Bauleiter"
+      ],
+      "well_known": [
+        "Volkswagen",
+        "BMW",
+        "Mercedes-Benz",
+        "Porsche",
+        "Audi",
+        "Bosch",
+        "Continental",
+        "ThyssenKrupp",
+        "BASF",
+        "Airbus",
+        "Tesla"
+      ],
+      "company_suffixes": [
+        "Technik",
+        "Industrie",
+        "Fertigung",
+        "GmbH"
+      ],
+      "company_nouns": [
+        "Technik",
+        "Fertigung",
+        "Bau",
+        "Industrie"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} und {last_name}",
+        "{city} Ingenieurbüro"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.07,
+      "jobs": [
+        "Betriebsleiter",
+        "Verwaltungsassistent",
+        "Personalleiter",
+        "Vertriebsmitarbeiter",
+        "Kundenberater",
+        "Geschäftsführer"
+      ],
+      "well_known": [
+        "Henkel",
+        "Adidas",
+        "Puma",
+        "Deutsche Post DHL",
+        "Lufthansa"
+      ],
+      "company_suffixes": [
+        "GmbH",
+        "AG",
+        "Gruppe",
+        "Unternehmen"
+      ],
+      "company_nouns": [
+        "Lösungen",
+        "Dienstleistungen",
+        "Management",
+        "Industrie"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} und {last_name}"
+      ]
+    },
+    {
+      "name": "social_services",
+      "weight": 0.02,
+      "jobs": [
+        "Sozialarbeiter"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{city} Sozialwerk",
+        "Caritas {city}",
+        "Diakonie {city}",
+        "{city} Familienberatung"
+      ]
+    },
+    {
+      "name": "energy_telecom",
+      "weight": 0.03,
+      "jobs": [
+        "Netzwerkadministrator",
+        "Systemadministrator"
+      ],
+      "well_known": [
+        "Deutsche Telekom",
+        "E.ON",
+        "RWE"
+      ],
+      "company_suffixes": [
+        "Energie",
+        "Strom",
+        "Kommunikation",
+        "Netzwerke"
+      ],
+      "company_nouns": [
+        "Energie",
+        "Strom",
+        "Kommunikation",
+        "Netzwerke"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/DK/company.json
+++ b/pointblank/countries/data/DK/company.json
@@ -265,5 +265,321 @@
     "sikrer",
     "fremmer"
   ],
-  "catch_phrase_connector": "der"
+  "catch_phrase_connector": "der",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Konsulent",
+        "Projektleder"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sælger",
+        "Direktør",
+        "Politibetjent",
+        "Brandmand"
+      ],
+      "well_known": [
+        "Mærsk",
+        "Novo Nordisk",
+        "Carlsberg",
+        "Vestas",
+        "LEGO",
+        "Ørsted",
+        "DSV",
+        "Coloplast",
+        "Pandora",
+        "ISS",
+        "Danfoss",
+        "Grundfos",
+        "Arla",
+        "Rockwool",
+        "Jysk",
+        "Ecco",
+        "Bang & Olufsen",
+        "Coop Danmark",
+        "TDC"
+      ],
+      "company_suffixes": [
+        "A/S",
+        "ApS",
+        "Gruppen",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Lærer"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Københavns Universitet",
+        "{city} Gymnasium",
+        "Erhvervsskolen i {city}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Ingeniør",
+        "Arkitekt"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Revisor"
+      ],
+      "well_known": [
+        "Danske Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Sygeplejerske",
+        "Læge",
+        "Tandlæge",
+        "Fysioterapeut"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} Hospital",
+        "{city} Universitetshospital",
+        "{last_name} Klinik"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Kok",
+        "Tjener"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Restaurant {last_name}",
+        "Hotel {city}",
+        "{last_name} Kro"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Advokat"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Advokatfirmaet {last_name}",
+        "{last_name} & {last_name} Advokater"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Journalist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Ejendomsmægler"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Softwareudvikler"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Elektriker",
+        "Tømrer",
+        "Mekaniker",
+        "Frisør"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} VVS",
+        "{last_name} El-service",
+        "{city} Håndværkerservice"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/EE/company.json
+++ b/pointblank/countries/data/EE/company.json
@@ -260,5 +260,234 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Eesti Energia",
+        "Tallink Grupp",
+        "Skype",
+        "SEB Pank",
+        "LHV Pank",
+        "Telia Eesti",
+        "Elisa Eesti",
+        "Tele2 Eesti",
+        "Maxima Eesti",
+        "Selver",
+        "Coop Eesti",
+        "Viru Keemia Grupp",
+        "Enefit"
+      ],
+      "company_suffixes": [
+        "AS",
+        "OÜ",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Production Manager",
+        "Quality Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Swedbank Eesti",
+        "Luminor Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Specialist"
+      ],
+      "well_known": [
+        "Estonian Air"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist",
+        "IT Administrator"
+      ],
+      "well_known": [
+        "Bolt",
+        "Wise",
+        "Playtech",
+        "Pipedrive"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/ES/company.json
+++ b/pointblank/countries/data/ES/company.json
@@ -641,5 +641,432 @@
     "diseñamos",
     "gestionamos"
   ],
-  "catch_phrase_connector": "que"
+  "catch_phrase_connector": "que",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.08,
+      "jobs": [
+        "Analista",
+        "Consultor",
+        "Jefe de proyecto",
+        "Analista",
+        "Consultora",
+        "Jefa de proyecto"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Administrador",
+        "Agente comercial",
+        "Comercial",
+        "Coordinador",
+        "Director",
+        "Gerente",
+        "Policía",
+        "Secretario",
+        "Administradora",
+        "Coordinadora",
+        "Directora",
+        "Gerente",
+        "Secretaria"
+      ],
+      "well_known": [
+        "Telefónica",
+        "Banco Santander",
+        "BBVA",
+        "Inditex",
+        "Mapfre",
+        "Ferrovial",
+        "ACS",
+        "Acciona",
+        "Aena",
+        "Sacyr",
+        "FCC",
+        "OHL",
+        "Abertis",
+        "Cellnex",
+        "Mercadona",
+        "El Corte Inglés",
+        "Dia",
+        "Carrefour España",
+        "Eroski",
+        "Prosegur",
+        "Técnicas Reunidas",
+        "Acerinox",
+        "ArcelorMittal España",
+        "Navantia",
+        "Airbus España",
+        "Correos",
+        "Viscofan",
+        "Osborne",
+        "González Byass"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "S.L.",
+        "Grupo",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Científico",
+        "Investigador",
+        "Maestro",
+        "Profesor",
+        "Científica",
+        "Investigadora",
+        "Maestra",
+        "Profesora"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Universidad de {city}",
+        "Universidad {last_name}",
+        "Instituto {last_name}",
+        "Colegio {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Arquitecto",
+        "Ingeniero",
+        "Técnico",
+        "Arquitecta",
+        "Ingeniera",
+        "Técnica"
+      ],
+      "well_known": [
+        "Iberdrola",
+        "Repsol",
+        "Endesa",
+        "Naturgy",
+        "Red Eléctrica",
+        "Siemens Gamesa",
+        "Seat",
+        "Cepsa"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Asesor fiscal",
+        "Auditor",
+        "Cajero",
+        "Contable",
+        "Economista",
+        "Asesora fiscal",
+        "Auditora",
+        "Contable",
+        "Economista"
+      ],
+      "well_known": [
+        "CaixaBank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.08,
+      "jobs": [
+        "Enfermero",
+        "Farmacéutico",
+        "Médico",
+        "Psicólogo",
+        "Veterinario",
+        "Enfermera",
+        "Farmacéutica",
+        "Médica",
+        "Psicóloga",
+        "Veterinaria"
+      ],
+      "well_known": [
+        "Grifols",
+        "Almirall",
+        "PharmaMar"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "Hospital de {city}",
+        "Clínica {last_name}",
+        "Centro Médico {city}",
+        "Hospital General de {city}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Chef",
+        "Recepcionista",
+        "Recepcionista"
+      ],
+      "well_known": [
+        "Meliá Hotels",
+        "NH Hotel Group",
+        "Ebro Foods",
+        "Pescanova",
+        "Campofrío",
+        "Mahou San Miguel",
+        "Estrella Damm"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Restaurante {last_name}",
+        "Hotel {city}",
+        "Hostal {last_name}",
+        "Parador de {city}"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Abogado",
+        "Abogada"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Bufete {last_name}",
+        "{last_name} & {last_name} Abogados",
+        "Despacho {last_name}"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.04,
+      "jobs": [
+        "Conductor",
+        "Piloto"
+      ],
+      "well_known": [
+        "Iberia",
+        "Vueling",
+        "Renfe"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.08,
+      "jobs": [
+        "Diseñador",
+        "Editor",
+        "Locutor",
+        "Periodista",
+        "Publicista",
+        "Traductor",
+        "Diseñadora",
+        "Editora",
+        "Periodista",
+        "Publicista",
+        "Traductora"
+      ],
+      "well_known": [
+        "Puig",
+        "Mango",
+        "Desigual",
+        "RTVE",
+        "Mediaset España",
+        "Atresmedia",
+        "Prisa",
+        "Vocento",
+        "Henneo",
+        "La Vanguardia",
+        "Grupo Planeta",
+        "Random House Mondadori"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Desarrollador",
+        "Programador",
+        "Desarrolladora",
+        "Programadora"
+      ],
+      "well_known": [
+        "Amadeus IT",
+        "Indra"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Electricista",
+        "Fontanero",
+        "Jardinero",
+        "Mecánico",
+        "Pintor",
+        "Soldador"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Instalaciones",
+        "{last_name} Construcciones",
+        "Servicios {city}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/FI/company.json
+++ b/pointblank/countries/data/FI/company.json
@@ -259,5 +259,321 @@
     "varmistaa",
     "edistää"
   ],
-  "catch_phrase_connector": "jotka"
+  "catch_phrase_connector": "jotka",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Konsultti",
+        "Projektipäällikkö"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Myyjä",
+        "Toimitusjohtaja",
+        "Poliisi",
+        "Palomies"
+      ],
+      "well_known": [
+        "Nokia",
+        "Kone",
+        "Neste",
+        "UPM-Kymmene",
+        "Stora Enso",
+        "Fortum",
+        "Wärtsilä",
+        "Elisa",
+        "Nordea",
+        "Sampo",
+        "OP Ryhmä",
+        "Kesko",
+        "S-ryhmä",
+        "Finnair",
+        "Metso",
+        "Valmet",
+        "Outokumpu",
+        "Kemira",
+        "Fazer"
+      ],
+      "company_suffixes": [
+        "Oy",
+        "Oyj",
+        "Konserni",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Opettaja"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{city} Yliopisto",
+        "{city} Ammattikorkeakoulu",
+        "{city} Lukio"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Insinööri",
+        "Arkkitehti"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Kirjanpitäjä"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Sairaanhoitaja",
+        "Lääkäri",
+        "Hammaslääkäri",
+        "Fysioterapeutti"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} Sairaala",
+        "{city} Yliopistollinen Sairaala",
+        "{last_name} Klinikka"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Kokki",
+        "Tarjoilija"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Ravintola {last_name}",
+        "Hotelli {city}",
+        "{last_name} Majatalo"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Asianajaja"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Asianajotoimisto {last_name}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Suunnittelija",
+        "Toimittaja"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Kiinteistönvälittäjä"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Ohjelmistokehittäjä"
+      ],
+      "well_known": [
+        "Supercell"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Sähköasentaja",
+        "Puuseppä",
+        "Mekaanikko",
+        "Kampaaja"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Putki",
+        "{last_name} Sähkö",
+        "{city} Kotipalvelu"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/FR/company.json
+++ b/pointblank/countries/data/FR/company.json
@@ -530,5 +530,402 @@
     "numérise",
     "développe"
   ],
-  "catch_phrase_connector": "qui"
+  "catch_phrase_connector": "qui",
+  "industries": [
+    {
+      "name": "technology",
+      "weight": 0.16,
+      "jobs": [
+        "Ingénieur logiciel",
+        "Chef de produit",
+        "Analyste de données",
+        "Développeur web",
+        "Ingénieur DevOps",
+        "Architecte cloud",
+        "Analyste sécurité",
+        "Data scientist",
+        "Ingénieur qualité",
+        "Administrateur réseau",
+        "Administrateur de base de données",
+        "Administrateur système"
+      ],
+      "well_known": [
+        "Dassault Systèmes",
+        "Capgemini",
+        "Atos",
+        "Sopra Steria",
+        "OVHcloud",
+        "Criteo",
+        "Ubisoft",
+        "Deezer",
+        "BlaBlaCar",
+        "Doctolib",
+        "Google",
+        "Amazon",
+        "Microsoft",
+        "Meta"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systèmes"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systèmes",
+        "Données",
+        "Analytique",
+        "Réseaux",
+        "Sécurité"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.08,
+      "jobs": [
+        "Médecin",
+        "Pharmacien"
+      ],
+      "well_known": [
+        "Sanofi"
+      ],
+      "company_suffixes": [
+        "Santé",
+        "Médical",
+        "Pharmacie"
+      ],
+      "company_nouns": [
+        "Santé",
+        "Médical"
+      ],
+      "company_formats": [
+        "Hôpital de {city}",
+        "Centre Hospitalier de {city}",
+        "Clinique {last_name}",
+        "CHU de {city}",
+        "Centre Médical de {city}"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.1,
+      "jobs": [
+        "Analyste financier",
+        "Comptable",
+        "Conseiller bancaire"
+      ],
+      "well_known": [
+        "BNP Paribas",
+        "Société Générale",
+        "Crédit Agricole",
+        "AXA"
+      ],
+      "company_suffixes": [
+        "Finance",
+        "Capital",
+        "Investissements",
+        "Partenaires",
+        "Groupe"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investissements",
+        "Finance",
+        "Patrimoine"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} et {last_name}",
+        "{adjective} {noun} {suffix}",
+        "Caisse d'Épargne de {city}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Professeur",
+        "Enseignant"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Université de {city}",
+        "Lycée {last_name}",
+        "Collège {last_name}",
+        "École {last_name}",
+        "Institut de {city}"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Avocat"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Cabinet {last_name} & {last_name}",
+        "{last_name} Avocats",
+        "Cabinet {last_name}"
+      ]
+    },
+    {
+      "name": "consulting",
+      "weight": 0.08,
+      "jobs": [
+        "Consultant",
+        "Analyste métier",
+        "Chef de projet"
+      ],
+      "well_known": [
+        "McKinsey & Company",
+        "Boston Consulting Group",
+        "Bain & Company",
+        "Deloitte",
+        "PwC",
+        "EY",
+        "KPMG",
+        "Accenture"
+      ],
+      "company_suffixes": [
+        "Conseil",
+        "Groupe",
+        "Partenaires",
+        "Consulting"
+      ],
+      "company_nouns": [
+        "Conseil",
+        "Management",
+        "Stratégie"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} et {last_name}"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.06,
+      "jobs": [
+        "Responsable marketing",
+        "Graphiste",
+        "Designer UX",
+        "Rédacteur technique"
+      ],
+      "well_known": [
+        "Publicis",
+        "Vivendi"
+      ],
+      "company_suffixes": [
+        "Médias",
+        "Créatif",
+        "Studios",
+        "Communication",
+        "Groupe"
+      ],
+      "company_nouns": [
+        "Médias",
+        "Créatif",
+        "Communication",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} et {last_name}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Cuisinier",
+        "Directeur d'hôtel"
+      ],
+      "well_known": [
+        "Danone",
+        "Pernod Ricard"
+      ],
+      "company_suffixes": [
+        "Hôtellerie",
+        "Groupe",
+        "Hôtels",
+        "Restauration"
+      ],
+      "company_nouns": [
+        "Hôtellerie",
+        "Hôtels",
+        "Restauration",
+        "Traiteur"
+      ],
+      "company_formats": [
+        "Restaurant {last_name}",
+        "Hôtel {city}",
+        "{adjective} Traiteur {suffix}"
+      ]
+    },
+    {
+      "name": "real_estate",
+      "weight": 0.04,
+      "jobs": [
+        "Agent immobilier"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Immobilier",
+        "Propriétés",
+        "Groupe"
+      ],
+      "company_nouns": [
+        "Immobilier",
+        "Propriétés"
+      ],
+      "company_formats": [
+        "{last_name} Immobilier",
+        "{city} Immobilier",
+        "Agence {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.1,
+      "jobs": [
+        "Ingénieur mécanique",
+        "Ingénieur électrique",
+        "Ingénieur civil",
+        "Architecte"
+      ],
+      "well_known": [
+        "Renault",
+        "Peugeot",
+        "Citroën",
+        "Michelin",
+        "Airbus",
+        "Safran",
+        "Thales",
+        "Schneider Electric",
+        "Vinci",
+        "Saint-Gobain",
+        "Bouygues"
+      ],
+      "company_suffixes": [
+        "Ingénierie",
+        "Industries",
+        "Production",
+        "SA"
+      ],
+      "company_nouns": [
+        "Ingénierie",
+        "Production",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} et {last_name}",
+        "Bureau d'Études {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.08,
+      "jobs": [
+        "Responsable des opérations",
+        "Assistant administratif",
+        "Responsable RH",
+        "Commercial",
+        "Conseiller clientèle",
+        "Directeur général"
+      ],
+      "well_known": [
+        "LVMH",
+        "L'Oréal",
+        "Carrefour",
+        "Hermès",
+        "Kering",
+        "TotalEnergies"
+      ],
+      "company_suffixes": [
+        "SA",
+        "SAS",
+        "SARL",
+        "Groupe",
+        "Entreprises"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} et {last_name}"
+      ]
+    },
+    {
+      "name": "social_services",
+      "weight": 0.02,
+      "jobs": [
+        "Travailleur social"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Services Sociaux de {city}",
+        "Centre Communautaire de {city}",
+        "Association Familiale de {city}"
+      ]
+    },
+    {
+      "name": "energy_telecom",
+      "weight": 0.03,
+      "jobs": [
+        "Administrateur réseau"
+      ],
+      "well_known": [
+        "Orange",
+        "Air France",
+        "SNCF",
+        "La Poste",
+        "Engie",
+        "EDF",
+        "Veolia"
+      ],
+      "company_suffixes": [
+        "Énergie",
+        "Télécom",
+        "Communications",
+        "Réseaux"
+      ],
+      "company_nouns": [
+        "Énergie",
+        "Télécom",
+        "Communications",
+        "Réseaux"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/GB/company.json
+++ b/pointblank/countries/data/GB/company.json
@@ -777,5 +777,462 @@
     "modernise",
     "digitise"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "technology",
+      "weight": 0.18,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "Web Developer",
+        "DevOps Engineer",
+        "Cloud Architect",
+        "Security Analyst",
+        "Data Scientist",
+        "Machine Learning Engineer",
+        "QA Engineer",
+        "Network Administrator",
+        "Database Administrator",
+        "Systems Administrator"
+      ],
+      "well_known": [
+        "ARM Holdings",
+        "Sage Group",
+        "Sophos",
+        "Darktrace",
+        "Wise",
+        "Revolut",
+        "Monzo",
+        "Deliveroo",
+        "ASOS",
+        "Ocado",
+        "Rightmove",
+        "Autotrader"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks",
+        "Security",
+        "Solutions"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.1,
+      "jobs": [
+        "Nurse",
+        "Doctor",
+        "Pharmacist",
+        "Counsellor",
+        "Psychologist"
+      ],
+      "well_known": [
+        "GlaxoSmithKline",
+        "AstraZeneca"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Centre",
+        "{city} Royal Infirmary",
+        "{city} Community Health",
+        "Royal {city} Hospital",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.12,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant",
+        "Bank Clerk",
+        "Mortgage Adviser",
+        "Financial Adviser",
+        "Investment Analyst"
+      ],
+      "well_known": [
+        "HSBC",
+        "Barclays",
+        "Lloyds Banking Group",
+        "NatWest Group",
+        "Standard Chartered",
+        "Schroders",
+        "Legal & General",
+        "Aviva",
+        "Prudential"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Building Society",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Teacher",
+        "Lecturer",
+        "Librarian",
+        "Research Scientist"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} Metropolitan University",
+        "{city} College",
+        "{city} Academy",
+        "{city} School",
+        "{last_name} University"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Solicitor",
+        "Barrister",
+        "Paralegal"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Solicitors",
+        "{last_name}, {last_name} & Partners",
+        "{last_name} Law",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "consulting",
+      "weight": 0.08,
+      "jobs": [
+        "Consultant",
+        "Business Analyst",
+        "Project Manager"
+      ],
+      "well_known": [
+        "PwC UK",
+        "Deloitte UK",
+        "EY UK",
+        "KPMG UK",
+        "Accenture UK",
+        "Capgemini UK"
+      ],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.08,
+      "jobs": [
+        "Marketing Manager",
+        "Graphic Designer",
+        "UX Designer",
+        "UI Designer",
+        "Content Writer",
+        "Technical Writer"
+      ],
+      "well_known": [
+        "BBC",
+        "ITV",
+        "Channel 4",
+        "WPP",
+        "Pearson",
+        "RELX",
+        "Sky",
+        "Burberry"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.06,
+      "jobs": [
+        "Chef",
+        "Restaurant Manager",
+        "Hotel Manager",
+        "Events Coordinator"
+      ],
+      "well_known": [
+        "Compass Group",
+        "InterContinental Hotels",
+        "Whitbread"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel",
+        "{adjective} Catering {suffix}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.04,
+      "jobs": [
+        "Estate Agent",
+        "Insurance Broker"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Properties",
+        "Insurance",
+        "Group",
+        "Estates"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Estates",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Estates",
+        "{city} Property Services",
+        "{last_name} Insurance",
+        "{adjective} {noun} {suffix}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.08,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Civil Engineer",
+        "Chemical Engineer",
+        "Environmental Engineer",
+        "Architect",
+        "Interior Designer",
+        "Construction Manager"
+      ],
+      "well_known": [
+        "Rolls-Royce",
+        "BAE Systems",
+        "Jaguar Land Rover",
+        "Bentley Motors",
+        "McLaren",
+        "Aston Martin",
+        "Dyson"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Ltd"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.07,
+      "jobs": [
+        "Operations Manager",
+        "Administrator",
+        "Executive Assistant",
+        "HR Manager",
+        "Sales Executive",
+        "Customer Service Adviser"
+      ],
+      "well_known": [
+        "Tesco",
+        "Sainsbury's",
+        "Marks & Spencer",
+        "JD Sports",
+        "Next",
+        "John Lewis Partnership",
+        "Boots",
+        "WH Smith",
+        "Unilever"
+      ],
+      "company_suffixes": [
+        "Ltd",
+        "PLC",
+        "Group",
+        "Enterprises"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.03,
+      "jobs": [
+        "Plumber",
+        "Electrician",
+        "Carpenter"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Ltd"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Plumbing",
+        "{last_name} Electrical",
+        "{last_name} Construction",
+        "{city} Plumbing & Heating",
+        "{last_name} Building Services"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.03,
+      "jobs": [
+        "Supply Chain Manager",
+        "Logistics Coordinator",
+        "Warehouse Manager",
+        "Buyer",
+        "Procurement Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Freight"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "social_services",
+      "weight": 0.02,
+      "jobs": [
+        "Social Worker"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{city} Community Services",
+        "{city} Family Services",
+        "{city} Council Social Services",
+        "{city} Youth and Family Centre"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/GR/company.json
+++ b/pointblank/countries/data/GR/company.json
@@ -291,5 +291,296 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "OTE (COSMOTE)",
+        "Mytilineos",
+        "OPAP",
+        "Jumbo",
+        "Sklavenitis",
+        "AB Vassilopoulos",
+        "Plaisio",
+        "Fourlis Holdings",
+        "GEK TERNA",
+        "Coca-Cola HBC",
+        "FAGE"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "A.E.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Teacher"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Civil Engineer",
+        "Architect"
+      ],
+      "well_known": [
+        "DEI (Public Power Corporation)",
+        "Hellenic Petroleum",
+        "Motor Oil Hellas",
+        "Titan Cement"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Piraeus Bank",
+        "National Bank of Greece",
+        "Alpha Bank",
+        "Eurobank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Pharmacist",
+        "Doctor"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.06,
+      "jobs": [
+        "Tourism Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.05,
+      "jobs": [
+        "Shipping Manager"
+      ],
+      "well_known": [
+        "AEGEAN Airlines"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.21,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/HK/company.json
+++ b/pointblank/countries/data/HK/company.json
@@ -361,5 +361,284 @@
     "connect",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.11,
+      "jobs": [
+        "Project Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.14,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Account Manager",
+        "Business Development Manager"
+      ],
+      "well_known": [
+        "HSBC",
+        "Standard Chartered",
+        "CK Hutchison",
+        "Sun Hung Kai Properties",
+        "New World Development",
+        "Henderson Land",
+        "Swire Properties",
+        "MTR Corporation",
+        "AIA Group",
+        "Link REIT",
+        "CLP Holdings",
+        "Jardine Matheson",
+        "Wharf Holdings",
+        "Lenovo",
+        "Li & Fung",
+        "Dairy Farm",
+        "Mandarin Oriental",
+        "Shangri-La Hotels"
+      ],
+      "company_suffixes": [
+        "Ltd",
+        "Holdings",
+        "Group",
+        "International",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.14,
+      "jobs": [
+        "Architect",
+        "Quantity Surveyor"
+      ],
+      "well_known": [
+        "HK Electric"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.14,
+      "jobs": [
+        "Financial Analyst",
+        "Investment Banker",
+        "Fund Manager",
+        "Risk Analyst",
+        "Compliance Officer",
+        "Auditor",
+        "Trade Finance Specialist"
+      ],
+      "well_known": [
+        "Hang Seng Bank",
+        "Bank of China Hong Kong",
+        "Hong Kong Exchanges"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.05,
+      "jobs": [
+        "Legal Counsel",
+        "Paralegal"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.05,
+      "jobs": [
+        "Logistics Coordinator"
+      ],
+      "well_known": [
+        "Cathay Pacific"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.11,
+      "jobs": [
+        "Marketing Manager",
+        "Interior Designer"
+      ],
+      "well_known": [
+        "Galaxy Entertainment"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.03,
+      "jobs": [
+        "Property Agent"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.24,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "QA Engineer",
+        "DevOps Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "Techtronic Industries"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/HR/company.json
+++ b/pointblank/countries/data/HR/company.json
@@ -252,5 +252,258 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.11,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.14,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "INA",
+        "HEP",
+        "Hrvatski Telekom",
+        "Podravka",
+        "Pliva",
+        "Agrokor",
+        "Konzum",
+        "Atlantic Grupa",
+        "Rimac Automobili",
+        "Končar",
+        "Đuro Đaković",
+        "Jadrolinija",
+        "Uljanik",
+        "Nanobit",
+        "Photon"
+      ],
+      "company_suffixes": [
+        "d.d.",
+        "d.o.o.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.14,
+      "jobs": [
+        "Marine Engineer"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.14,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Privredna banka Zagreb",
+        "Zagrebačka banka"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.07,
+      "jobs": [
+        "Tourism Manager",
+        "Hospitality Manager",
+        "Winemaker",
+        "Chef"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.05,
+      "jobs": [
+        "Logistics Coordinator",
+        "Ship Captain"
+      ],
+      "well_known": [
+        "Hrvatska pošta",
+        "Croatia Airlines"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.11,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.25,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "Infobip"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/HU/company.json
+++ b/pointblank/countries/data/HU/company.json
@@ -283,5 +283,234 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "MOL Group",
+        "Magyar Telekom",
+        "Richter Gedeon",
+        "MVM Group",
+        "EGIS Pharmaceuticals",
+        "Zwack Unicum",
+        "Pick Szeged",
+        "Tesco Hungary"
+      ],
+      "company_suffixes": [
+        "Zrt.",
+        "Kft.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Chemical Engineer",
+        "Production Manager",
+        "Quality Manager"
+      ],
+      "well_known": [
+        "BorsodChem",
+        "Dunaferr",
+        "Suzuki Hungary",
+        "Audi Hungary",
+        "Mercedes-Benz Hungary",
+        "Samsung SDI Hungary",
+        "Bosch Hungary"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "OTP Bank",
+        "CIB Bank",
+        "K&H Bank",
+        "Erste Bank Hungary"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Specialist"
+      ],
+      "well_known": [
+        "Wizz Air"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/ID/company.json
+++ b/pointblank/countries/data/ID/company.json
@@ -312,5 +312,234 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Executive",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service"
+      ],
+      "well_known": [
+        "Telkom Indonesia",
+        "Pertamina",
+        "Astra International",
+        "Indofood",
+        "Unilever Indonesia",
+        "Grab Indonesia",
+        "Semen Indonesia",
+        "PLN (Perusahaan Listrik Negara)",
+        "XL Axiata",
+        "Indosat Ooredoo"
+      ],
+      "company_suffixes": [
+        "PT",
+        "Tbk",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Mechanical Engineer",
+        "Civil Engineer",
+        "Electrical Engineer",
+        "Production Supervisor",
+        "Quality Control"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Bank Central Asia (BCA)",
+        "Bank Rakyat Indonesia (BRI)",
+        "Bank Mandiri"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Manager"
+      ],
+      "well_known": [
+        "Garuda Indonesia",
+        "Lion Air"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "Gojek",
+        "Tokopedia",
+        "Shopee Indonesia",
+        "Bukalapak",
+        "Traveloka"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/IE/company.json
+++ b/pointblank/countries/data/IE/company.json
@@ -771,5 +771,381 @@
     "serve",
     "care"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [
+        "Accenture Ireland",
+        "PwC Ireland",
+        "KPMG Ireland",
+        "Deloitte Ireland"
+      ],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sales Executive",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative",
+        "Account Manager",
+        "Garda",
+        "Civil Servant"
+      ],
+      "well_known": [
+        "Ryanair",
+        "CRH",
+        "Smurfit Kappa",
+        "Kerry Group",
+        "AIB",
+        "DCC",
+        "Kingspan",
+        "Glanbia",
+        "Musgrave",
+        "Dunnes Stores",
+        "Penneys",
+        "SuperValu",
+        "Tesco Ireland",
+        "Lidl Ireland",
+        "Aldi Ireland",
+        "ESB",
+        "Energia",
+        "Irish Ferries",
+        "Stena Line Ireland",
+        "Bus Éireann",
+        "Irish Rail",
+        "Dublin Bus",
+        "Aer Lingus",
+        "DAA",
+        "Irish Life",
+        "Zurich Ireland",
+        "Aviva Ireland",
+        "EY Ireland",
+        "Grant Thornton Ireland",
+        "Arthur Cox",
+        "A&L Goodbody",
+        "McCann FitzGerald",
+        "William Fry",
+        "Matheson",
+        "Diageo Ireland",
+        "Heineken Ireland",
+        "Britvic Ireland",
+        "Baileys",
+        "Jameson",
+        "Kerrygold",
+        "Lakeland Dairies",
+        "Kepak",
+        "Greencore",
+        "Allergan",
+        "Pfizer Ireland",
+        "MSD Ireland",
+        "Johnson & Johnson Ireland",
+        "Boston Scientific Ireland",
+        "Medtronic Ireland",
+        "Stryker Ireland",
+        "Abbott Ireland",
+        "Intel Ireland",
+        "Apple Ireland",
+        "Google Ireland",
+        "Meta Ireland",
+        "Amazon Ireland",
+        "LinkedIn Ireland",
+        "Twitter Ireland",
+        "Salesforce Ireland",
+        "Stripe Ireland",
+        "Workday Ireland",
+        "SAP Ireland",
+        "Oracle Ireland",
+        "IBM Ireland",
+        "Dell Ireland",
+        "HP Ireland"
+      ],
+      "company_suffixes": [
+        "Ltd",
+        "plc",
+        "Group",
+        "Holdings",
+        "Partners"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Teacher",
+        "Lecturer",
+        "Researcher"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Engineer",
+        "Architect",
+        "Quantity Surveyor",
+        "Farm Manager",
+        "Agricultural Advisor"
+      ],
+      "well_known": [
+        "Bord Gáis Energy",
+        "Coillte"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Bank of Ireland",
+        "FBD Insurance"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Nurse",
+        "Doctor",
+        "Pharmacist",
+        "Veterinarian",
+        "Physiotherapist"
+      ],
+      "well_known": [
+        "ICON Clinical Research",
+        "Jazz Pharmaceuticals"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.06,
+      "jobs": [
+        "Chef",
+        "Hotel Manager",
+        "Publican"
+      ],
+      "well_known": [
+        "Dairygold",
+        "Dawn Meats",
+        "ABP Food Group"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.05,
+      "jobs": [
+        "Solicitor",
+        "Barrister"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [
+        "Flutter Entertainment"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "social_services",
+      "weight": 0.01,
+      "jobs": [
+        "Social Worker"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{city} Community Services",
+        "{city} Family Services",
+        "{city} Social Services Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.2,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "IT Support Specialist",
+        "Quality Assurance Engineer",
+        "UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer"
+      ],
+      "well_known": [
+        "Microsoft Ireland"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/IN/company.json
+++ b/pointblank/countries/data/IN/company.json
@@ -255,5 +255,306 @@
     "ensure",
     "promote"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Business Analyst"
+      ],
+      "well_known": [
+        "Tata Consultancy Services"
+      ],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sales Executive",
+        "Manager",
+        "Director",
+        "Government Officer",
+        "Police Officer"
+      ],
+      "well_known": [
+        "Infosys",
+        "Hindustan Unilever",
+        "Bharti Airtel",
+        "ITC Limited",
+        "Wipro",
+        "Larsen & Toubro",
+        "Asian Paints",
+        "Maruti Suzuki",
+        "Bajaj Finance",
+        "Titan Company"
+      ],
+      "company_suffixes": [
+        "Ltd",
+        "Pvt Ltd",
+        "Group",
+        "Industries",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Teacher",
+        "Professor"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Architect",
+        "Civil Engineer"
+      ],
+      "well_known": [
+        "Reliance Industries"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Accountant",
+        "Bank Officer",
+        "CA"
+      ],
+      "well_known": [
+        "HDFC Bank",
+        "ICICI Bank",
+        "State Bank of India",
+        "Axis Bank",
+        "Kotak Mahindra Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Doctor",
+        "Dentist",
+        "Pharmacist"
+      ],
+      "well_known": [
+        "Sun Pharma"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Chef"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Lawyer"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Journalist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.2,
+      "jobs": [
+        "Software Engineer",
+        "IT Consultant",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "HCL Technologies",
+        "Tech Mahindra"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Electrician",
+        "Mechanic"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Plumbing",
+        "{last_name} Electric",
+        "{city} Home Services"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/IS/company.json
+++ b/pointblank/countries/data/IS/company.json
@@ -276,5 +276,299 @@
     "transform",
     "enable"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Project Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager"
+      ],
+      "well_known": [
+        "Vodafone Iceland",
+        "Siminn",
+        "Origo",
+        "Icelandic Group",
+        "Fjarðaál",
+        "Norðurál",
+        "Olís"
+      ],
+      "company_suffixes": [
+        "hf.",
+        "ehf.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Marine Biologist",
+        "Environmental Scientist",
+        "Teacher",
+        "Researcher"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Geothermal Engineer",
+        "Renewable Energy Engineer",
+        "Aluminum Production Worker"
+      ],
+      "well_known": [
+        "Landsvirkjun",
+        "Marel",
+        "Össur"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Financial Analyst"
+      ],
+      "well_known": [
+        "Arion Bank",
+        "Íslandsbanki",
+        "Landsbankinn"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Healthcare Professional"
+      ],
+      "well_known": [
+        "Actavis"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.06,
+      "jobs": [
+        "Tourism Guide",
+        "Chef",
+        "Hotel Manager",
+        "Tour Operator"
+      ],
+      "well_known": [
+        "Blue Lagoon"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.05,
+      "jobs": [
+        "Fisheries Manager",
+        "Ship Captain",
+        "Pilot"
+      ],
+      "well_known": [
+        "Icelandair",
+        "Eimskip",
+        "Samherji",
+        "Brim"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.21,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer"
+      ],
+      "well_known": [
+        "CCP Games"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/IT/company.json
+++ b/pointblank/countries/data/IT/company.json
@@ -769,5 +769,420 @@
     "potenzia",
     "realizza"
   ],
-  "catch_phrase_connector": "che"
+  "catch_phrase_connector": "che",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.08,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst",
+        "Consulente",
+        "Analista",
+        "Libero Professionista"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Amministratore Delegato",
+        "Direttore Generale",
+        "Direttore Commerciale",
+        "Direttore Risorse Umane",
+        "Direttore Operativo",
+        "Responsabile Vendite",
+        "Account Manager",
+        "Commerciante",
+        "Imprenditore"
+      ],
+      "well_known": [
+        "Eni",
+        "Enel",
+        "Intesa Sanpaolo",
+        "Generali",
+        "Ferrari",
+        "Stellantis",
+        "Fiat",
+        "Alfa Romeo",
+        "Lamborghini",
+        "Maserati",
+        "Ducati",
+        "Piaggio",
+        "Vespa",
+        "TIM",
+        "Vodafone Italia",
+        "Poste Italiane",
+        "Trenitalia",
+        "Italo",
+        "Alitalia",
+        "Leonardo",
+        "Finmeccanica",
+        "Pirelli",
+        "Brembo",
+        "Luxottica",
+        "Ray-Ban",
+        "Dolce & Gabbana",
+        "Valentino",
+        "Fendi",
+        "Bulgari",
+        "Salvatore Ferragamo",
+        "Tod's",
+        "Benetton",
+        "Diesel",
+        "Intimissimi",
+        "Calzedonia",
+        "Nutella",
+        "De Cecco",
+        "Parmalat",
+        "Banca Mediolanum",
+        "Mediobanca",
+        "Unipol",
+        "Cattolica Assicurazioni",
+        "Saipem",
+        "Snam",
+        "Terna",
+        "A2A",
+        "Hera",
+        "Italgas",
+        "Autostrade per l'Italia",
+        "Atlantia",
+        "Salini Impregilo",
+        "Maire Tecnimont",
+        "Prysmian",
+        "Reply",
+        "Brunello Cucinelli",
+        "Loro Piana"
+      ],
+      "company_suffixes": [
+        "S.p.A.",
+        "S.r.l.",
+        "Gruppo",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Professore",
+        "Ricercatore",
+        "Insegnante"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Università di {city}",
+        "Politecnico di {city}",
+        "Liceo {last_name}",
+        "Istituto {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Direttore Tecnico",
+        "Responsabile Produzione",
+        "Responsabile Qualità",
+        "Ingegnere",
+        "Architetto"
+      ],
+      "well_known": [
+        "Wind Tre",
+        "Webuild",
+        "Engineering"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Direttore Finanziario",
+        "Commercialista"
+      ],
+      "well_known": [
+        "UniCredit",
+        "FinecoBank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.08,
+      "jobs": [
+        "Medico",
+        "Farmacista",
+        "Infermiere",
+        "Veterinario"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "Ospedale di {city}",
+        "Clinica {last_name}",
+        "{city} Centro Medico",
+        "Policlinico di {city}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Chef",
+        "Cuoco",
+        "Pasticcere",
+        "Sommelier"
+      ],
+      "well_known": [
+        "Barilla",
+        "Ferrero",
+        "Lavazza",
+        "Illy",
+        "Campari",
+        "Cinzano",
+        "Martini",
+        "Aperol"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Ristorante {last_name}",
+        "Trattoria {last_name}",
+        "Hotel {city}",
+        "Albergo {last_name}"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Avvocato",
+        "Notaio"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Studio Legale {last_name}",
+        "Studio {last_name} & {last_name}",
+        "{last_name} Avvocati"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.04,
+      "jobs": [
+        "Responsabile Acquisti"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.08,
+      "jobs": [
+        "Direttore Marketing",
+        "Giornalista",
+        "Redattore",
+        "Editor",
+        "Copywriter",
+        "Designer",
+        "Art Director",
+        "Grafico"
+      ],
+      "well_known": [
+        "Prada",
+        "Gucci",
+        "Armani",
+        "Versace",
+        "Mediaset",
+        "RAI",
+        "Sky Italia",
+        "Mondadori",
+        "RCS MediaGroup",
+        "GEDI Gruppo Editoriale",
+        "Moncler"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Programmatore",
+        "Sviluppatore",
+        "Sistemista",
+        "Web Designer"
+      ],
+      "well_known": [
+        "STMicroelectronics",
+        "Datalogic",
+        "Technogym"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Meccanico",
+        "Elettricista",
+        "Idraulico",
+        "Falegname",
+        "Artigiano"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Impianti",
+        "{last_name} Costruzioni",
+        "{city} Servizi"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/JP/company.json
+++ b/pointblank/countries/data/JP/company.json
@@ -591,5 +591,305 @@
     "develop",
     "inspire"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "technology",
+      "weight": 0.18,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Scientist",
+        "System Administrator",
+        "Network Engineer",
+        "Security Specialist",
+        "Technical Writer"
+      ],
+      "well_known": [
+        "Sony",
+        "Panasonic",
+        "Hitachi",
+        "Toshiba",
+        "Fujitsu",
+        "NEC",
+        "Canon",
+        "Nikon",
+        "SoftBank",
+        "Rakuten",
+        "LINE",
+        "Mercari",
+        "CyberAgent",
+        "Google Japan",
+        "Amazon Japan",
+        "Microsoft Japan",
+        "Apple Japan",
+        "Meta Japan"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.08,
+      "jobs": [
+        "Pharmacist",
+        "Medical Doctor",
+        "Nurse"
+      ],
+      "well_known": [
+        "Takeda Pharmaceutical",
+        "Astellas Pharma"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Pharma"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Pharma"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} University Hospital",
+        "{last_name} Clinic"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.1,
+      "jobs": [
+        "Finance Manager",
+        "Accountant",
+        "Tax Specialist"
+      ],
+      "well_known": [
+        "Mitsubishi UFJ Financial",
+        "Sumitomo Mitsui Banking",
+        "Mizuho Financial",
+        "Nomura Holdings",
+        "Daiwa Securities",
+        "Nippon Life",
+        "Tokio Marine"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Securities",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Securities",
+        "Financial",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Credit Bank"
+      ]
+    },
+    {
+      "name": "consulting",
+      "weight": 0.08,
+      "jobs": [
+        "Consultant",
+        "Business Analyst",
+        "Project Manager",
+        "Account Executive"
+      ],
+      "well_known": [
+        "McKinsey & Company",
+        "Boston Consulting Group",
+        "Bain & Company",
+        "Deloitte Tohmatsu",
+        "PwC Japan",
+        "EY Japan",
+        "KPMG Japan",
+        "Accenture Japan"
+      ],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.06,
+      "jobs": [
+        "Marketing Manager",
+        "Design Engineer",
+        "Customer Support"
+      ],
+      "well_known": [
+        "Nintendo",
+        "Bandai Namco",
+        "Capcom",
+        "Square Enix",
+        "Sega",
+        "Dentsu",
+        "Recruit Holdings",
+        "Shiseido",
+        "Kao"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.1,
+      "jobs": [
+        "Manufacturing Engineer",
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Civil Engineer",
+        "Architect",
+        "Field Engineer",
+        "Quality Assurance"
+      ],
+      "well_known": [
+        "Toyota",
+        "Honda",
+        "Nissan"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.12,
+      "jobs": [
+        "Sales Manager",
+        "Operations Manager",
+        "HR Manager",
+        "Legal Counsel",
+        "Research Scientist",
+        "Executive Director",
+        "Department Head",
+        "Team Leader",
+        "General Manager",
+        "Vice President",
+        "Managing Director",
+        "Chief Executive Officer",
+        "Board Member"
+      ],
+      "well_known": [
+        "Mitsubishi Corporation",
+        "Mitsui & Co.",
+        "Sumitomo Corporation",
+        "Itochu",
+        "Marubeni",
+        "Fast Retailing",
+        "Seven & i Holdings",
+        "Aeon",
+        "ANA Holdings",
+        "Japan Airlines",
+        "JR East",
+        "JR West",
+        "NTT",
+        "KDDI"
+      ],
+      "company_suffixes": [
+        "Corp",
+        "Group",
+        "Holdings",
+        "Inc"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.04,
+      "jobs": [
+        "Supply Chain Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/KR/company.json
+++ b/pointblank/countries/data/KR/company.json
@@ -325,5 +325,221 @@
     "pioneer",
     "shape"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Management Consultant",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.16,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager"
+      ],
+      "well_known": [
+        "SK Hynix",
+        "POSCO",
+        "Samsung SDI",
+        "LG Chem",
+        "Samsung Display",
+        "Korean Air",
+        "Asiana Airlines",
+        "Lotte Corporation",
+        "CJ Corporation",
+        "Hanwha Group",
+        "Doosan Group"
+      ],
+      "company_suffixes": [
+        "Corp",
+        "Group",
+        "Holdings",
+        "Inc",
+        "Co"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.16,
+      "jobs": [
+        "Semiconductor Engineer",
+        "Display Engineer",
+        "Battery Engineer",
+        "Automotive Engineer",
+        "Chemical Engineer"
+      ],
+      "well_known": [
+        "Hyundai Motor",
+        "Kia Motors",
+        "Hyundai Mobis"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.16,
+      "jobs": [
+        "Financial Analyst",
+        "Investment Banker",
+        "Fund Manager",
+        "Accountant"
+      ],
+      "well_known": [
+        "KB Financial Group",
+        "Shinhan Financial Group",
+        "Hana Financial Group"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager",
+        "Content Creator",
+        "K-pop Manager",
+        "Esports Manager",
+        "Entertainment Producer"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.28,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Scientist",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "Mobile Developer",
+        "AI Engineer",
+        "Game Developer"
+      ],
+      "well_known": [
+        "Samsung Electronics",
+        "LG Electronics",
+        "Naver",
+        "Kakao",
+        "Coupang",
+        "Krafton",
+        "NC Soft",
+        "Netmarble"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/LT/company.json
+++ b/pointblank/countries/data/LT/company.json
@@ -263,5 +263,235 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Maxima LT",
+        "Vilkyskiu pieniné",
+        "Telia Lietuva",
+        "Tele2 Lietuva",
+        "Bite Lietuva",
+        "Lidl Lietuva",
+        "Rimi Lietuva",
+        "Iki",
+        "Pigu",
+        "Varle",
+        "Baltic Clipper"
+      ],
+      "company_suffixes": [
+        "AB",
+        "UAB",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Production Manager",
+        "Quality Manager"
+      ],
+      "well_known": [
+        "Ignitis Group",
+        "Orlen Lietuva",
+        "Achema Group"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "SEB Bankas",
+        "Swedbank",
+        "Luminor Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Specialist"
+      ],
+      "well_known": [
+        "Girteka Logistics",
+        "Lietuvos gelezinkeliai"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist",
+        "IT Administrator"
+      ],
+      "well_known": [
+        "Vinted"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/LU/company.json
+++ b/pointblank/countries/data/LU/company.json
@@ -250,5 +250,201 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.14,
+      "jobs": [
+        "Project Manager",
+        "EU Affairs Specialist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.17,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager"
+      ],
+      "well_known": [
+        "ArcelorMittal",
+        "Tenaris",
+        "SES",
+        "Luxair",
+        "Cargolux",
+        "Banque de Luxembourg",
+        "BGL BNP Paribas",
+        "Spuerkeess",
+        "POST Luxembourg",
+        "Lombard International",
+        "Amazon Europe",
+        "PayPal Europe",
+        "Ferrero International",
+        "Goodyear Luxembourg",
+        "Guardian Europe",
+        "Millicom"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "S.à r.l.",
+        "Group",
+        "Holdings",
+        "International"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.17,
+      "jobs": [
+        "Financial Analyst",
+        "Fund Administrator",
+        "Compliance Officer",
+        "Risk Manager",
+        "Asset Manager",
+        "Private Banker",
+        "Accountant",
+        "Tax Consultant",
+        "Auditor",
+        "Investment Analyst",
+        "Portfolio Manager",
+        "Wealth Advisor",
+        "Treasury Manager"
+      ],
+      "well_known": [
+        "Clearstream"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.07,
+      "jobs": [
+        "Legal Counsel"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.14,
+      "jobs": [
+        "Marketing Manager",
+        "Translator"
+      ],
+      "well_known": [
+        "RTL Group"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.31,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer"
+      ],
+      "well_known": [
+        "Delphi Technologies",
+        "Skype Communications"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/LV/company.json
+++ b/pointblank/countries/data/LV/company.json
@@ -259,5 +259,235 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Latvijas Pasts",
+        "Maxima Latvija",
+        "Rimi Latvia",
+        "Latvijas Mobilais Telefons",
+        "Tele2 Latvia",
+        "Bite Latvia",
+        "Aldaris",
+        "Grindeks",
+        "Olainfarm",
+        "Laima",
+        "Latvijas Finieris"
+      ],
+      "company_suffixes": [
+        "AS",
+        "SIA",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Production Manager",
+        "Quality Manager"
+      ],
+      "well_known": [
+        "Latvenergo",
+        "Latvijas Gaze"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Swedbank Latvia",
+        "SEB banka",
+        "Citadele banka"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Specialist"
+      ],
+      "well_known": [
+        "Latvijas Dzelzceļš",
+        "airBaltic",
+        "Riga International Airport"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist",
+        "IT Administrator"
+      ],
+      "well_known": [
+        "Printful"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/MT/company.json
+++ b/pointblank/countries/data/MT/company.json
@@ -249,5 +249,250 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "HSBC Malta",
+        "GO plc",
+        "Melita Limited",
+        "Enemalta",
+        "Water Services Corporation",
+        "Playmobil Malta",
+        "MCAST",
+        "University of Malta",
+        "FinanceMalta",
+        "Tumas Group",
+        "db Group",
+        "AX Holdings"
+      ],
+      "company_suffixes": [
+        "Ltd",
+        "plc",
+        "Holdings",
+        "Group",
+        "International"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Compliance Officer",
+        "Risk Manager",
+        "Accountant",
+        "Auditor",
+        "Tax Consultant",
+        "Investment Analyst"
+      ],
+      "well_known": [
+        "Bank of Valletta",
+        "GasanMamo Insurance"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.07,
+      "jobs": [
+        "Casino Manager",
+        "Tourism Manager",
+        "Hotel Manager"
+      ],
+      "well_known": [
+        "Simonds Farsons Cisk"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.06,
+      "jobs": [
+        "Legal Counsel"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Maritime Officer",
+        "Pilot",
+        "Ship Captain"
+      ],
+      "well_known": [
+        "Air Malta",
+        "Malta International Airport"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.27,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "iGaming Developer"
+      ],
+      "well_known": [
+        "ST Microelectronics",
+        "Malta Gaming Authority",
+        "RS2 Software"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/MX/company.json
+++ b/pointblank/countries/data/MX/company.json
@@ -256,5 +256,302 @@
     "asegura",
     "promueve"
   ],
-  "catch_phrase_connector": "que"
+  "catch_phrase_connector": "que",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Analista"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Administrador",
+        "Vendedor",
+        "Director",
+        "Gerente",
+        "Policía",
+        "Bombero"
+      ],
+      "well_known": [
+        "América Móvil",
+        "FEMSA",
+        "Walmart de México",
+        "Cemex",
+        "Grupo Televisa",
+        "Grupo México",
+        "Banorte",
+        "BBVA México",
+        "Grupo Elektra",
+        "Liverpool",
+        "Peñoles",
+        "Grupo Carso",
+        "Alfa",
+        "Arca Continental",
+        "Grupo Aeroportuario del Pacífico",
+        "Nemak",
+        "Gruma"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "S.L.",
+        "Grupo",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Maestro"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Universidad de {city}",
+        "Universidad {last_name}",
+        "Instituto {last_name}",
+        "Colegio {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Ingeniero",
+        "Arquitecto"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Contador"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Médico",
+        "Enfermero",
+        "Dentista",
+        "Veterinario",
+        "Psicólogo"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "Hospital de {city}",
+        "Clínica {last_name}",
+        "Centro Médico {city}",
+        "Hospital General de {city}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Chef",
+        "Mesero"
+      ],
+      "well_known": [
+        "Grupo Bimbo",
+        "Grupo Modelo",
+        "Grupo Lala"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Restaurante {last_name}",
+        "Hotel {city}",
+        "Hostal {last_name}",
+        "Parador de {city}"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Abogado"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Bufete {last_name}",
+        "{last_name} & {last_name} Abogados",
+        "Despacho {last_name}"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Diseñador",
+        "Periodista"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.2,
+      "jobs": [
+        "Programador"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Electricista",
+        "Mecánico",
+        "Taxista"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Instalaciones",
+        "{last_name} Construcciones",
+        "Servicios {city}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/NG/company.json
+++ b/pointblank/countries/data/NG/company.json
@@ -299,5 +299,248 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.11,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.13,
+      "jobs": [
+        "Sales Executive",
+        "HR Manager",
+        "Operations Manager"
+      ],
+      "well_known": [
+        "MTN Nigeria",
+        "Nigerian Breweries",
+        "Nestlé Nigeria",
+        "Airtel Nigeria",
+        "Globacom",
+        "Oando Plc",
+        "Cadbury Nigeria",
+        "Flour Mills of Nigeria"
+      ],
+      "company_suffixes": [
+        "Plc",
+        "Ltd",
+        "Group",
+        "Holdings",
+        "Industries"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.13,
+      "jobs": [
+        "Petroleum Engineer",
+        "Geologist",
+        "Civil Engineer",
+        "Architect"
+      ],
+      "well_known": [
+        "Dangote Industries",
+        "Nigerian National Petroleum Corporation",
+        "Seplat Energy",
+        "BUA Group"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.13,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant",
+        "Banker"
+      ],
+      "well_known": [
+        "Zenith Bank",
+        "Access Bank",
+        "Guaranty Trust Bank",
+        "First Bank of Nigeria",
+        "United Bank for Africa",
+        "Sterling Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.11,
+      "jobs": [
+        "Pharmacist",
+        "Doctor"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.05,
+      "jobs": [
+        "Lawyer"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.11,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.24,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "Interswitch",
+        "Flutterwave"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/NL/company.json
+++ b/pointblank/countries/data/NL/company.json
@@ -676,5 +676,402 @@
     "ondersteunen",
     "versterken"
   ],
-  "catch_phrase_connector": "die"
+  "catch_phrase_connector": "die",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Projectmanager",
+        "Business Analyst",
+        "Consultant"
+      ],
+      "well_known": [
+        "KPMG Nederland",
+        "Deloitte Nederland",
+        "PwC Nederland"
+      ],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Verkoper",
+        "HR-manager",
+        "Operations Manager",
+        "Accountmanager",
+        "Administratief medewerker",
+        "Directeur"
+      ],
+      "well_known": [
+        "Shell",
+        "Unilever",
+        "Philips",
+        "ING Group",
+        "ABN AMRO",
+        "Heineken",
+        "Ahold Delhaize",
+        "KLM",
+        "Randstad",
+        "EY Nederland",
+        "DSM",
+        "Akzo Nobel",
+        "TNT",
+        "PostNL",
+        "NS",
+        "ProRail",
+        "Schiphol Group",
+        "Aegon",
+        "NN Group",
+        "ASR Nederland",
+        "Wolters Kluwer",
+        "RELX",
+        "VodafoneZiggo",
+        "KPN",
+        "T-Mobile Nederland",
+        "Albert Heijn",
+        "Jumbo Supermarkten",
+        "HEMA",
+        "Wehkamp",
+        "Brunel",
+        "Arcadis",
+        "Fugro",
+        "BAM Groep",
+        "Heijmans",
+        "VolkerWessels",
+        "Boskalis",
+        "Damen Shipyards",
+        "Vopak",
+        "SBM Offshore",
+        "Bunge Loders Croklaan",
+        "Lamb Weston",
+        "Grolsch",
+        "Bavaria",
+        "Blokker",
+        "Action",
+        "Hunkemöller",
+        "Rituals",
+        "G-Star RAW",
+        "Scotch & Soda",
+        "Tommy Hilfiger",
+        "Calvin Klein",
+        "Suitsupply",
+        "Van Lanschot Kempen",
+        "IMC Trading",
+        "Optiver",
+        "Flow Traders"
+      ],
+      "company_suffixes": [
+        "B.V.",
+        "N.V.",
+        "Groep",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Leraar",
+        "Hoogleraar"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Universiteit {city}",
+        "Hogeschool {city}",
+        "Technische Universiteit {city}",
+        "{city} Lyceum"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Kwaliteitsmanager",
+        "Werktuigbouwkundig ingenieur",
+        "Elektrotechnisch ingenieur",
+        "Civiel ingenieur",
+        "Architect",
+        "Bouwmanager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Financieel analist",
+        "Boekhouder",
+        "Bankmedewerker",
+        "Financieel adviseur"
+      ],
+      "well_known": [
+        "Rabobank",
+        "Bunq",
+        "Triodos Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Arts",
+        "Apotheker"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} Ziekenhuis",
+        "Medisch Centrum {city}",
+        "{last_name} Kliniek",
+        "Universitair Medisch Centrum {city}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.06,
+      "jobs": [
+        "Kok",
+        "Hotelmanager"
+      ],
+      "well_known": [
+        "FrieslandCampina",
+        "Vion Food Group",
+        "Tony's Chocolonely",
+        "Douwe Egberts"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Restaurant {last_name}",
+        "Hotel {city}",
+        "Grand Hotel {city}"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Advocaat"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Advocatenkantoor {last_name}",
+        "{last_name} & {last_name} Advocaten",
+        "{last_name} Juridisch Advies"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Marketingmanager",
+        "Grafisch ontwerper"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Makelaar"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "social_services",
+      "weight": 0.01,
+      "jobs": [
+        "Maatschappelijk werker"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{city} Community Services",
+        "{city} Family Services",
+        "{city} Social Services Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.2,
+      "jobs": [
+        "Softwareontwikkelaar",
+        "Productmanager",
+        "Data-analist",
+        "Webontwikkelaar",
+        "Netwerkbeheerder",
+        "Databasebeheerder",
+        "Systeembeheerder",
+        "Technisch schrijver",
+        "UX-ontwerper",
+        "DevOps-engineer",
+        "Cloud-architect",
+        "Security-analist",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "ASML",
+        "Adyen",
+        "Booking.com",
+        "TomTom",
+        "NXP Semiconductors",
+        "Signify",
+        "Coolblue",
+        "Bol.com",
+        "Exact",
+        "AFAS Software",
+        "Unit4",
+        "Elastic",
+        "Miro",
+        "Mollie"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/NO/company.json
+++ b/pointblank/countries/data/NO/company.json
@@ -263,5 +263,276 @@
     "fremmer",
     "skaper"
   ],
-  "catch_phrase_connector": "som"
+  "catch_phrase_connector": "som",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Prosjektleder",
+        "Konsulent",
+        "Analytiker",
+        "Prosjektkoordinator"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.12,
+      "jobs": [
+        "Daglig leder",
+        "Selger",
+        "Kundebehandler",
+        "HR-leder"
+      ],
+      "well_known": [
+        "DNB",
+        "Telenor",
+        "Yara International",
+        "Orkla",
+        "Storebrand",
+        "Aker",
+        "Mowi",
+        "Gjensidige",
+        "Veidekke",
+        "Norwegian Air",
+        "Posten Norge",
+        "Tine",
+        "Nortura",
+        "Rema 1000"
+      ],
+      "company_suffixes": [
+        "AS",
+        "ASA",
+        "Gruppen",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Lærer"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Universitetet i {city}",
+        "{city} Videregående Skole",
+        "Høgskolen i {city}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.12,
+      "jobs": [
+        "Ingeniør",
+        "Arkitekt"
+      ],
+      "well_known": [
+        "Equinor",
+        "Norsk Hydro",
+        "Kongsberg Gruppen",
+        "Statkraft"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.12,
+      "jobs": [
+        "Regnskapsfører",
+        "Økonom"
+      ],
+      "well_known": [
+        "SpareBank 1"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Lege",
+        "Sykepleier"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} Sykehus",
+        "{city} Universitetssykehus",
+        "{last_name} Klinikk"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.05,
+      "jobs": [
+        "Advokat"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Advokatfirmaet {last_name}",
+        "{last_name} & {last_name} Advokater"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Markedsfører"
+      ],
+      "well_known": [
+        "Schibsted"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.21,
+      "jobs": [
+        "Utvikler",
+        "IT-sjef"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.05,
+      "jobs": [
+        "Tekniker",
+        "Mekaniker",
+        "Elektriker",
+        "Tømrer",
+        "Rørlegger"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Rør & Varme",
+        "{last_name} Elektro",
+        "{city} Hjemmeservice"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/NZ/company.json
+++ b/pointblank/countries/data/NZ/company.json
@@ -254,5 +254,328 @@
     "ensure",
     "promote"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Consultant",
+        "Project Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sales Representative",
+        "Director",
+        "Police Officer",
+        "Firefighter"
+      ],
+      "well_known": [
+        "Spark New Zealand",
+        "Air New Zealand",
+        "Mainfreight",
+        "Auckland International Airport",
+        "Countdown"
+      ],
+      "company_suffixes": [
+        "Ltd",
+        "Group",
+        "Holdings",
+        "NZ",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Teacher"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Engineer",
+        "Architect"
+      ],
+      "well_known": [
+        "Fletcher Building",
+        "Meridian Energy",
+        "Mercury NZ",
+        "Contact Energy",
+        "Genesis Energy",
+        "Rocket Lab"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Accountant"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Nurse",
+        "Doctor",
+        "Dentist",
+        "Physiotherapist"
+      ],
+      "well_known": [
+        "Fisher & Paykel Healthcare",
+        "Ryman Healthcare"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Chef",
+        "Waiter"
+      ],
+      "well_known": [
+        "Fonterra",
+        "a2 Milk Company",
+        "Zespri",
+        "Silver Fern Farms"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Lawyer"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Journalist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Real Estate Agent"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Software Developer"
+      ],
+      "well_known": [
+        "Xero",
+        "Pushpay",
+        "Vista Group"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Electrician",
+        "Carpenter",
+        "Mechanic",
+        "Hairdresser"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Plumbing",
+        "{last_name} Electric",
+        "{city} Home Services"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/PH/company.json
+++ b/pointblank/countries/data/PH/company.json
@@ -301,5 +301,273 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.1,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.12,
+      "jobs": [
+        "Sales Executive",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative",
+        "Call Center Agent",
+        "Virtual Assistant"
+      ],
+      "well_known": [
+        "SM Investments Corporation",
+        "Ayala Corporation",
+        "San Miguel Corporation",
+        "JG Summit Holdings",
+        "Jollibee Foods Corporation",
+        "PLDT Inc.",
+        "Globe Telecom",
+        "Meralco",
+        "Aboitiz Equity Ventures",
+        "Metro Pacific Investments",
+        "Megaworld Corporation",
+        "Robinsons Land Corporation"
+      ],
+      "company_suffixes": [
+        "Inc",
+        "Corp",
+        "Holdings",
+        "Group",
+        "International"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Teacher"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.12,
+      "jobs": [
+        "Civil Engineer",
+        "Architect"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.12,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "BDO Unibank",
+        "Bank of the Philippine Islands",
+        "UnionBank of the Philippines",
+        "Security Bank Corporation"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.1,
+      "jobs": [
+        "Nurse"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.05,
+      "jobs": [
+        "Seaman"
+      ],
+      "well_known": [
+        "Philippine Airlines",
+        "Cebu Pacific Air"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.1,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [
+        "GMA Network",
+        "ABS-CBN Corporation"
+      ],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.22,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/PL/company.json
+++ b/pointblank/countries/data/PL/company.json
@@ -259,5 +259,323 @@
     "zapewnia",
     "promuje"
   ],
-  "catch_phrase_connector": "które"
+  "catch_phrase_connector": "które",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Konsultant",
+        "Kierownik projektu"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Sprzedawca",
+        "Dyrektor",
+        "Policjant",
+        "Strażak"
+      ],
+      "well_known": [
+        "PZU",
+        "LPP",
+        "Dino Polska",
+        "Żabka",
+        "CCC",
+        "Cyfrowy Polsat",
+        "Orange Polska",
+        "Play",
+        "Biedronka",
+        "Budimex"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "Sp. z o.o.",
+        "Grupa",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Nauczyciel"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Uniwersytet w {city}",
+        "Politechnika {city}",
+        "Liceum {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Inżynier",
+        "Architekt"
+      ],
+      "well_known": [
+        "PKN Orlen",
+        "KGHM",
+        "PGE",
+        "Lotos"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Księgowy"
+      ],
+      "well_known": [
+        "PKO Bank Polski",
+        "mBank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Pielęgniarka",
+        "Lekarz",
+        "Dentysta",
+        "Fizjoterapeuta"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "Szpital w {city}",
+        "Klinika {last_name}",
+        "Centrum Medyczne {city}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Kucharz",
+        "Kelner"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Restauracja {last_name}",
+        "Hotel {city}",
+        "Zajazd {last_name}"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Prawnik"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Kancelaria {last_name}",
+        "{last_name} & {last_name} Adwokaci"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Projektant",
+        "Dziennikarz"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Pośrednik nieruchomości"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Programista"
+      ],
+      "well_known": [
+        "CD Projekt",
+        "Allegro",
+        "Comarch",
+        "Asseco"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Elektryk",
+        "Stolarz",
+        "Mechanik",
+        "Fryzjer"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Instalacje",
+        "{last_name} Elektro",
+        "{city} Usługi Domowe"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/PT/company.json
+++ b/pointblank/countries/data/PT/company.json
@@ -258,5 +258,325 @@
     "garante",
     "promove"
   ],
-  "catch_phrase_connector": "que"
+  "catch_phrase_connector": "que",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Consultor",
+        "Gestor de Projeto"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Vendedor",
+        "Diretor",
+        "Polícia",
+        "Bombeiro"
+      ],
+      "well_known": [
+        "Jerónimo Martins",
+        "Sonae",
+        "NOS",
+        "BCP",
+        "TAP Air Portugal",
+        "Mota-Engil",
+        "Corticeira Amorim",
+        "Navigator Company",
+        "CTT",
+        "Brisa",
+        "Altice Portugal",
+        "Continente",
+        "Pingo Doce",
+        "Worten"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "Lda.",
+        "Grupo",
+        "Holding"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Professor"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Universidade de {city}",
+        "Universidade {last_name}",
+        "Instituto {last_name}",
+        "Colégio {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Engenheiro",
+        "Arquiteto"
+      ],
+      "well_known": [
+        "EDP",
+        "Galp",
+        "REN"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Contabilista"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Enfermeiro",
+        "Médico",
+        "Dentista",
+        "Fisioterapeuta"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "Hospital de {city}",
+        "Clínica {last_name}",
+        "Centro Médico {city}",
+        "Hospital Geral de {city}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Cozinheiro",
+        "Empregado de Mesa"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Restaurante {last_name}",
+        "Hotel {city}",
+        "Pousada {last_name}"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Advogado"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Escritório {last_name}",
+        "{last_name} & {last_name} Advogados",
+        "{last_name} Advocacia"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Jornalista"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Agente Imobiliário"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Programador"
+      ],
+      "well_known": [
+        "Farfetch",
+        "Outsystems",
+        "Talkdesk"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Eletricista",
+        "Carpinteiro",
+        "Mecânico",
+        "Cabeleireiro"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Instalações",
+        "{last_name} Construções",
+        "Serviços {city}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/RO/company.json
+++ b/pointblank/countries/data/RO/company.json
@@ -289,5 +289,233 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Banca Transilvania",
+        "BRD - Groupe Société Générale",
+        "Orange Romania",
+        "Vodafone Romania",
+        "Telekom Romania",
+        "Kaufland Romania",
+        "Lidl Romania",
+        "Carrefour Romania",
+        "Dedeman"
+      ],
+      "company_suffixes": [
+        "S.A.",
+        "S.R.L.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Civil Engineer",
+        "Production Manager",
+        "Quality Manager"
+      ],
+      "well_known": [
+        "Petrom",
+        "Dacia",
+        "Electrica",
+        "Romgaz",
+        "Transgaz",
+        "OMV Petrom",
+        "Continental Automotive Romania",
+        "Bosch Romania"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator",
+        "Procurement Specialist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "eMAG",
+        "Bitdefender",
+        "UiPath"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/RU/company.json
+++ b/pointblank/countries/data/RU/company.json
@@ -254,5 +254,235 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "MTS",
+        "Megafon"
+      ],
+      "company_suffixes": [
+        "OAO",
+        "ZAO",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Production Manager",
+        "Oil Engineer",
+        "Mining Engineer",
+        "Nuclear Engineer"
+      ],
+      "well_known": [
+        "Gazprom",
+        "Lukoil",
+        "Rosneft",
+        "Russian Railways",
+        "Rosatom",
+        "Rostec",
+        "Norilsk Nickel",
+        "Surgutneftegaz",
+        "Tatneft",
+        "Severstal",
+        "NLMK",
+        "Magnitogorsk Iron and Steel Works"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Sberbank",
+        "VTB Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator"
+      ],
+      "well_known": [
+        "Aeroflot"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist",
+        "IT Administrator",
+        "Cybersecurity Analyst"
+      ],
+      "well_known": [
+        "Yandex",
+        "Mail.ru Group",
+        "Kaspersky Lab"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/SE/company.json
+++ b/pointblank/countries/data/SE/company.json
@@ -266,5 +266,323 @@
     "säkerställer",
     "främjar"
   ],
-  "catch_phrase_connector": "som"
+  "catch_phrase_connector": "som",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Konsult",
+        "Projektledare"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Säljare",
+        "VD",
+        "Polis",
+        "Brandman"
+      ],
+      "well_known": [
+        "IKEA",
+        "H&M",
+        "Nordea",
+        "SEB",
+        "Electrolux",
+        "Telia",
+        "Securitas"
+      ],
+      "company_suffixes": [
+        "AB",
+        "Gruppen",
+        "Holding",
+        "Koncernen"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Lärare"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{city} Universitet",
+        "Högskolan i {city}",
+        "{city} Gymnasium"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Ingenjör",
+        "Arkitekt"
+      ],
+      "well_known": [
+        "Volvo",
+        "Atlas Copco",
+        "Scania",
+        "SKF",
+        "Sandvik",
+        "Vattenfall",
+        "Saab",
+        "Husqvarna"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Revisor"
+      ],
+      "well_known": [
+        "Handelsbanken",
+        "Swedbank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Sjuksköterska",
+        "Läkare",
+        "Tandläkare",
+        "Fysioterapeut"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} Sjukhus",
+        "{city} Universitetssjukhus",
+        "{last_name} Klinik"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Kock",
+        "Servitör"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "Restaurang {last_name}",
+        "Hotell {city}",
+        "{last_name} Värdshus"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Advokat"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "Advokatbyrån {last_name}",
+        "{last_name} & {last_name} Advokater"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Designer",
+        "Journalist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Fastighetsmäklare"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Mjukvaruutvecklare"
+      ],
+      "well_known": [
+        "Ericsson",
+        "Spotify",
+        "Klarna"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Elektriker",
+        "Snickare",
+        "Mekaniker",
+        "Frisör"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Rör",
+        "{last_name} El",
+        "{city} Hemservice"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/SG/company.json
+++ b/pointblank/countries/data/SG/company.json
@@ -297,5 +297,236 @@
     "drive",
     "build"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Operations Manager",
+        "Business Development Manager",
+        "Human Resources Manager"
+      ],
+      "well_known": [
+        "DBS Group Holdings",
+        "Singtel",
+        "Keppel Corporation",
+        "Wilmar International",
+        "PSA International",
+        "SembCorp Industries",
+        "Olam International",
+        "ComfortDelGro"
+      ],
+      "company_suffixes": [
+        "Pte Ltd",
+        "Ltd",
+        "Holdings",
+        "Group",
+        "International"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Marine Engineer"
+      ],
+      "well_known": [
+        "ST Engineering"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant",
+        "Risk Analyst",
+        "Compliance Officer",
+        "Investment Banker",
+        "Trade Finance Specialist",
+        "Wealth Manager",
+        "Portfolio Manager",
+        "Quantitative Analyst"
+      ],
+      "well_known": [
+        "OCBC Bank",
+        "United Overseas Bank",
+        "CapitaLand",
+        "Singapore Exchange",
+        "Mapletree Investments"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Supply Chain Manager",
+        "Logistics Coordinator",
+        "Shipping Manager"
+      ],
+      "well_known": [
+        "Singapore Airlines",
+        "Ninjavan"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Data Scientist",
+        "UX Designer",
+        "Systems Administrator",
+        "Full Stack Developer",
+        "DevOps Engineer",
+        "Product Manager"
+      ],
+      "well_known": [
+        "Grab Holdings",
+        "Sea Limited",
+        "Razer Inc",
+        "Lazada Group"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/SI/company.json
+++ b/pointblank/countries/data/SI/company.json
@@ -250,5 +250,283 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.1,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.12,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Mercator",
+        "NLB",
+        "Telekom Slovenije",
+        "Gorenje",
+        "Luka Koper",
+        "BTC",
+        "Intereuropa",
+        "Pivovarna Laško Union",
+        "Alpina",
+        "Akrapovič"
+      ],
+      "company_suffixes": [
+        "d.d.",
+        "d.o.o.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.12,
+      "jobs": [
+        "Production Manager",
+        "Quality Manager",
+        "Mechanical Engineer"
+      ],
+      "well_known": [
+        "Petrol",
+        "GEN-I",
+        "SIJ - Slovenska industrija jekla",
+        "Revoz",
+        "Cinkarna Celje"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.12,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Zavarovalnica Triglav"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.1,
+      "jobs": [
+        "Pharmacist"
+      ],
+      "well_known": [
+        "Krka",
+        "Lek"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.06,
+      "jobs": [
+        "Tourism Manager"
+      ],
+      "well_known": [
+        "Terme Čatež"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.05,
+      "jobs": [
+        "Logistics Coordinator"
+      ],
+      "well_known": [
+        "Pošta Slovenije"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.1,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.22,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist",
+        "IT Administrator"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/SK/company.json
+++ b/pointblank/countries/data/SK/company.json
@@ -249,5 +249,235 @@
     "innovate",
     "lead"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.12,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.15,
+      "jobs": [
+        "Sales Representative",
+        "HR Manager",
+        "Operations Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Slovenské elektrárne",
+        "Slovak Telekom",
+        "Orange Slovensko",
+        "Matador",
+        "SPP",
+        "Tatry Mountain Resorts",
+        "Grafobal Group",
+        "Kaufland Slovensko",
+        "Lidl Slovensko"
+      ],
+      "company_suffixes": [
+        "a.s.",
+        "s.r.o.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.15,
+      "jobs": [
+        "Production Manager",
+        "Automotive Engineer",
+        "Quality Manager",
+        "Mechanical Engineer",
+        "Electrical Engineer"
+      ],
+      "well_known": [
+        "Volkswagen Slovakia",
+        "Kia Slovakia",
+        "Stellantis Slovakia",
+        "U.S. Steel Košice",
+        "Slovnaft",
+        "Samsung Electronics Slovakia"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.15,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Tatra banka",
+        "Slovenská sporiteľňa",
+        "Allianz Slovenská poisťovňa"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Logistics Coordinator"
+      ],
+      "well_known": [
+        "Železnice Slovenskej republiky"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.12,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.26,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist",
+        "IT Administrator"
+      ],
+      "well_known": [
+        "ESET"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/TH/company.json
+++ b/pointblank/countries/data/TH/company.json
@@ -285,5 +285,274 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.1,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.12,
+      "jobs": [
+        "Sales Executive",
+        "HR Manager",
+        "Operations Manager"
+      ],
+      "well_known": [
+        "CP All Public Company Limited",
+        "AIS (Advanced Info Service)",
+        "Central Group",
+        "True Corporation",
+        "Thai Airways International",
+        "Indorama Ventures",
+        "Land and Houses"
+      ],
+      "company_suffixes": [
+        "PCL",
+        "Co. Ltd.",
+        "Group",
+        "Holdings"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Teacher"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.12,
+      "jobs": [
+        "Civil Engineer",
+        "Architect"
+      ],
+      "well_known": [
+        "PTT Public Company Limited",
+        "Siam Cement Group",
+        "Gulf Energy Development",
+        "Banpu Public Company Limited"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.12,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Bangkok Bank",
+        "Kasikornbank",
+        "SCB (Siam Commercial Bank)",
+        "Krungthai Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.1,
+      "jobs": [
+        "Nurse",
+        "Pharmacist"
+      ],
+      "well_known": [
+        "Bangkok Dusit Medical"
+      ],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.06,
+      "jobs": [
+        "Hotel Manager",
+        "Tour Guide",
+        "Chef"
+      ],
+      "well_known": [
+        "Thai Beverage",
+        "Charoen Pokphand Foods",
+        "Minor International"
+      ],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.1,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.22,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "Delta Electronics Thailand"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/TR/company.json
+++ b/pointblank/countries/data/TR/company.json
@@ -258,5 +258,322 @@
     "garanti eder",
     "destekler"
   ],
-  "catch_phrase_connector": "ile"
+  "catch_phrase_connector": "ile",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.09,
+      "jobs": [
+        "Danışman",
+        "Proje Yöneticisi"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.11,
+      "jobs": [
+        "Satıcı",
+        "Müdür",
+        "Polis",
+        "İtfaiyeci"
+      ],
+      "well_known": [
+        "Koç Holding",
+        "Sabancı Holding",
+        "Türk Telekom",
+        "Turkish Airlines",
+        "Arçelik",
+        "Vestel",
+        "Ülker",
+        "Eczacıbaşı",
+        "Turkcell",
+        "Garanti BBVA",
+        "Yapı Kredi",
+        "Migros",
+        "BİM",
+        "LC Waikiki",
+        "TAV",
+        "Pegasus"
+      ],
+      "company_suffixes": [
+        "A.Ş.",
+        "Ltd. Şti.",
+        "Holding",
+        "Grup"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.06,
+      "jobs": [
+        "Öğretmen"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{city} Üniversitesi",
+        "{last_name} Lisesi",
+        "{city} Meslek Yüksekokulu"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.11,
+      "jobs": [
+        "Mühendis",
+        "Mimar"
+      ],
+      "well_known": [
+        "Ford Otosan",
+        "Tofaş"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.11,
+      "jobs": [
+        "Muhasebeci"
+      ],
+      "well_known": [
+        "İş Bankası",
+        "Akbank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.09,
+      "jobs": [
+        "Hemşire",
+        "Doktor",
+        "Diş Hekimi",
+        "Fizyoterapist"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} Hastanesi",
+        "{last_name} Kliniği",
+        "{city} Tıp Merkezi"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.05,
+      "jobs": [
+        "Aşçı",
+        "Garson"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Hospitality",
+        "Group",
+        "Hotels",
+        "Restaurants"
+      ],
+      "company_nouns": [
+        "Hospitality",
+        "Hotels",
+        "Restaurants",
+        "Catering"
+      ],
+      "company_formats": [
+        "{last_name} Restoran",
+        "Otel {city}",
+        "{last_name} Lokantası"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Avukat"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Hukuk Bürosu",
+        "{last_name} & {last_name} Avukatlar"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.09,
+      "jobs": [
+        "Tasarımcı",
+        "Gazeteci"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.02,
+      "jobs": [
+        "Emlakçı"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Realty",
+        "Properties",
+        "Insurance",
+        "Group"
+      ],
+      "company_nouns": [
+        "Properties",
+        "Realty",
+        "Insurance"
+      ],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.19,
+      "jobs": [
+        "Yazılımcı"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Elektrikçi",
+        "Marangoz",
+        "Tamirci",
+        "Kuaför"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Services",
+        "Co"
+      ],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Tesisat",
+        "{last_name} Elektrik",
+        "{city} Ev Hizmetleri"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/TW/company.json
+++ b/pointblank/countries/data/TW/company.json
@@ -326,5 +326,260 @@
     "develop",
     "design"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.11,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.14,
+      "jobs": [
+        "Sales Manager",
+        "Operations Manager",
+        "HR Manager",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Hon Hai Precision",
+        "Pegatron",
+        "Wistron",
+        "Inventec",
+        "Largan Precision",
+        "Uni-President Enterprises",
+        "Evergreen Marine"
+      ],
+      "company_suffixes": [
+        "Corp",
+        "Inc",
+        "Holdings",
+        "Group",
+        "International"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.14,
+      "jobs": [
+        "Process Engineer",
+        "Quality Engineer",
+        "Manufacturing Engineer"
+      ],
+      "well_known": [
+        "Formosa Plastics",
+        "Giant Manufacturing"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.14,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Cathay Financial Holdings",
+        "Fubon Financial Holdings",
+        "CTBC Financial Holding"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.06,
+      "jobs": [
+        "Legal Counsel"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.06,
+      "jobs": [
+        "Supply Chain Manager",
+        "Procurement Specialist"
+      ],
+      "well_known": [
+        "EVA Air",
+        "China Airlines"
+      ],
+      "company_suffixes": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_nouns": [
+        "Logistics",
+        "Transport",
+        "Distribution",
+        "Supply"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.11,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.25,
+      "jobs": [
+        "Software Engineer",
+        "Hardware Engineer",
+        "IC Design Engineer",
+        "Product Manager",
+        "Data Scientist",
+        "Machine Learning Engineer",
+        "Frontend Developer",
+        "Backend Developer",
+        "Full Stack Developer",
+        "Test Engineer",
+        "R&D Engineer",
+        "Systems Analyst",
+        "Network Administrator",
+        "UI/UX Designer",
+        "Technical Writer"
+      ],
+      "well_known": [
+        "TSMC",
+        "MediaTek",
+        "Delta Electronics",
+        "ASUS",
+        "Acer",
+        "HTC",
+        "Quanta Computer",
+        "Compal Electronics",
+        "Novatek Microelectronics",
+        "Realtek Semiconductor",
+        "ASE Technology"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/US/company.json
+++ b/pointblank/countries/data/US/company.json
@@ -854,5 +854,390 @@
     "modernize",
     "digitize"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "technology",
+      "weight": 0.18,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "Web Developer",
+        "DevOps Engineer",
+        "Cloud Architect",
+        "Security Analyst",
+        "Data Scientist",
+        "Machine Learning Engineer",
+        "Quality Assurance Engineer",
+        "Network Administrator",
+        "Database Administrator",
+        "System Administrator"
+      ],
+      "well_known": [
+        "Microsoft",
+        "Apple",
+        "Google",
+        "Amazon",
+        "Meta",
+        "Netflix",
+        "Salesforce",
+        "Adobe",
+        "Oracle",
+        "IBM",
+        "Intel",
+        "Cisco",
+        "NVIDIA",
+        "PayPal",
+        "Uber",
+        "Airbnb",
+        "Spotify",
+        "LinkedIn",
+        "Shopify",
+        "Zoom",
+        "Slack",
+        "Stripe",
+        "Dropbox"
+      ],
+      "company_suffixes": ["Technologies", "Software", "Solutions", "Labs", "Digital", "Systems"],
+      "company_nouns": ["Software", "Technologies", "Systems", "Data", "Analytics", "Networks", "Security", "Solutions"],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.10,
+      "jobs": [
+        "Nurse",
+        "Physician",
+        "Pharmacist",
+        "Counselor",
+        "Psychologist"
+      ],
+      "well_known": [
+        "Johnson & Johnson",
+        "Pfizer",
+        "UnitedHealth Group",
+        "CVS Health",
+        "Merck"
+      ],
+      "company_suffixes": ["Health", "Medical", "Healthcare"],
+      "company_nouns": ["Healthcare", "Medical", "Health"],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{city} Community Health",
+        "{state} Health System",
+        "{last_name} Medical Group",
+        "{adjective} Healthcare {suffix}"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.12,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant",
+        "Bank Teller",
+        "Loan Officer",
+        "Financial Advisor",
+        "Investment Analyst"
+      ],
+      "well_known": [
+        "JPMorgan Chase",
+        "Goldman Sachs",
+        "Morgan Stanley",
+        "Bank of America",
+        "Citigroup",
+        "Wells Fargo",
+        "BlackRock",
+        "Fidelity Investments",
+        "Charles Schwab",
+        "American Express"
+      ],
+      "company_suffixes": ["Financial", "Capital", "Investments", "Partners", "Group"],
+      "company_nouns": ["Capital", "Investments", "Financial", "Wealth", "Advisory"],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Federal Credit Union",
+        "{city} Savings Bank",
+        "{state} Community Bank"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.07,
+      "jobs": [
+        "Teacher",
+        "Professor",
+        "Librarian",
+        "Research Scientist"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {state}",
+        "{city} State University",
+        "{city} Community College",
+        "{city} Public Schools",
+        "{city} Academy",
+        "{state} Institute of Technology",
+        "{last_name} University",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "legal",
+      "weight": 0.04,
+      "jobs": [
+        "Attorney",
+        "Paralegal"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} & {last_name} Law",
+        "{last_name}, {last_name} & Associates",
+        "{last_name} Law Group",
+        "{last_name} Legal Services",
+        "{city} Legal Associates"
+      ]
+    },
+    {
+      "name": "consulting",
+      "weight": 0.08,
+      "jobs": [
+        "Consultant",
+        "Business Analyst",
+        "Project Manager"
+      ],
+      "well_known": [
+        "McKinsey & Company",
+        "Boston Consulting Group",
+        "Bain & Company",
+        "Deloitte",
+        "PwC",
+        "EY",
+        "KPMG",
+        "Accenture"
+      ],
+      "company_suffixes": ["Consulting", "Group", "Partners", "Associates", "Advisory"],
+      "company_nouns": ["Consulting", "Management", "Strategy", "Advisory"],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.08,
+      "jobs": [
+        "Marketing Manager",
+        "Graphic Designer",
+        "UX Designer",
+        "UI Designer",
+        "Content Writer",
+        "Technical Writer"
+      ],
+      "well_known": [
+        "Disney",
+        "Warner Bros.",
+        "NBCUniversal"
+      ],
+      "company_suffixes": ["Media", "Creative", "Studios", "Communications", "Group"],
+      "company_nouns": ["Media", "Creative", "Communications", "Marketing", "Design"],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "hospitality",
+      "weight": 0.06,
+      "jobs": [
+        "Chef",
+        "Restaurant Manager",
+        "Hotel Manager",
+        "Event Coordinator"
+      ],
+      "well_known": [
+        "Starbucks",
+        "The Coca-Cola Company",
+        "PepsiCo"
+      ],
+      "company_suffixes": ["Hospitality", "Group", "Hotels", "Restaurants"],
+      "company_nouns": ["Hospitality", "Hotels", "Restaurants", "Catering"],
+      "company_formats": [
+        "The {adjective} {noun}",
+        "{last_name}'s Restaurant",
+        "{city} Grand Hotel",
+        "{adjective} Catering {suffix}",
+        "{city} Convention Center"
+      ]
+    },
+    {
+      "name": "real_estate_insurance",
+      "weight": 0.04,
+      "jobs": [
+        "Real Estate Agent",
+        "Insurance Agent"
+      ],
+      "well_known": [],
+      "company_suffixes": ["Realty", "Properties", "Insurance", "Group"],
+      "company_nouns": ["Properties", "Realty", "Insurance", "Real Estate"],
+      "company_formats": [
+        "{last_name} Realty",
+        "{city} Real Estate",
+        "{last_name} Insurance Agency",
+        "{adjective} {noun} {suffix}",
+        "{state} Insurance Group"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.08,
+      "jobs": [
+        "Mechanical Engineer",
+        "Electrical Engineer",
+        "Civil Engineer",
+        "Chemical Engineer",
+        "Environmental Engineer",
+        "Architect",
+        "Interior Designer",
+        "Construction Manager"
+      ],
+      "well_known": [
+        "Tesla",
+        "Ford",
+        "General Motors",
+        "Boeing",
+        "Lockheed Martin",
+        "SpaceX"
+      ],
+      "company_suffixes": ["Engineering", "Industries", "Manufacturing", "Corp"],
+      "company_nouns": ["Engineering", "Manufacturing", "Construction", "Industries"],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.07,
+      "jobs": [
+        "Operations Manager",
+        "Administrative Assistant",
+        "Executive Assistant",
+        "Human Resources Manager",
+        "Sales Representative",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "Walmart",
+        "Target",
+        "Costco",
+        "Home Depot",
+        "Nike"
+      ],
+      "company_suffixes": ["Inc", "LLC", "Corp", "Group", "Enterprises"],
+      "company_nouns": ["Solutions", "Services", "Management", "Industries"],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "trades",
+      "weight": 0.04,
+      "jobs": [
+        "Plumber",
+        "Electrician",
+        "Carpenter",
+        "HVAC Technician"
+      ],
+      "well_known": [],
+      "company_suffixes": ["Services", "Co", "LLC"],
+      "company_nouns": [],
+      "company_formats": [
+        "{last_name} Plumbing",
+        "{last_name} Electric",
+        "{last_name} Construction",
+        "{city} Plumbing & Heating",
+        "{last_name} HVAC Services",
+        "{city} Home Services"
+      ]
+    },
+    {
+      "name": "logistics",
+      "weight": 0.04,
+      "jobs": [
+        "Supply Chain Manager",
+        "Logistics Coordinator",
+        "Warehouse Manager",
+        "Buyer",
+        "Procurement Specialist"
+      ],
+      "well_known": [
+        "Amazon"
+      ],
+      "company_suffixes": ["Logistics", "Transport", "Distribution", "Supply"],
+      "company_nouns": ["Logistics", "Transport", "Distribution", "Supply"],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}",
+        "{city} Freight Services",
+        "{state} Distribution Center"
+      ]
+    },
+    {
+      "name": "social_services",
+      "weight": 0.02,
+      "jobs": [
+        "Social Worker"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "{city} Community Services",
+        "{city} Family Services",
+        "{state} Department of Social Services",
+        "{city} Youth and Family Center",
+        "{city} Social Services Agency"
+      ]
+    },
+    {
+      "name": "telecom",
+      "weight": 0.02,
+      "jobs": [
+        "Network Administrator",
+        "System Administrator",
+        "Customer Service Representative"
+      ],
+      "well_known": [
+        "AT&T",
+        "Verizon",
+        "T-Mobile"
+      ],
+      "company_suffixes": ["Communications", "Telecom", "Networks"],
+      "company_nouns": ["Communications", "Networks", "Telecom"],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{last_name} {suffix}"
+      ]
+    }
+  ]
 }

--- a/pointblank/countries/data/ZA/company.json
+++ b/pointblank/countries/data/ZA/company.json
@@ -292,5 +292,249 @@
     "optimize",
     "enhance"
   ],
-  "catch_phrase_connector": "that"
+  "catch_phrase_connector": "that",
+  "industries": [
+    {
+      "name": "consulting",
+      "weight": 0.1,
+      "jobs": [
+        "Project Manager",
+        "Business Analyst",
+        "Environmental Consultant"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Consulting",
+        "Group",
+        "Partners",
+        "Associates",
+        "Advisory"
+      ],
+      "company_nouns": [
+        "Consulting",
+        "Management",
+        "Strategy",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "corporate",
+      "weight": 0.13,
+      "jobs": [
+        "Sales Executive",
+        "HR Manager",
+        "Operations Manager"
+      ],
+      "well_known": [
+        "MTN Group",
+        "FirstRand Limited",
+        "Shoprite Holdings",
+        "Vodacom Group",
+        "Woolworths Holdings",
+        "Pick n Pay Stores",
+        "Discovery Limited",
+        "Anglo American Platinum",
+        "Absa Group",
+        "Old Mutual",
+        "Tiger Brands",
+        "Sanlam",
+        "Bidvest Group",
+        "Sappi Limited"
+      ],
+      "company_suffixes": [
+        "(Pty) Ltd",
+        "Ltd",
+        "Holdings",
+        "Group",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Solutions",
+        "Services",
+        "Management",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{last_name} and {last_name}"
+      ]
+    },
+    {
+      "name": "education",
+      "weight": 0.08,
+      "jobs": [
+        "Teacher"
+      ],
+      "well_known": [],
+      "company_suffixes": [],
+      "company_nouns": [],
+      "company_formats": [
+        "University of {city}",
+        "{city} University",
+        "{city} Academy",
+        "{city} School District"
+      ]
+    },
+    {
+      "name": "engineering",
+      "weight": 0.13,
+      "jobs": [
+        "Mining Engineer",
+        "Geologist",
+        "Civil Engineer",
+        "Architect",
+        "Quantity Surveyor"
+      ],
+      "well_known": [
+        "Sasol Limited"
+      ],
+      "company_suffixes": [
+        "Engineering",
+        "Industries",
+        "Manufacturing",
+        "Corp"
+      ],
+      "company_nouns": [
+        "Engineering",
+        "Manufacturing",
+        "Construction",
+        "Industries"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun} {suffix}",
+        "{city} Engineering Group"
+      ]
+    },
+    {
+      "name": "finance",
+      "weight": 0.13,
+      "jobs": [
+        "Financial Analyst",
+        "Accountant"
+      ],
+      "well_known": [
+        "Standard Bank Group",
+        "Nedbank Group",
+        "Investec",
+        "Capitec Bank"
+      ],
+      "company_suffixes": [
+        "Financial",
+        "Capital",
+        "Investments",
+        "Partners",
+        "Group"
+      ],
+      "company_nouns": [
+        "Capital",
+        "Investments",
+        "Financial",
+        "Wealth",
+        "Advisory"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{last_name} & {last_name}",
+        "{adjective} {noun} {suffix}",
+        "{city} Savings Bank"
+      ]
+    },
+    {
+      "name": "healthcare",
+      "weight": 0.1,
+      "jobs": [
+        "Nurse"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Health",
+        "Medical",
+        "Healthcare"
+      ],
+      "company_nouns": [
+        "Healthcare",
+        "Medical",
+        "Health"
+      ],
+      "company_formats": [
+        "{city} General Hospital",
+        "{city} Medical Center",
+        "{city} Regional Health",
+        "{last_name} Medical Group"
+      ]
+    },
+    {
+      "name": "marketing_creative",
+      "weight": 0.1,
+      "jobs": [
+        "Marketing Manager"
+      ],
+      "well_known": [],
+      "company_suffixes": [
+        "Media",
+        "Creative",
+        "Studios",
+        "Communications",
+        "Group"
+      ],
+      "company_nouns": [
+        "Media",
+        "Creative",
+        "Communications",
+        "Marketing",
+        "Design"
+      ],
+      "company_formats": [
+        "{last_name} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} & {last_name}"
+      ]
+    },
+    {
+      "name": "technology",
+      "weight": 0.23,
+      "jobs": [
+        "Software Engineer",
+        "Product Manager",
+        "Data Analyst",
+        "UI/UX Designer",
+        "Frontend Developer",
+        "Backend Developer",
+        "DevOps Engineer",
+        "QA Engineer",
+        "Data Scientist"
+      ],
+      "well_known": [
+        "Naspers"
+      ],
+      "company_suffixes": [
+        "Technologies",
+        "Software",
+        "Solutions",
+        "Labs",
+        "Digital",
+        "Systems"
+      ],
+      "company_nouns": [
+        "Software",
+        "Technologies",
+        "Systems",
+        "Data",
+        "Analytics",
+        "Networks"
+      ],
+      "company_formats": [
+        "{adjective} {noun} {suffix}",
+        "{adjective} {noun}",
+        "{last_name} {noun}"
+      ]
+    }
+  ]
 }

--- a/pointblank/generate/generators.py
+++ b/pointblank/generate/generators.py
@@ -446,12 +446,17 @@ ADDRESS_RELATED_PRESETS = {
     "longitude",
 }
 PERSON_RELATED_PRESETS = {"name", "name_full", "first_name", "last_name", "email", "user_name"}
+BUSINESS_RELATED_PRESETS = {"job", "company"}
 
 
-def _get_coherence_needs(fields: dict[str, Field]) -> tuple[bool, bool]:
+def _get_coherence_needs(fields: dict[str, Field]) -> tuple[bool, bool, bool]:
     """Check what coherence is needed for the given fields."""
     needs_address = False
     needs_person = False
+    needs_business = False
+
+    found_job = False
+    found_company = False
 
     for field in fields.values():
         preset = getattr(field, "preset", None)
@@ -459,8 +464,16 @@ def _get_coherence_needs(fields: dict[str, Field]) -> tuple[bool, bool]:
             needs_address = True
         if preset in PERSON_RELATED_PRESETS:
             needs_person = True
+        if preset == "job":
+            found_job = True
+        if preset == "company":
+            found_company = True
 
-    return needs_address, needs_person
+    # Business coherence only needed when BOTH job and company are present
+    if found_job and found_company:
+        needs_business = True
+
+    return needs_address, needs_person, needs_business
 
 
 def _generate_column_with_row_context(
@@ -509,8 +522,8 @@ def generate_dataframe(
         Generated DataFrame in the format specified by config.output.
     """
     # Check what coherence is needed
-    needs_address, needs_person = _get_coherence_needs(fields)
-    needs_coherence = needs_address or needs_person
+    needs_address, needs_person, needs_business = _get_coherence_needs(fields)
+    needs_coherence = needs_address or needs_person or needs_business
 
     # Set up shared locale generator if any coherence is needed
     shared_locale_gen = None
@@ -520,6 +533,12 @@ def generate_dataframe(
             shared_locale_gen.init_row_locations(config.n)
         if needs_person:
             shared_locale_gen.init_row_persons(config.n)
+        if needs_business:
+            # Business coherence also needs location context for templates like
+            # "{city} General Hospital", so init locations if not already done
+            if not needs_address:
+                shared_locale_gen.init_row_locations(config.n)
+            shared_locale_gen.init_row_employers(config.n)
 
     # Determine which presets need row context
     coherent_presets = set()
@@ -527,6 +546,8 @@ def generate_dataframe(
         coherent_presets.update(ADDRESS_RELATED_PRESETS)
     if needs_person:
         coherent_presets.update(PERSON_RELATED_PRESETS)
+    if needs_business:
+        coherent_presets.update(BUSINESS_RELATED_PRESETS)
 
     # Generate data for each column
     data: dict[str, list[Any]] = {}
@@ -541,10 +562,12 @@ def generate_dataframe(
 
     # Clean up
     if shared_locale_gen is not None:
-        if needs_address:
+        if needs_address or needs_business:
             shared_locale_gen.clear_row_locations()
         if needs_person:
             shared_locale_gen.clear_row_persons()
+        if needs_business:
+            shared_locale_gen.clear_row_employers()
 
     # Convert to requested output format
     if config.output == "dict":


### PR DESCRIPTION
This PR adds detailed industry-specific data to the company information files. For each country, an `industries` array has been introduced, providing structured information about common industries, associated jobs, well-known companies, company name formats, and related metadata. This all allows for more realistic and localized company data generation.


