### PR TITLE
Fix broken links in `quickstart.qmd` by removing incorrect path prefixes

### DIFF
--- a/docs/user-guide/quickstart.qmd
+++ b/docs/user-guide/quickstart.qmd
@@ -178,48 +178,48 @@ sections that will help you navigate the various features.
 The *Getting Started* section introduces you to Pointblank:
 
 - [Introduction](index.qmd): Overview of Pointblank and core concepts (**this article**)
-- [Installation](user-guide/installation.qmd): How to install and set up Pointblank
+- [Installation](installation.qmd): How to install and set up Pointblank
 
 ### Validation Plan
 
 The *Validation Plan* section covers everything you need to know about creating robust
 validation plans:
 
-- [Overview](user-guide/validation-overview.qmd): Survey of validation methods and their shared parameters
-- [Validation Methods](user-guide/validation-methods.qmd): A closer look at the more common validation methods
-- [Column Selection Patterns](user-guide/column-selection-patterns.qmd): Techniques for targeting specific columns
-- [Preprocessing](user-guide/preprocessing.qmd): Transform data before validation
-- [Segmentation](user-guide/segmentation.qmd): Apply validations to specific segments of your data
-- [Thresholds](user-guide/thresholds.qmd): Set quality standards and trigger severity levels
-- [Actions](user-guide/actions.qmd): Respond to threshold exceedances with notifications or custom functions
-- [Briefs](user-guide/briefs.qmd): Add context to validation steps
+- [Overview](validation-overview.qmd): Survey of validation methods and their shared parameters
+- [Validation Methods](validation-methods.qmd): A closer look at the more common validation methods
+- [Column Selection Patterns](column-selection-patterns.qmd): Techniques for targeting specific columns
+- [Preprocessing](preprocessing.qmd): Transform data before validation
+- [Segmentation](segmentation.qmd): Apply validations to specific segments of your data
+- [Thresholds](thresholds.qmd): Set quality standards and trigger severity levels
+- [Actions](actions.qmd): Respond to threshold exceedances with notifications or custom functions
+- [Briefs](briefs.qmd): Add context to validation steps
 
 ### Advanced Validation
 
 The *Advanced Validation* section explores more specialized validation techniques:
 
-- [Expression-Based Validation](user-guide/expressions.qmd): Use column expressions for advanced validation
-- [Schema Validation](user-guide/schema-validation.qmd): Enforce table structure and column types
-- [Assertions](user-guide/assertions.qmd): Raise exceptions to enforce data quality requirements
-- [Draft Validation](user-guide/draft-validation.qmd): Create validation plans from existing data
+- [Expression-Based Validation](expressions.qmd): Use column expressions for advanced validation
+- [Schema Validation](schema-validation.qmd): Enforce table structure and column types
+- [Assertions](assertions.qmd): Raise exceptions to enforce data quality requirements
+- [Draft Validation](draft-validation.qmd): Create validation plans from existing data
 
 ### Post Interrogation
 
 After validating your data, the *Post Interrogation* section helps you analyze and respond to
 results:
 
-- [Validation Reports](user-guide/validation-reports.qmd): Understand and customize the validation report table
-- [Step Reports](user-guide/step-reports.qmd): View detailed results for individual validation steps
-- [Data Extracts](user-guide/extracts.qmd): Extract and analyze failing data
-- [Sundering Validated Data](user-guide/sundering.qmd): Split data based on validation results
+- [Validation Reports](validation-reports.qmd): Understand and customize the validation report table
+- [Step Reports](step-reports.qmd): View detailed results for individual validation steps
+- [Data Extracts](extracts.qmd): Extract and analyze failing data
+- [Sundering Validated Data](sundering.qmd): Split data based on validation results
 
 ### Data Inspection
 
 The *Data Inspection* section provides tools to explore and understand your data:
 
-- [Previewing Data](user-guide/preview.qmd): View samples of your data
-- [Column Summaries](user-guide/col-summary-tbl.qmd): Get statistical summaries of your data
-- [Missing Values Reporting](user-guide/missing-vals-tbl.qmd): Identify and visualize missing data
+- [Previewing Data](preview.qmd): View samples of your data
+- [Column Summaries](col-summary-tbl.qmd): Get statistical summaries of your data
+- [Missing Values Reporting](missing-vals-tbl.qmd): Identify and visualize missing data
 
 By following this guide, you'll gain a comprehensive understanding of how to validate, monitor, and
 maintain high-quality data with Pointblank.


### PR DESCRIPTION
# Summary

Fixes broken internal links in the Quickstart User Guide by removing the unnecessary "user-guide/" prefix from relative file paths. Since quickstart.qmd is already located in the user-guide folder, links to sibling files should use relative paths without the folder prefix.

# Related GitHub Issues and PRs

- Ref: #356 

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [-] I have added **pytest** unit tests for any new functionality.
