### PR TITLE
fix: add country-specific license plate formats

### DIFF
--- a/pointblank/generate/generators.py
+++ b/pointblank/generate/generators.py
@@ -446,6 +446,7 @@ ADDRESS_RELATED_PRESETS = {
     "phone_number",
     "latitude",
     "longitude",
+    "license_plate",
 }
 PERSON_RELATED_PRESETS = {"name", "name_full", "first_name", "last_name", "email", "user_name"}
 BUSINESS_RELATED_PRESETS = {"job", "company"}


### PR DESCRIPTION
This PR enhances the `license_plate` generation logic to produce more realistic, location-aware license plate numbers. The update introduces country- and region-specific plate formats for Canada, the US, UK, Germany, and Australia, using new internal mappings and generation logic. The fallback behavior now also uses a restricted letter set to avoid ambiguous characters.
