### PR TITLE
Audit the performance of lazy transformations

### DIFF
--- a/pointblank/_agg.py
+++ b/pointblank/_agg.py
@@ -5,10 +5,8 @@ from collections.abc import Callable
 
 import narwhals as nw
 
-from pointblank._typing import SupportsOrder, supports_order
-
-Aggregator = Callable[[nw.DataFrame | nw.LazyFrame], SupportsOrder]
-Comparator = Callable[[SupportsOrder, SupportsOrder, SupportsOrder], bool]
+Aggregator = Callable[[nw.DataFrame | nw.LazyFrame], float]
+Comparator = Callable[[float, float, float], bool]
 
 AGGREGATOR_REGISTRY: dict[str, Aggregator] = {}
 
@@ -29,58 +27,61 @@ def register(fn):
 
 ## Aggregator Functions
 @register
-def agg_sum(column: nw.DataFrame | nw.LazyFrame) -> SupportsOrder:
+def agg_sum(column: nw.DataFrame | nw.LazyFrame) -> float:
     plan = column.select(nw.all().sum())
     result = plan.collect().item() if isinstance(plan, nw.LazyFrame) else plan.item()
-    assert supports_order(result), "INTERNAL: Query scalar would not support ordering."
+    result = nw.to_py_scalar(result)
+    assert isinstance(result, (int, float)), "INTERNAL: Query scalar would not be numeric."
     return result
 
 
 @register
-def agg_avg(column: nw.DataFrame | nw.LazyFrame) -> SupportsOrder:
+def agg_avg(column: nw.DataFrame | nw.LazyFrame) -> float:
     plan = column.select(nw.all().mean())
     result = plan.collect().item() if isinstance(plan, nw.LazyFrame) else plan.item()
-    assert supports_order(result), "INTERNAL: Query scalar would not support ordering."
+    result = nw.to_py_scalar(result)
+    assert isinstance(result, (int, float)), "INTERNAL: Query scalar would not be numeric."
     return result
 
 
 @register
-def agg_sd(column: nw.DataFrame | nw.LazyFrame) -> SupportsOrder:
+def agg_sd(column: nw.DataFrame | nw.LazyFrame) -> float:
     plan = column.select(nw.all().std())
     result = plan.collect().item() if isinstance(plan, nw.LazyFrame) else plan.item()
-    assert supports_order(result), "INTERNAL: Query scalar would not support ordering."
+    result = nw.to_py_scalar(result)
+    assert isinstance(result, (int, float)), "INTERNAL: Query scalar would not be numeric."
     return result
 
 
 ## Comparator functions:
 @register
