### PR TITLE
feat: add pytest `generate_dataset()` fixture

### DIFF
--- a/docs/user-guide/test-data-generation.qmd
+++ b/docs/user-guide/test-data-generation.qmd
@@ -451,9 +451,7 @@ fully-qualified name. This means:
 
 Use it by adding `generate_dataset` to your test function's parameter list:
 
-```python
-# test_pipeline.py
-
+```{.python filename="test_pipeline.py"}
 import pointblank as pb
 
 def test_etl_handles_nulls(generate_dataset):
@@ -516,8 +514,7 @@ def test_name_normalizer(generate_dataset, country):
 
 Define schemas as fixtures in `conftest.py` and compose them with `generate_dataset`:
 
-```python
-# conftest.py
+```{.python filename="conftest.py"}
 import pytest
 import pointblank as pb
 
@@ -529,18 +526,47 @@ def customer_schema():
         email=pb.string_field(preset="email"),
         city=pb.string_field(preset="city"),
     )
+```
 
-# test_validation.py
+```{.python filename="test_validation.py"}
 def test_customer_validation(generate_dataset, customer_schema):
     df = generate_dataset(customer_schema, n=200, country="DE")
     validation = pb.Validate(df).col_vals_not_null(columns="email").interrogate()
     assert validation.all_passed()
+```
 
-# test_export.py
+```{.python filename="test_export.py"}
 def test_customer_export(generate_dataset, customer_schema):
     df = generate_dataset(customer_schema, n=50, country="JP")
     exported = export_to_parquet(df)
     assert exported.exists()
+```
+
+### Debugging with Seed Introspection
+
+The fixture callable exposes two attributes that make debugging failed tests straightforward:
+
+- `generate_dataset.default_seed`: the base seed derived from the test name (available before any call)
+- `generate_dataset.last_seed`: the seed actually used for the most recent call (accounts for the call counter and explicit overrides)
+
+Include `.last_seed` in assertion messages so failures are immediately reproducible:
+
+```python
+def test_age_range(generate_dataset):
+    schema = pb.Schema(age=pb.int_field(min_val=18, max_val=100))
+    df = generate_dataset(schema, n=500)
+    min_age = df["age"].min()
+    assert min_age >= 18, (
+        f"Expected min age >= 18, got {min_age} (seed={generate_dataset.last_seed})"
+    )
+```
+
+You can also use `.default_seed` to reproduce the exact dataset outside of pytest:
+
+```python
+# In a REPL or notebook, reproduce the data from a failed test:
+import pointblank as pb
+df = pb.generate_dataset(schema, n=500, seed=<default_seed_from_output>)
 ```
 
 ### Seed Stability

--- a/docs/user-guide/test-data-generation.qmd
+++ b/docs/user-guide/test-data-generation.qmd
@@ -436,16 +436,16 @@ applying it to production data, or for creating reproducible test fixtures in yo
 ## Pytest Fixture
 
 When Pointblank is installed, a `generate_dataset` **pytest fixture** is automatically available
-in all your test files. There is no need to import anything or add configuration to `conftest.py`
-— the fixture is registered via pytest's plugin system.
+in all your test files. There is no need to import anything or add configuration to `conftest.py`:
+the fixture is registered via pytest's plugin system.
 
 The fixture works identically to `pb.generate_dataset()`, but with one key difference: when you
 don't supply a `seed=` parameter, a deterministic seed is automatically derived from the test's
 fully-qualified name. This means:
 
-- The **same test** always produces the **same data** — no manual seed management required.
-- **Different tests** get different seeds, so they exercise different datasets.
-- You can still pass an explicit `seed=` to override the automatic seed when needed.
+- the **same test** always produces the **same data**: no manual seed management required.
+- *different tests* get different seeds, so they exercise different datasets.
+- you can still pass an explicit `seed=` to override the automatic seed when needed.
 
 ### Basic Usage
 
@@ -468,7 +468,7 @@ def test_etl_handles_nulls(generate_dataset):
     assert result.filter(pl.col("email").is_null()).shape[0] == 0
 ```
 
-All parameters from `generate_dataset()` are supported — `n`, `seed`, `output`, and `country`:
+All parameters from `generate_dataset()` are supported: `n=`, `seed=`, `output=`, and `country=`:
 
 ```python
 def test_german_data(generate_dataset):
@@ -483,8 +483,7 @@ def test_german_data(generate_dataset):
 
 ### Multiple Datasets in One Test
 
-Calling the fixture multiple times within the same test produces different (but still
-deterministic) data on each call:
+Calling the fixture multiple times within the same test produces different (but still deterministic) data on each call:
 
 ```python
 def test_merge_pipeline(generate_dataset):

