### PR TITLE
fix: have `preview()` work with duration columns

### DIFF
--- a/pointblank/field.py
+++ b/pointblank/field.py
@@ -1941,7 +1941,7 @@ def duration_field(
         ),
     )
 
-    pb.generate_dataset(schema, n=100, seed=23)
+    pb.preview(pb.generate_dataset(schema, n=100, seed=23))
     ```
 
     Colon-separated strings can also be used for quick duration definitions:
@@ -1952,7 +1952,7 @@ def duration_field(
         break_time=pb.duration_field(min_duration="0:05:00", max_duration="0:30:00"),
     )
 
-    pb.generate_dataset(schema, n=30, seed=23)
+    pb.preview(pb.generate_dataset(schema, n=30, seed=23))
     ```
 
     Optional durations can be created with `nullable=True`, and duration fields work well
@@ -1972,7 +1972,7 @@ def duration_field(
         ),
     )
 
-    pb.generate_dataset(schema, n=30, seed=7)
+    pb.preview(pb.generate_dataset(schema, n=30, seed=7))
     ```
     """
     return DurationField(

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -1821,7 +1821,7 @@ def generate_dataset(
         ),
     )
 
-    pb.generate_dataset(schema, n=50, seed=23)
+    pb.preview(pb.generate_dataset(schema, n=50, seed=23))
     ```
     """
     return schema.generate(


### PR DESCRIPTION
This PR improves the handling and display of duration columns in validation tables, as well as a minor update to dataset previewing. The most significant change is the conversion of duration columns to string format for display, ensuring compatibility with Great Tables.