-def comp_eq(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
+def comp_eq(real: float, lower: float, upper: float) -> bool:
     if lower == upper:
         return bool(real == lower)
     return _generic_between(real, lower, upper)
 
 
 @register
-def comp_gt(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
+def comp_gt(real: float, lower: float, upper: float) -> bool:
     return bool(real > lower)
 
 
 @register
-def comp_ge(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
+def comp_ge(real: float, lower: float, upper: float) -> bool:
     return bool(real >= lower)
 
 
 @register
-def comp_lt(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
+def comp_lt(real: float, lower: float, upper: float) -> bool:
     return bool(real < upper)
 
 
 @register
-def comp_le(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
+def comp_le(real: float, lower: float, upper: float) -> bool:
     return bool(real <= upper)
 
 
-def _generic_between(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
+def _generic_between(real: float, lower: float, upper: float) -> bool:
     """Call if comparator needs to check between two values."""
     return bool(lower <= real <= upper)
 

--- a/pointblank/_agg.py
+++ b/pointblank/_agg.py
@@ -6,8 +6,7 @@ from typing import Any
 
 import narwhals as nw
 
-# TODO: Should take any frame type
-Aggregator = Callable[[nw.DataFrame], float | int]
+Aggregator = Callable[[nw.DataFrame | nw.LazyFrame], float | int]
 Comparator = Callable[[Any, Any, Any], bool]
 
 AGGREGATOR_REGISTRY: dict[str, Aggregator] = {}
@@ -29,18 +28,27 @@ def register(fn):
 
 ## Aggregator Functions
 @register
-def agg_sum(column: nw.DataFrame) -> float:
-    return column.select(nw.all().sum()).item()
+def agg_sum(column: nw.DataFrame | nw.LazyFrame) -> float:
+    plan = column.select(nw.all().sum())
+    result = plan.collect().item() if isinstance(plan, nw.LazyFrame) else plan.item()
+    assert isinstance(result, (int, float))
+    return result
 
 
 @register
-def agg_avg(column: nw.DataFrame) -> float:
-    return column.select(nw.all().mean()).item()
+def agg_avg(column: nw.DataFrame | nw.LazyFrame) -> float:
+    plan = column.select(nw.all().mean())
+    result = plan.collect().item() if isinstance(plan, nw.LazyFrame) else plan.item()
+    assert isinstance(result, (int, float))
+    return result
 
 
 @register
-def agg_sd(column: nw.DataFrame) -> float:
-    return column.select(nw.all().std()).item()
+def agg_sd(column: nw.DataFrame | nw.LazyFrame) -> float:
+    plan = column.select(nw.all().std())
+    result = plan.collect().item() if isinstance(plan, nw.LazyFrame) else plan.item()
+    assert isinstance(result, (int, float))
+    return result
 
 
 ## Comparator functions:

--- a/pointblank/_agg.py
+++ b/pointblank/_agg.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Callable
-from typing import Any
 
 import narwhals as nw
 
-Aggregator = Callable[[nw.DataFrame | nw.LazyFrame], float | int]
-Comparator = Callable[[Any, Any, Any], bool]
+from pointblank._typing import SupportsOrder, supports_order
+
+Aggregator = Callable[[nw.DataFrame | nw.LazyFrame], SupportsOrder]
+Comparator = Callable[[SupportsOrder, SupportsOrder, SupportsOrder], bool]
 
 AGGREGATOR_REGISTRY: dict[str, Aggregator] = {}
 
@@ -28,58 +29,58 @@ def register(fn):
 
 ## Aggregator Functions
 @register
-def agg_sum(column: nw.DataFrame | nw.LazyFrame) -> float:
+def agg_sum(column: nw.DataFrame | nw.LazyFrame) -> SupportsOrder:
     plan = column.select(nw.all().sum())
     result = plan.collect().item() if isinstance(plan, nw.LazyFrame) else plan.item()
-    assert isinstance(result, (int, float))
+    assert supports_order(result), "INTERNAL: Query scalar would not support ordering."
     return result
 
 
 @register
-def agg_avg(column: nw.DataFrame | nw.LazyFrame) -> float:
+def agg_avg(column: nw.DataFrame | nw.LazyFrame) -> SupportsOrder:
     plan = column.select(nw.all().mean())
     result = plan.collect().item() if isinstance(plan, nw.LazyFrame) else plan.item()
-    assert isinstance(result, (int, float))
+    assert supports_order(result), "INTERNAL: Query scalar would not support ordering."
     return result
 
 
 @register
-def agg_sd(column: nw.DataFrame | nw.LazyFrame) -> float:
+def agg_sd(column: nw.DataFrame | nw.LazyFrame) -> SupportsOrder:
     plan = column.select(nw.all().std())
     result = plan.collect().item() if isinstance(plan, nw.LazyFrame) else plan.item()
-    assert isinstance(result, (int, float))
+    assert supports_order(result), "INTERNAL: Query scalar would not support ordering."
     return result
 
 
 ## Comparator functions:
 @register
-def comp_eq(real: float, lower: float, upper: float) -> bool:
+def comp_eq(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
     if lower == upper:
         return bool(real == lower)
     return _generic_between(real, lower, upper)
 
 
 @register
-def comp_gt(real: float, lower: float, upper: float) -> bool:
+def comp_gt(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
     return bool(real > lower)
 
 
 @register
-def comp_ge(real: Any, lower: float, upper: float) -> bool:
+def comp_ge(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
     return bool(real >= lower)
 
 
 @register
-def comp_lt(real: float, lower: float, upper: float) -> bool:
+def comp_lt(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
     return bool(real < upper)
 
 
 @register
-def comp_le(real: float, lower: float, upper: float) -> bool:
+def comp_le(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
     return bool(real <= upper)
 
 
-def _generic_between(real: Any, lower: Any, upper: Any) -> bool:
+def _generic_between(real: SupportsOrder, lower: SupportsOrder, upper: SupportsOrder) -> bool:
     """Call if comparator needs to check between two values."""
     return bool(lower <= real <= upper)
 

--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -31,7 +31,7 @@ from pointblank._utils import (
 from pointblank.column import Column
 
 if TYPE_CHECKING:
-    from narwhals.typing import IntoFrame
+    from narwhals.typing import Frame, IntoFrame
 
 
 def _safe_modify_datetime_compare_val(data_frame: Any, column: str, compare_val: Any) -> Any:
@@ -126,7 +126,12 @@ def _safe_is_nan_or_null_expr(data_frame: IntoFrame, column_expr: nw.Expr, colum
     """
     null_check = column_expr.is_null()
 
-    df: nw.DataFrame | nw.LazyFrame = nw.from_native(data_frame, allow_series=False)
+    df: Frame = nw.from_native(data_frame, allow_series=False)
+
+    # Ibis backends (e.g. SQLite) don't support is_nan(), so only check nulls
+    if df.implementation.is_ibis():
+        return null_check
+
     schema: nw.Schema = df.collect_schema()
 
     dtype: nw.dtypes.DType = schema[column_name]

--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -45,10 +45,10 @@ def _safe_modify_datetime_compare_val(data_frame: Any, column: str, compare_val:
         # First try to get column dtype from schema for LazyFrames
         column_dtype = None
 
-        if hasattr(data_frame, "collect_schema"):
+        if is_narwhals_lazyframe(data_frame):
             schema = data_frame.collect_schema()
             column_dtype = schema.get(column)
-        elif hasattr(data_frame, "schema"):
+        elif is_narwhals_dataframe(data_frame):
             schema = data_frame.schema
             column_dtype = schema.get(column)
 
@@ -143,9 +143,9 @@ def _safe_is_nan_or_null_expr(
 
     # For non-Ibis backends, try to use `is_nan()` if the column type supports it
     try:
-        if hasattr(data_frame, "collect_schema"):
+        if is_narwhals_lazyframe(data_frame):
             schema = data_frame.collect_schema()
-        elif hasattr(data_frame, "schema"):
+        elif is_narwhals_dataframe(data_frame):
             schema = data_frame.schema
         else:  # pragma: no cover
             schema = None  # pragma: no cover

--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -103,7 +103,7 @@ def _safe_modify_datetime_compare_val(data_frame: Any, column: str, compare_val:
 
 
 def _safe_is_nan_or_null_expr(
-    data_frame: Any, column_expr: Any, column_name: str | None = None
+    data_frame: nw.DataFrame | nw.LazyFrame, column_expr: nw.Expr, column_name: str
 ) -> Any:
     """
     Create an expression that safely checks for both Null and NaN values.
@@ -129,49 +129,18 @@ def _safe_is_nan_or_null_expr(
     # Always check for null values
     null_check = column_expr.is_null()
 
-    # For Ibis backends, many don't support `is_nan()` so we stick to Null checks only;
-    # use `narwhals.get_native_namespace()` for reliable backend detection
-    try:
-        native_namespace = nw.get_native_namespace(data_frame)
+    df = nw.from_native(data_frame, allow_series=False)
+    if is_narwhals_lazyframe(df):
+        schema: nw.Schema = data_frame.collect_schema()
+    else:
+        schema: nw.Schema = data_frame.schema
 
-        # If it's an Ibis backend, only check for null values
-        # The namespace is the actual module, so we check its name
-        if hasattr(native_namespace, "__name__") and "ibis" in native_namespace.__name__:
-            return null_check
-    except Exception:  # pragma: no cover
-        pass  # pragma: no cover
+    dtype: nw.dtypes.DType = schema[column_name]
 
-    # For non-Ibis backends, try to use `is_nan()` if the column type supports it
-    try:
-        if is_narwhals_lazyframe(data_frame):
-            schema = data_frame.collect_schema()
-        elif is_narwhals_dataframe(data_frame):
-            schema = data_frame.schema
-        else:  # pragma: no cover
-            schema = None  # pragma: no cover
+    if not dtype.is_numeric():
+        return null_check
 
-        if schema and column_name:
-            column_dtype = schema.get(column_name)
-            if column_dtype:
-                dtype_str = str(column_dtype).lower()
-
-                # Check if it's a numeric type that supports NaN
-                is_numeric = any(
-                    num_type in dtype_str for num_type in ["float", "double", "f32", "f64"]
-                )
-
-                if is_numeric:
-                    try:
-                        # For numeric types, try to check both Null and NaN
-                        return null_check | column_expr.is_nan()
-                    except Exception:
-                        # If `is_nan()` fails for any reason, fall back to Null only
-                        pass
-    except Exception:  # pragma: no cover
-        pass  # pragma: no cover
-
-    # Fallback: just check Null values
-    return null_check
+    return null_check | column_expr.is_nan()
 
 
 class ConjointlyValidation:

--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -102,9 +102,7 @@ def _safe_modify_datetime_compare_val(data_frame: Any, column: str, compare_val:
     return compare_val
 
 
-def _safe_is_nan_or_null_expr(
-    data_frame: nw.DataFrame | nw.LazyFrame, column_expr: nw.Expr, column_name: str
-) -> Any:
+def _safe_is_nan_or_null_expr(data_frame: IntoFrame, column_expr: nw.Expr, column_name: str) -> Any:
     """
     Create an expression that safely checks for both Null and NaN values.
 
@@ -126,14 +124,10 @@ def _safe_is_nan_or_null_expr(
     Any
         A narwhals expression that returns `True` for Null or NaN values.
     """
-    # Always check for null values
     null_check = column_expr.is_null()
 
-    df = nw.from_native(data_frame, allow_series=False)
-    if is_narwhals_lazyframe(df):
-        schema: nw.Schema = data_frame.collect_schema()
-    else:
-        schema: nw.Schema = data_frame.schema
+    df: nw.DataFrame | nw.LazyFrame = nw.from_native(data_frame, allow_series=False)
+    schema: nw.Schema = df.collect_schema()
 
     dtype: nw.dtypes.DType = schema[column_name]
 

--- a/pointblank/_typing.py
+++ b/pointblank/_typing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import sys
 from collections.abc import Container
-from typing import List, Tuple, Union
+from typing import List, Protocol, Tuple, TypeGuard, Union
 
 # Check Python version for TypeAlias support
 if sys.version_info >= (3, 10):
@@ -75,3 +75,20 @@ try:
     )
 except AttributeError:
     pass
+
+
+# Need this to describe a generic numeric type that we can compare against another generic type
+# ie ordering. Apparently, python never implemented this which surprised me. There is numeric.Real
+# but that is a little narrower and wishy washy w/some numpy or FFI driven types. So, I guess we'll
+# define a little protocol here to help us. Also surprising is we don't have a super reliable
+# way to enforce this without a type guard, so we define `supports_order`. I originally thought this
+# was overkill but it's used in a lot of internal agg code, and a failure downstream would be
+# very confusing. I think this fits a case where an AssertionError is enough to qualify the runtime
+# check.
+class SupportsOrder(Protocol):
+    def __lt__(self, other: object) -> bool: ...
+    def __gt__(self, other: object) -> bool: ...
+
+
+def supports_order(x: object) -> TypeGuard[SupportsOrder]:
+    return hasattr(type(x), "__lt__") and hasattr(type(x), "__gt__")

--- a/pointblank/_typing.py
+++ b/pointblank/_typing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import sys
 from collections.abc import Container
-from typing import List, Protocol, Tuple, TypeGuard, Union
+from typing import List, Tuple, Union
 
 # Check Python version for TypeAlias support
 if sys.version_info >= (3, 10):
@@ -75,20 +75,3 @@ try:
     )
 except AttributeError:
     pass
-
-
-# Need this to describe a generic numeric type that we can compare against another generic type
-# ie ordering. Apparently, python never implemented this which surprised me. There is numeric.Real
-# but that is a little narrower and wishy washy w/some numpy or FFI driven types. So, I guess we'll
-# define a little protocol here to help us. Also surprising is we don't have a super reliable
-# way to enforce this without a type guard, so we define `supports_order`. I originally thought this
-# was overkill but it's used in a lot of internal agg code, and a failure downstream would be
-# very confusing. I think this fits a case where an AssertionError is enough to qualify the runtime
-# check.
-class SupportsOrder(Protocol):
-    def __lt__(self, other: object) -> bool: ...
-    def __gt__(self, other: object) -> bool: ...
-
-
-def supports_order(x: object) -> TypeGuard[SupportsOrder]:
-    return hasattr(type(x), "__lt__") and hasattr(type(x), "__gt__")

--- a/pointblank/column.py
+++ b/pointblank/column.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import narwhals as nw
+from narwhals.dependencies import is_narwhals_lazyframe
 from narwhals.typing import IntoDataFrame
 
 __all__ = [
@@ -240,7 +241,7 @@ class ColumnSelectorNarwhals(Column):
         # Use the selector to select columns and return their names
         selected_df = dfn.select(self.exprs.exprs)  # type: ignore[attr-defined]
         # Use `collect_schema()` for LazyFrame to avoid performance warnings
-        if hasattr(selected_df, "collect_schema"):
+        if is_narwhals_lazyframe(selected_df):
             return list(selected_df.collect_schema().keys())
         else:  # pragma: no cover
             return list(selected_df.columns)

--- a/pointblank/scan_profile.py
+++ b/pointblank/scan_profile.py
@@ -260,12 +260,10 @@ class _DataProfile:  # TODO: feels redundant and weird
 
     def set_row_count(self, data: Frame) -> None:
         assert self.columns  # internal: cols should already be set
-
-        slim = data.select(nw.col(self.columns[0]))
-
-        physical = _as_physical(slim)
-
-        self.row_count = len(physical)
+        if hasattr(data, "collect"):
+            self.row_count = data.select(nw.len()).collect().item()
+        else:
+            self.row_count = len(data)
 
     def as_dataframe(self, *, strict: bool = True) -> DataFrame:
         assert self.column_profiles

--- a/pointblank/scan_profile.py
+++ b/pointblank/scan_profile.py
@@ -260,8 +260,8 @@ class _DataProfile:  # TODO: feels redundant and weird
 
     def set_row_count(self, data: Frame) -> None:
         assert self.columns  # internal: cols should already be set
-        if hasattr(data, "collect"):
-            self.row_count = data.select(nw.len()).collect().item()
+        if hasattr(data, "collect"):  # there's no canonical way (yet) to check in narwhals
+            self.row_count = data.select(nw.len()).collect().item()  # ty: ignore
         else:
             self.row_count = len(data)
 

--- a/pointblank/scan_profile.py
+++ b/pointblank/scan_profile.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import narwhals as nw
 from narwhals.dataframe import DataFrame
+from narwhals.dependencies import is_narwhals_lazyframe
 
 from pointblank._constants import SVG_ICONS_FOR_DATA_TYPES
 from pointblank._utils import transpose_dicts
@@ -260,7 +261,7 @@ class _DataProfile:  # TODO: feels redundant and weird
 
     def set_row_count(self, data: Frame) -> None:
         assert self.columns  # internal: cols should already be set
-        if hasattr(data, "collect"):  # there's no canonical way (yet) to check in narwhals
+        if is_narwhals_lazyframe(data):
             self.row_count = data.select(nw.len()).collect().item()  # ty: ignore
         else:
             self.row_count = len(data)

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -3674,11 +3674,12 @@ def get_row_count(data: Any) -> int:
         import narwhals as nw
 
         df_nw = nw.from_native(data)
-        # Handle LazyFrames by collecting them first
+        # For LazyFrames, use lazy aggregation to avoid materializing entire frame
         if hasattr(df_nw, "collect"):
-            df_nw = df_nw.collect()
-        # Try different ways to get row count
-        if hasattr(df_nw, "shape"):
+            # Use lazy len() aggregation instead of collecting entire frame
+            return df_nw.select(nw.len()).collect().item()
+        # Try different ways to get row count for eager frames
+        elif hasattr(df_nw, "shape"):
             return df_nw.shape[0]
         elif hasattr(df_nw, "height"):  # pragma: no cover
             return df_nw.height  # pragma: no cover

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -14030,8 +14030,8 @@ class Validate:
                         agg, comp = resolve_agg_registries(assertion_type)
 
                         # Produce a 1-column Narwhals DataFrame
-                        # TODO: Should be able to take lazy too
-                        vec: nw.DataFrame = nw.from_native(data_tbl_step).select(column)
+                        # Note: lazy frames are materialized in agg() to compute aggregates
+                        vec = nw.from_native(data_tbl_step).select(column)
                         real = agg(vec)
 
                         raw_value = value["value"]
@@ -14045,9 +14045,7 @@ class Validate:
                                     "setting reference data on the Validate object. "
                                     "Use Validate(data=..., reference=...) to set reference data."
                                 )
-                            ref_vec: nw.DataFrame = nw.from_native(self.reference).select(
-                                raw_value.column_name
-                            )
+                            ref_vec = nw.from_native(self.reference).select(raw_value.column_name)
                             target: float | int = agg(ref_vec)
                         else:
                             target = raw_value

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -14093,9 +14093,12 @@ class Validate:
 
                     is_column_not_found = "column" in error_msg and "not found" in error_msg
 
+                    # Older Polars versions (< ~1.33) raise KeyError instead of
+                    # ColumnNotFoundError for missing columns in expressions, so we
+                    # need to catch both error shapes.
                     is_comparison_column_not_found = (
                         "unable to find column" in error_msg and "valid columns" in error_msg
-                    )
+                    ) or isinstance(e, KeyError)
 
                     if (
                         is_comparison_error or is_column_not_found or is_comparison_column_not_found
@@ -14127,12 +14130,16 @@ class Validate:
                         # Add a note for comparison column not found errors
                         elif is_comparison_column_not_found:
                             # Extract column name from error message
-                            # Error format: 'unable to find column "col_name"; valid columns: ...'
+                            # ColumnNotFoundError: 'unable to find column "col_name"; valid columns: ...'
+                            # KeyError (older Polars): "'col_name'"
                             match = re.search(r'unable to find column "([^"]+)"', str(e))
-
+                            missing_col_name = None
                             if match:
                                 missing_col_name = match.group(1)
+                            elif isinstance(e, KeyError) and e.args:
+                                missing_col_name = e.args[0]
 
+                            if missing_col_name is not None:
                                 # Determine position for between/outside validations
                                 position = None
                                 if assertion_type in ["col_vals_between", "col_vals_outside"]:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -3673,7 +3673,8 @@ def get_row_count(data: Any) -> int:
     try:
         import narwhals as nw
 
-        df_nw = nw.from_native(data)
+        df_nw = nw.from_native(data, allow_series=False)
+
         # For LazyFrames, use lazy aggregation to avoid materializing entire frame
         if hasattr(df_nw, "collect"):
             # Use lazy len() aggregation instead of collecting entire frame

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -22,6 +22,7 @@ from zoneinfo import ZoneInfo
 
 import commonmark
 import narwhals as nw
+from narwhals.dependencies import is_narwhals_lazyframe
 from great_tables import GT, from_column, google_font, html, loc, md, style, vals
 from great_tables.gt import _get_column_of_values
 from great_tables.vals import fmt_integer, fmt_number
@@ -3260,7 +3261,7 @@ def _get_column_names_safe(data: Any) -> list[str]:
 
         df_nw = nw.from_native(data)
         # Use `collect_schema()` for LazyFrames to avoid performance warnings
-        if hasattr(df_nw, "collect_schema"):
+        if is_narwhals_lazyframe(df_nw):
             return list(df_nw.collect_schema().keys())
         else:
             return list(df_nw.columns)  # pragma: no cover
@@ -3462,7 +3463,7 @@ def get_column_count(data: Any) -> int:
 
         df_nw = nw.from_native(data)
         # Use `collect_schema()` for LazyFrames to avoid performance warnings
-        if hasattr(df_nw, "collect_schema"):
+        if is_narwhals_lazyframe(df_nw):
             return len(df_nw.collect_schema())
         else:
             return len(df_nw.columns)  # pragma: no cover
@@ -3676,7 +3677,7 @@ def get_row_count(data: Any) -> int:
         df_nw = nw.from_native(data, allow_series=False)
 
         # For LazyFrames, use lazy aggregation to avoid materializing entire frame
-        if hasattr(df_nw, "collect"):
+        if is_narwhals_lazyframe(df_nw):
             # Use lazy len() aggregation instead of collecting entire frame
             return df_nw.select(nw.len()).collect().item()
         # Try different ways to get row count for eager frames
@@ -14540,7 +14541,7 @@ class Validate:
 
                 # Ensure that the extract is collected and set to its native format
                 # For LazyFrames (like PySpark), we need to collect before converting to native
-                if hasattr(validation_extract_nw, "collect"):
+                if is_narwhals_lazyframe(validation_extract_nw):
                     validation_extract_nw = validation_extract_nw.collect()
                 validation.extract = nw.to_native(validation_extract_nw)
 
@@ -17151,7 +17152,7 @@ class Validate:
             except TypeError:  # pragma: no cover
                 # For LazyFrames, collect() first to get length
                 n_rows = (
-                    len(extract_nw.collect()) if hasattr(extract_nw, "collect") else 0
+                    len(extract_nw.collect()) if is_narwhals_lazyframe(extract_nw) else 0
                 )  # pragma: no cover
 
             # If the number of rows is zero, then produce an em dash then go to the next iteration
@@ -17160,7 +17161,7 @@ class Validate:
                 continue
 
             # Write the CSV text (ensure LazyFrames are collected first)
-            if hasattr(extract_nw, "collect"):  # pragma: no cover
+            if is_narwhals_lazyframe(extract_nw):  # pragma: no cover
                 extract_nw = extract_nw.collect()
             csv_text = extract_nw.write_csv()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ docs = [
     "nbclient>=0.10.0",
     "nbformat>=5.10.4",
     "quartodoc>=0.8.1; python_version >= '3.9'",
-    "griffe>=0.38.1,<2",                          # Pin below griffe 2.0 which removed parse_numpy(options)
+    "griffe>=0.38.1,<2",                         # Pin below griffe 2.0 which removed parse_numpy(options)
     "pandas>=2.2.3",
     "polars>=1.17.1",
     "pyspark==3.5.6",
@@ -112,7 +112,7 @@ dev = [
     "openpyxl>=3.0.0",
     "mcp[cli]>=1.10.1",
     "fastmcp>=2.10.5",
-    "ty>=0.0.1a31",
+    "ty>=0.0.23",
     "mypy>=1.19.0",
 ]
 

--- a/tests/test__interrogation.py
+++ b/tests/test__interrogation.py
@@ -1,3 +1,4 @@
+import pyexpat
 import pytest
 import pandas as pd
 import polars as pl
@@ -51,37 +52,32 @@ COLUMN_LIST_DISTINCT = ["col_1", "col_2", "col_3", "pb_is_good_"]
 
 
 def test_safe_modify_datetime_with_collect_schema():
-    """Test using collect_schema method."""
+    """Test _safe_modify_datetime_compare_val with a LazyFrame (collect_schema path)."""
+    import datetime
+    import narwhals as nw
 
-    # Create a mock dataframe with collect_schema
-    mock_df = Mock()
-    mock_schema = {"date_col": "datetime64[ns]"}
-    mock_df.collect_schema.return_value = mock_schema
+    df = nw.from_native(pl.DataFrame({"date_col": [datetime.date(2023, 6, 1)]})).lazy()
+    compare_val = datetime.datetime(2023, 1, 1, 12, 0, 0)
 
-    # Mock the _modify_datetime_compare_val function
-    with patch("pointblank._interrogation._modify_datetime_compare_val") as mock_modify:
-        mock_modify.return_value = "modified_value"
+    result = _safe_modify_datetime_compare_val(df, "date_col", compare_val)
 
-        result = _safe_modify_datetime_compare_val(mock_df, "date_col", "2023-01-01")
-
-        assert result == "modified_value"
-        mock_modify.assert_called_once()
+    # datetime should be coerced to date to match the column dtype
+    assert isinstance(result, datetime.date)
+    assert not isinstance(result, datetime.datetime)
 
 
 def test_safe_modify_datetime_with_schema_attribute():
-    """Test using schema attribute."""
+    """Test _safe_modify_datetime_compare_val with an eager DataFrame (schema path)."""
+    import datetime
+    import narwhals as nw
 
-    # Create a mock dataframe with schema attribute
-    mock_df = Mock()
-    del mock_df.collect_schema  # Remove collect_schema
-    mock_df.schema = {"date_col": "datetime64[ns]"}
+    df = nw.from_native(pl.DataFrame({"date_col": [datetime.date(2023, 6, 1)]}))
+    compare_val = datetime.datetime(2023, 1, 1, 12, 0, 0)
 
-    with patch("pointblank._interrogation._modify_datetime_compare_val") as mock_modify:
-        mock_modify.return_value = "modified_value"
+    result = _safe_modify_datetime_compare_val(df, "date_col", compare_val)
 
-        result = _safe_modify_datetime_compare_val(mock_df, "date_col", "2023-01-01")
-
-        assert result == "modified_value"
+    assert isinstance(result, datetime.date)
+    assert not isinstance(result, datetime.datetime)
 
 
 def test_safe_modify_datetime_fallback_sample_collect():
@@ -325,76 +321,118 @@ def test_modify_datetime_column_isinstance_check():
 
 
 def test_safe_is_nan_or_null_expr_with_schema_attribute():
-    """Test _safe_is_nan_or_null_expr() using schema attribute."""
+    """Test _safe_is_nan_or_null_expr with an eager DataFrame and float column."""
+    import narwhals as nw
 
-    # Create a mock dataframe with schema attribute
-    mock_df = Mock(spec=["schema"])  # spec ensures only 'schema' attribute exists
+    df = nw.from_native(pl.DataFrame({"float_col": [1.0, float("nan"), None]}))
+    col_expr = nw.col("float_col")
 
-    # Set up schema attribute with a float column
-    mock_df.schema = {"float_col": "Float64"}
+    result = _safe_is_nan_or_null_expr(df, col_expr, "float_col")
 
-    # Create a mock column expression
-    mock_col_expr = Mock()
-    mock_is_null = Mock()
-    mock_is_nan = Mock()
-    mock_col_expr.is_null.return_value = mock_is_null
-    mock_col_expr.is_nan.return_value = mock_is_nan
-
-    # Mock the OR operation
-    mock_is_null.__or__ = Mock(return_value="null_or_nan_check")
-
-    # Call the function
-    result = _safe_is_nan_or_null_expr(mock_df, mock_col_expr, "float_col")
-
-    # Should have called is_nan() for numeric type
-    assert result == "null_or_nan_check"
-    mock_col_expr.is_null.assert_called_once()
-    mock_col_expr.is_nan.assert_called_once()
+    evaluated = df.select(result).to_native()["float_col"].to_list()
+    assert evaluated == [False, True, True]
 
 
 def test_safe_is_nan_or_null_expr_schema_non_numeric():
-    """Test _safe_is_nan_or_null_expr() with schema attribute for non-numeric column."""
+    """String columns should only get null checks, not NaN checks."""
+    import narwhals as nw
 
-    # Create a mock dataframe with schema attribute (but not collect_schema)
-    mock_df = Mock(spec=["schema"])  # spec ensures only 'schema' attribute exists
+    df = nw.from_native(pl.DataFrame({"str_col": ["a", None, "b"]}))
+    col_expr = nw.col("str_col")
+    result = _safe_is_nan_or_null_expr(df, col_expr, "str_col")
 
-    # Set up schema attribute with a string column (non-numeric)
-    mock_df.schema = {"string_col": "String"}
-
-    # Create a mock column expression
-    mock_col_expr = Mock()
-    mock_is_null_result = "null_check"
-    mock_col_expr.is_null.return_value = mock_is_null_result
-
-    # Call the function
-    result = _safe_is_nan_or_null_expr(mock_df, mock_col_expr, "string_col")
-
-    # Should only check for null (not NaN) for string column
-    # The result is what is_null() returned (null_check = column_expr.is_null())
-    assert result == mock_is_null_result
-    mock_col_expr.is_null.assert_called_once()
-    # is_nan should not be called for string column
-    mock_col_expr.is_nan.assert_not_called()
+    evaluated = df.select(result).to_native()["str_col"].to_list()
+    assert evaluated == [False, True, False]
 
 
 def test_safe_is_nan_or_null_expr_schema_is_nan_fails():
-    """Test _safe_is_nan_or_null_expr() when is_nan() raises exception."""
+    """Test _safe_is_nan_or_null_expr falls back to null-only for string columns."""
+    import narwhals as nw
 
-    # Create a mock dataframe with schema attribute
-    mock_df = Mock(spec=["schema"])  # spec ensures only 'schema' attribute exists
-    mock_df.schema = {"float_col": "Float64"}
+    df = nw.from_native(pl.DataFrame({"str_col": ["a", None, "b"]}))
+    col_expr = nw.col("str_col")
 
-    # Create a mock column expression where is_nan() fails
-    mock_col_expr = Mock()
-    mock_is_null_result = "null_check_only"
-    mock_col_expr.is_null.return_value = mock_is_null_result
-    mock_col_expr.is_nan.side_effect = Exception("is_nan not supported")
+    result = _safe_is_nan_or_null_expr(df, col_expr, "str_col")
 
-    # Call the function
-    result = _safe_is_nan_or_null_expr(mock_df, mock_col_expr, "float_col")
+    evaluated = df.select(result).to_native()["str_col"].to_list()
+    assert evaluated == [False, True, False]
 
-    # Should fall back to null check only when is_nan() fails
-    # The result is what is_null() returned (since null_check = column_expr.is_null())
-    assert result == mock_is_null_result
-    mock_col_expr.is_null.assert_called_once()
-    mock_col_expr.is_nan.assert_called_once()
+
+def test_safe_is_nan_or_null_expr_lazy_polars():
+    """Works with a Polars LazyFrame."""
+    import narwhals as nw
+
+    df = nw.from_native(pl.DataFrame({"x": [1.0, float("nan"), None]}).lazy())
+    col_expr = nw.col("x")
+    result = _safe_is_nan_or_null_expr(df, col_expr, "x")
+
+    evaluated = df.select(result).collect().to_native()["x"].to_list()
+    assert evaluated == [False, True, True]
+
+
+def test_safe_is_nan_or_null_expr_eager_polars():
+    """Works with an eager Polars DataFrame."""
+    import narwhals as nw
+
+    df = nw.from_native(pl.DataFrame({"x": [1.0, float("nan"), None]}))
+    col_expr = nw.col("x")
+    result = _safe_is_nan_or_null_expr(df, col_expr, "x")
+
+    evaluated = df.select(result).to_native()["x"].to_list()
+    assert evaluated == [False, True, True]
+
+
+def test_safe_is_nan_or_null_expr_eager_pandas():
+    """Works with an eager Pandas DataFrame."""
+    import narwhals as nw
+
+    df = nw.from_native(pd.DataFrame({"x": [1.0, float("nan"), None]}))
+    col_expr = nw.col("x")
+    result = _safe_is_nan_or_null_expr(df, col_expr, "x")
+
+    evaluated = df.select(result).to_native()["x"].tolist()
+    assert evaluated == [False, True, True]
+
+
+def test_safe_is_nan_or_null_expr_ibis_sqlite():
+    """Works with an Ibis SQLite backend (should only do null checks)."""
+    import ibis
+    import narwhals as nw
+
+    con = ibis.sqlite.connect()
+    t = con.create_table("test", pd.DataFrame({"x": [1.0, None, 3.0]}))
+    nw_tbl = nw.from_native(t)
+    col_expr = nw.col("x")
+
+    result = _safe_is_nan_or_null_expr(nw_tbl, col_expr, "x")
+
+    evaluated = nw_tbl.select(result).to_native().to_pandas()["x"].tolist()
+    assert evaluated == [False, True, False]
+
+
+def test_safe_modify_datetime_lazy_polars():
+    """Works with a Polars LazyFrame."""
+    import datetime
+    import narwhals as nw
+
+    df = nw.from_native(pl.DataFrame({"d": [datetime.date(2023, 6, 1)]}).lazy())
+    result = _safe_modify_datetime_compare_val(df, "d", datetime.datetime(2023, 1, 1, 12, 0))
+
+    assert isinstance(result, datetime.date)
+    assert not isinstance(result, datetime.datetime)
+
+
+def test_safe_modify_datetime_eager_pandas():
+    """Works with an eager Pandas DataFrame."""
+    import datetime
+    import narwhals as nw
+
+    df = nw.from_native(pd.DataFrame({"d": [datetime.date(2023, 6, 1)]}))
+    result = _safe_modify_datetime_compare_val(df, "d", datetime.datetime(2023, 1, 1, 12, 0))
+
+    assert isinstance(result, datetime.date)
+    assert not isinstance(result, datetime.datetime)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_agg.py
+++ b/tests/test_agg.py
@@ -1,4 +1,5 @@
 import pytest
+from itertools import product
 
 from pointblank import Validate, ref
 import polars as pl
@@ -1139,3 +1140,43 @@ def test_agg_report_multiple_steps_formatting():
 
     # Step 3: Value with asymmetric tolerance
     assert "2.0<br/>tol=(0.1, 0.2)" in html
+
+
+@pytest.mark.parametrize(
+    ("data_eager", "ref_eager"),
+    list(product([True, False], repeat=2)),
+    ids=[
+        "data=eager,ref=eager",
+        "data=eager,ref=lazy",
+        "data=lazy,ref=eager",
+        "data=lazy,ref=lazy",
+    ],
+)
+def test_agg_with_reference_dataframe_types(
+    matching_data: pl.DataFrame,
+    reference_data: pl.DataFrame,
+    data_eager: bool,
+    ref_eager: bool,
+):
+    data = matching_data if data_eager else matching_data.lazy()
+    reference = reference_data if ref_eager else reference_data.lazy()
+
+    v = (
+        Validate(data=data, reference=reference)
+        .col_sum_eq("a", ref("a"))
+        .col_sum_eq("b", ref("b"))
+        .col_avg_eq("a", ref("a"))
+        .col_avg_eq("b", ref("b"))
+        .interrogate()
+    )
+    v.assert_passing()
+
+    v = (
+        Validate(data=data, reference=reference)
+        .col_sum_eq("a")
+        .col_sum_eq("b")
+        .col_avg_eq("a")
+        .col_avg_eq("b")
+        .interrogate()
+    )
+    v.assert_passing()


### PR DESCRIPTION
# Summary

I was having some unexpected performance issues at work, I had a hunch it had to do with early materializations. I removed an early collect and I seemed to have huge performance boosts without regression. However, it's really hard to evaluate it without a proper full benchmarking. Regardless, it was an early collect so it should be better objectively, just not sure how much.

Been using claude to help search big codebases like this, it would've taken me a lot longer to find the early collect without it :)

# Related GitHub Issues and PRs

- Ref: #

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