--- a/docs/user-guide/test-data-generation.qmd
+++ b/docs/user-guide/test-data-generation.qmd
@@ -433,6 +433,128 @@ Since the generated data respects the constraints defined in the schema, it shou
 validation checks. This workflow is particularly useful for testing validation logic before
 applying it to production data, or for creating reproducible test fixtures in your CI/CD pipeline.
 
+## Pytest Fixture
+
+When Pointblank is installed, a `generate_dataset` **pytest fixture** is automatically available
+in all your test files. There is no need to import anything or add configuration to `conftest.py`
+— the fixture is registered via pytest's plugin system.
+
+The fixture works identically to `pb.generate_dataset()`, but with one key difference: when you
+don't supply a `seed=` parameter, a deterministic seed is automatically derived from the test's
+fully-qualified name. This means:
+
+- The **same test** always produces the **same data** — no manual seed management required.
+- **Different tests** get different seeds, so they exercise different datasets.
+- You can still pass an explicit `seed=` to override the automatic seed when needed.
+
+### Basic Usage
+
+Use it by adding `generate_dataset` to your test function's parameter list:
+
+```python
+# test_pipeline.py
+
+import pointblank as pb
+
+def test_etl_handles_nulls(generate_dataset):
+    schema = pb.Schema(
+        user_id=pb.int_field(unique=True),
+        email=pb.string_field(preset="email", nullable=True, null_probability=0.3),
+        age=pb.int_field(min_val=0, max_val=120),
+    )
+
+    df = generate_dataset(schema, n=500)
+    result = my_etl_pipeline(df)
+    assert result.filter(pl.col("email").is_null()).shape[0] == 0
+```
+
+All parameters from `generate_dataset()` are supported — `n`, `seed`, `output`, and `country`:
+
+```python
+def test_german_data(generate_dataset):
+    schema = pb.Schema(
+        name=pb.string_field(preset="name"),
+        city=pb.string_field(preset="city"),
+    )
+
+    df = generate_dataset(schema, n=200, country="DE", output="pandas")
+    assert len(df) == 200
+```
+
+### Multiple Datasets in One Test
+
+Calling the fixture multiple times within the same test produces different (but still
+deterministic) data on each call:
+
+```python
+def test_merge_pipeline(generate_dataset):
+    customers = generate_dataset(customer_schema, n=1000, country="US")
+    orders = generate_dataset(order_schema, n=5000)
+
+    # Each call gets a unique seed derived from the test name + call index,
+    # so both DataFrames are deterministic and different from each other.
+    result = merge_pipeline(customers, orders)
+    assert result.shape[0] > 0
+```
+
+### Testing Across Locales
+
+The fixture makes locale testing particularly concise when combined with `pytest.mark.parametrize`:
+
+```python
+import pytest
+import pointblank as pb
+
+@pytest.mark.parametrize("country", ["US", "DE", "JP", "BR"])
+def test_name_normalizer(generate_dataset, country):
+    schema = pb.Schema(name=pb.string_field(preset="name_full"))
+    df = generate_dataset(schema, n=100, country=country)
+    result = normalize_names(df)
+    assert result["name"].str.len_chars().min() > 0
+```
+
+### Sharing Schemas Across Tests
+
+Define schemas as fixtures in `conftest.py` and compose them with `generate_dataset`:
+
+```python
+# conftest.py
+import pytest
+import pointblank as pb
+
+@pytest.fixture
+def customer_schema():
+    return pb.Schema(
+        id=pb.int_field(unique=True),
+        name=pb.string_field(preset="name"),
+        email=pb.string_field(preset="email"),
+        city=pb.string_field(preset="city"),
+    )
+
+# test_validation.py
+def test_customer_validation(generate_dataset, customer_schema):
+    df = generate_dataset(customer_schema, n=200, country="DE")
+    validation = pb.Validate(df).col_vals_not_null(columns="email").interrogate()
+    assert validation.all_passed()
+
+# test_export.py
+def test_customer_export(generate_dataset, customer_schema):
+    df = generate_dataset(customer_schema, n=50, country="JP")
+    exported = export_to_parquet(df)
+    assert exported.exists()
+```
+
+### Seed Stability
+
+A given seed (whether explicit or auto-derived) is guaranteed to produce identical output **within
+the same Pointblank version**. Across versions, changes to country data files or generator logic
+may alter the output for a given seed.
+
+For CI pipelines that require bit-exact data across library upgrades, we recommend saving
+generated DataFrames as Parquet or CSV snapshot files rather than relying on cross-version seed
+stability. This is the same approach used by snapshot-testing tools like `pytest-snapshot` and
+`syrupy`.
+
 ## Conclusion
 
 Test data generation provides a convenient way to create realistic synthetic datasets directly from

--- a/pointblank/pytest_plugin.py
+++ b/pointblank/pytest_plugin.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Any, Literal
+
+import pytest
+
+if TYPE_CHECKING:
+    from pointblank.schema import Schema
+
+
+def _seed_from_node_id(node_id: str) -> int:
+    """Derive a stable, positive 31-bit seed from a pytest node ID.
+
+    Uses SHA-256 so that small changes in the test name produce very
+    different seeds, avoiding accidental correlation between tests.
+    """
+    digest = hashlib.sha256(node_id.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") % (2**31)
+
+
+@pytest.fixture
+def generate_dataset(request: pytest.FixtureRequest):
+    """Fixture form of `pointblank.generate_dataset()` with automatic seeding.
+
+    Behaves identically to `pointblank.generate_dataset()`, but when the
+    `seed=` parameter is not supplied (or is `None`), a deterministic seed
+    is derived from the running test's fully-qualified node ID.  This means:
+
+    - the **same test** always produces the **same data**: no manual seed
+    management required.
+    - **different tests** get different seeds, so they exercise different data.
+    - **you** can still pass an explicit `seed=` to override the automatic one.
+
+    Parameters
+    ----------
+    schema : Schema
+        Schema defining the dataset structure (same as `generate_dataset()`).
+    n : int, default 100
+        Number of rows to generate.
+    seed : int or None, default None
+        Random seed.  When `None`, a seed is derived from the test's node ID.
+    output : `"polars"` | `"pandas"` | `"dict"`, default `"polars"`
+        Output format.
+    country : str, default `"US"`
+        Country code for locale-aware generation.
+
+    Returns
+    -------
+    DataFrame or dict
+        Generated data, identical to what `pointblank.generate_dataset()`
+        returns.
+
+    Notes
+    -----
+    **Seed stability caveat:**  The seed guarantees identical output *within
+    the same Pointblank version*. Across versions, changes to country data
+    files or generator logic may alter the output for a given seed. For
+    CI pipelines that require bit-exact data across upgrades, save generated
+    DataFrames as Parquet/CSV snapshots rather than relying on seed
+    reproducibility.
+    """
+
+    from pointblank.schema import generate_dataset as _generate_dataset
+
+    default_seed = _seed_from_node_id(request.node.nodeid)
+
+    # Track a call counter so that multiple calls within the same test
+    # produce different (but still deterministic) data.
+    call_count = 0
+
+    def _generate(
+        schema: Schema,
+        n: int = 100,
+        seed: int | None = None,
+        output: Literal["polars", "pandas", "dict"] = "polars",
+        country: str = "US",
+    ) -> Any:
+        nonlocal call_count
+
+        if seed is None:
+            # Each successive call within the same test gets a unique but
+            # deterministic seed: base_seed + call_index.
+            seed = (default_seed + call_count) % (2**31)
+            call_count += 1
+
+        return _generate_dataset(schema, n=n, seed=seed, output=output, country=country)
+
+    return _generate

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -1644,6 +1644,7 @@ def generate_dataset(
     - **you** can still pass an explicit `seed=` to override the automatic seed.
     - **calling** the fixture **multiple times** within one test produces different (but still
     deterministic) data on each call.
+    - the fixture exposes `.default_seed` and `.last_seed` attributes for debugging.
 
     ```python
     def test_my_pipeline(generate_dataset):
@@ -1668,6 +1669,15 @@ def generate_dataset(
         customers = generate_dataset(customer_schema, n=1000, country="US")
         orders = generate_dataset(order_schema, n=5000)
         # Both DataFrames are deterministic; each call gets a unique seed
+    ```
+
+    When a test fails, include the seed in the assertion message so the failure is easy to
+    reproduce:
+
+    ```python
+    def test_age_range(generate_dataset):
+        df = generate_dataset(schema, n=100)
+        assert df["age"].min() >= 18, f"Failed with seed {generate_dataset.last_seed}"
     ```
 
     Seed Stability

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,9 @@ dev = [
 [project.urls]
 homepage = "https://github.com/posit-dev/pointblank"
 
+[project.entry-points.pytest11]
+pointblank = "pointblank.pytest_plugin"
+
 [project.scripts]
 pb = "pointblank.cli:cli"
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,224 @@
+"""
+Tests for the pointblank pytest plugin (`generate_dataset` fixture).
+
+These tests verify:
+
+- the fixture is auto-discovered and usable
+- automatic seeding produces deterministic data
+- different tests get different seeds (different data)
+- multiple calls within one test get different but deterministic data
+- explicit seed override works
+- all output formats work
+- country parameter is respected
+- seed-derivation helper produces sane values
+"""
+
+import pytest
+
+from pointblank import Schema, int_field, float_field, string_field
+from pointblank.pytest_plugin import _seed_from_node_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SIMPLE_SCHEMA = Schema(
+    id=int_field(min_val=1, max_val=10_000),
+    value=float_field(min_val=0.0, max_val=100.0),
+    name=string_field(min_length=3, max_length=10),
+)
+
+
+# ---------------------------------------------------------------------------
+# _seed_from_node_id unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeedFromNodeId:
+    """Tests for the seed derivation helper."""
+
+    def test_returns_positive_int(self):
+        seed = _seed_from_node_id("tests/test_example.py::test_foo")
+        assert isinstance(seed, int)
+        assert 0 <= seed < 2**31
+
+    def test_deterministic(self):
+        a = _seed_from_node_id("tests/test_example.py::test_foo")
+        b = _seed_from_node_id("tests/test_example.py::test_foo")
+        assert a == b
+
+    def test_different_names_give_different_seeds(self):
+        a = _seed_from_node_id("tests/test_example.py::test_foo")
+        b = _seed_from_node_id("tests/test_example.py::test_bar")
+        assert a != b
+
+    def test_parametrize_ids_give_different_seeds(self):
+        a = _seed_from_node_id("tests/test_example.py::test_param[0]")
+        b = _seed_from_node_id("tests/test_example.py::test_param[1]")
+        assert a != b
+
+    def test_empty_string(self):
+        seed = _seed_from_node_id("")
+        assert isinstance(seed, int)
+        assert 0 <= seed < 2**31
+
+
+# ---------------------------------------------------------------------------
+# Fixture integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureBasicUsage:
+    """Test the generate_dataset fixture produces valid data."""
+
+    def test_returns_polars_by_default(self, generate_dataset):
+        import polars as pl
+
+        df = generate_dataset(SIMPLE_SCHEMA, n=10)
+        assert isinstance(df, pl.DataFrame)
+        assert df.shape == (10, 3)
+        assert set(df.columns) == {"id", "value", "name"}
+
+    def test_pandas_output(self, generate_dataset):
+        import pandas as pd
+
+        df = generate_dataset(SIMPLE_SCHEMA, n=5, output="pandas")
+        assert isinstance(df, pd.DataFrame)
+        assert df.shape == (5, 3)
+
+    def test_dict_output(self, generate_dataset):
+        result = generate_dataset(SIMPLE_SCHEMA, n=5, output="dict")
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"id", "value", "name"}
+        assert all(len(v) == 5 for v in result.values())
+
+    def test_country_parameter(self, generate_dataset):
+        schema = Schema(city=string_field(preset="city"))
+        df = generate_dataset(schema, n=5, country="DE")
+        assert df.shape == (5, 1)
+
+
+class TestFixtureDeterminism:
+    """Verify that the fixture produces the same data on repeated runs."""
+
+    def test_same_data_across_calls(self, generate_dataset, request):
+        """The fixture with auto-seed should produce the same data as a manual
+        call to generate_dataset() with the same derived seed."""
+        from pointblank.schema import generate_dataset as raw_generate
+
+        # Compute the seed the fixture would use for call_count=0
+        node_seed = _seed_from_node_id(request.node.nodeid)
+
+        df_fixture = generate_dataset(SIMPLE_SCHEMA, n=20, output="dict")
+        df_manual = raw_generate(SIMPLE_SCHEMA, n=20, seed=node_seed, output="dict")
+
+        assert df_fixture["id"] == df_manual["id"]
+        assert df_fixture["value"] == df_manual["value"]
+        assert df_fixture["name"] == df_manual["name"]
+
+    def test_fixture_is_deterministic_first(self, generate_dataset):
+        """First of a pair: generates data that should match test_fixture_is_deterministic_second
+        only if they share the same test name (they don't), so they should differ."""
+        df = generate_dataset(SIMPLE_SCHEMA, n=10)
+        # Just store the first value for structural verification
+        assert df.shape == (10, 3)
+
+    def test_fixture_is_deterministic_second(self, generate_dataset):
+        """Different test name → different seed → different data."""
+        df = generate_dataset(SIMPLE_SCHEMA, n=10)
+        assert df.shape == (10, 3)
+
+
+class TestFixtureMultipleCalls:
+    """Verify multiple calls within one test produce different but deterministic data."""
+
+    def test_two_calls_produce_different_data(self, generate_dataset):
+        """Two calls in the same test should use different seeds (via call counter)."""
+        df1 = generate_dataset(SIMPLE_SCHEMA, n=50, output="dict")
+        df2 = generate_dataset(SIMPLE_SCHEMA, n=50, output="dict")
+
+        # With different seeds and 50 rows, the id columns should differ
+        assert df1["id"] != df2["id"], "Two calls in the same test should produce different data"
+
+    def test_three_calls_all_differ(self, generate_dataset):
+        """Three calls should all produce different data."""
+        results = [generate_dataset(SIMPLE_SCHEMA, n=30, output="dict") for _ in range(3)]
+
+        # All id columns should be pairwise different
+        for i in range(len(results)):
+            for j in range(i + 1, len(results)):
+                assert results[i]["id"] != results[j]["id"], (
+                    f"Call {i} and {j} produced the same data"
+                )
+
+
+class TestFixtureExplicitSeed:
+    """Verify explicit seed overrides the automatic one."""
+
+    def test_explicit_seed_overrides_auto(self, generate_dataset):
+        """When seed is passed explicitly, it should be used instead of the auto-derived one."""
+        from pointblank.schema import generate_dataset as raw_generate
+
+        df_fixture = generate_dataset(SIMPLE_SCHEMA, n=10, seed=42, output="dict")
+        df_raw = raw_generate(SIMPLE_SCHEMA, n=10, seed=42, output="dict")
+
+        assert df_fixture["id"] == df_raw["id"]
+        assert df_fixture["value"] == df_raw["value"]
+        assert df_fixture["name"] == df_raw["name"]
+
+    def test_explicit_seed_does_not_increment_counter(self, generate_dataset):
+        """Explicit seeds should not be affected by call_count incrementing.
+        The call_count only affects auto-seeded calls."""
+        from pointblank.schema import generate_dataset as raw_generate
+
+        # First call: auto-seeded (increments counter)
+        _ = generate_dataset(SIMPLE_SCHEMA, n=5)
+
+        # Second call: explicit seed — should match raw function with same seed
+        df_fixture = generate_dataset(SIMPLE_SCHEMA, n=10, seed=99, output="dict")
+        df_raw = raw_generate(SIMPLE_SCHEMA, n=10, seed=99, output="dict")
+
+        assert df_fixture["id"] == df_raw["id"]
+
+    def test_two_explicit_same_seed_give_same_data(self, generate_dataset):
+        """Two calls with the same explicit seed give the same data."""
+        df1 = generate_dataset(SIMPLE_SCHEMA, n=20, seed=123, output="dict")
+        df2 = generate_dataset(SIMPLE_SCHEMA, n=20, seed=123, output="dict")
+
+        assert df1["id"] == df2["id"]
+        assert df1["value"] == df2["value"]
+
+
+class TestFixtureDifferentTestsDifferentData:
+    """Each test function gets a different auto-seed."""
+
+    def test_alpha(self, generate_dataset):
+        """Returns data seeded from 'test_alpha' node ID."""
+        df = generate_dataset(SIMPLE_SCHEMA, n=30, output="dict")
+        # Store as attribute on the class for cross-test comparison
+        TestFixtureDifferentTestsDifferentData._alpha_ids = df["id"]
+
+    def test_beta(self, generate_dataset):
+        """Returns data seeded from 'test_beta' node ID — should differ from alpha."""
+        df = generate_dataset(SIMPLE_SCHEMA, n=30, output="dict")
+
+        if hasattr(TestFixtureDifferentTestsDifferentData, "_alpha_ids"):
+            assert df["id"] != TestFixtureDifferentTestsDifferentData._alpha_ids, (
+                "Different tests should produce different data"
+            )
+
+
+class TestFixtureParametrize:
+    """Parametrized tests get different seeds per parameter."""
+
+    @pytest.mark.parametrize("country", ["US", "DE", "JP"])
+    def test_parametrized_countries(self, generate_dataset, country):
+        schema = Schema(city=string_field(preset="city"))
+        df = generate_dataset(schema, n=5, country=country)
+        assert df.shape == (5, 1)
+
+    @pytest.mark.parametrize("n", [1, 10, 50])
+    def test_parametrized_sizes(self, generate_dataset, n):
+        df = generate_dataset(SIMPLE_SCHEMA, n=n)
+        assert df.shape == (n, 3)


### PR DESCRIPTION
This PR introduces a new pytest fixture for deterministic test data generation using Pointblank, along with docs, plugin registration, and thorough testing. The main goal is to streamline and standardize test data creation in Python projects using Pointblank, ensuring reproducibility and ease of use across test suites.