### PR TITLE
feat: add locale code preset

### DIFF
--- a/docs/user-guide/test-data-generation.qmd
+++ b/docs/user-guide/test-data-generation.qmd
@@ -257,6 +257,7 @@ The `preset=` parameter in `string_field()` supports many data types:
 - `file_extension`: file extension
 - `mime_type`: MIME type
 - `user_agent`: browser user agent string (country-weighted)
+- `locale_code`: locale identifier (e.g., `"en_US"`, `"de_DE"`; multilingual countries return a random official locale)
 
 ## Profile Fields
 

--- a/pointblank/countries/__init__.py
+++ b/pointblank/countries/__init__.py
@@ -335,6 +335,112 @@ COUNTRIES_WITH_FULL_DATA: list[str] = [
 ]
 
 # Comprehensive country info mapping: alpha-2 -> (alpha-3, English name)
+# Maps each supported country code to its locale code(s).
+# For multilingual countries, multiple locale codes are listed in order of prevalence;
+# the generator randomly selects one per row.
+_COUNTRY_LOCALE_CODES: dict[str, list[str]] = {
+    "AE": ["ar_AE"],
+    "AM": ["hy_AM"],
+    "AR": ["es_AR"],
+    "AT": ["de_AT"],
+    "AU": ["en_AU"],
+    "AZ": ["az_AZ"],
+    "BD": ["bn_BD"],
+    "BE": ["nl_BE", "fr_BE", "de_BE"],
+    "BG": ["bg_BG"],
+    "BO": ["es_BO"],
+    "BR": ["pt_BR"],
+    "CA": ["en_CA", "fr_CA"],
+    "CH": ["de_CH", "fr_CH", "it_CH"],
+    "CL": ["es_CL"],
+    "CM": ["fr_CM", "en_CM"],
+    "CN": ["zh_CN"],
+    "CO": ["es_CO"],
+    "CR": ["es_CR"],
+    "CY": ["el_CY", "tr_CY"],
+    "CZ": ["cs_CZ"],
+    "DE": ["de_DE"],
+    "DK": ["da_DK"],
+    "DO": ["es_DO"],
+    "DZ": ["ar_DZ", "fr_DZ"],
+    "EC": ["es_EC"],
+    "EE": ["et_EE"],
+    "EG": ["ar_EG"],
+    "ES": ["es_ES"],
+    "ET": ["am_ET"],
+    "FI": ["fi_FI"],
+    "FR": ["fr_FR"],
+    "GB": ["en_GB"],
+    "GE": ["ka_GE"],
+    "GH": ["en_GH"],
+    "GR": ["el_GR"],
+    "GT": ["es_GT"],
+    "HK": ["zh_HK", "en_HK"],
+    "HN": ["es_HN"],
+    "HR": ["hr_HR"],
+    "HU": ["hu_HU"],
+    "ID": ["id_ID"],
+    "IE": ["en_IE", "ga_IE"],
+    "IL": ["he_IL", "ar_IL"],
+    "IN": ["hi_IN", "en_IN"],
+    "IS": ["is_IS"],
+    "IT": ["it_IT"],
+    "JM": ["en_JM"],
+    "JO": ["ar_JO"],
+    "JP": ["ja_JP"],
+    "KE": ["en_KE", "sw_KE"],
+    "KH": ["km_KH"],
+    "KR": ["ko_KR"],
+    "KZ": ["kk_KZ", "ru_KZ"],
+    "LB": ["ar_LB", "fr_LB"],
+    "LK": ["si_LK", "ta_LK"],
+    "LT": ["lt_LT"],
+    "LU": ["lb_LU", "fr_LU", "de_LU"],
+    "LV": ["lv_LV"],
+    "MA": ["ar_MA", "fr_MA"],
+    "MD": ["ro_MD", "ru_MD"],
+    "MM": ["my_MM"],
+    "MT": ["mt_MT", "en_MT"],
+    "MX": ["es_MX"],
+    "MY": ["ms_MY", "en_MY"],
+    "MZ": ["pt_MZ"],
+    "NG": ["en_NG"],
+    "NL": ["nl_NL"],
+    "NO": ["nb_NO", "nn_NO"],
+    "NP": ["ne_NP"],
+    "NZ": ["en_NZ"],
+    "PA": ["es_PA"],
+    "PE": ["es_PE"],
+    "PH": ["en_PH", "tl_PH"],
+    "PK": ["ur_PK", "en_PK"],
+    "PL": ["pl_PL"],
+    "PT": ["pt_PT"],
+    "PY": ["es_PY", "gn_PY"],
+    "RO": ["ro_RO"],
+    "RS": ["sr_RS"],
+    "RU": ["ru_RU"],
+    "RW": ["rw_RW", "en_RW", "fr_RW"],
+    "SA": ["ar_SA"],
+    "SE": ["sv_SE"],
+    "SG": ["en_SG", "zh_SG", "ms_SG", "ta_SG"],
+    "SI": ["sl_SI"],
+    "SK": ["sk_SK"],
+    "SN": ["fr_SN"],
+    "SV": ["es_SV"],
+    "TH": ["th_TH"],
+    "TN": ["ar_TN", "fr_TN"],
+    "TR": ["tr_TR"],
+    "TW": ["zh_TW"],
+    "TZ": ["sw_TZ", "en_TZ"],
+    "UA": ["uk_UA"],
+    "UG": ["en_UG", "sw_UG"],
+    "US": ["en_US"],
+    "UY": ["es_UY"],
+    "UZ": ["uz_UZ", "ru_UZ"],
+    "VN": ["vi_VN"],
+    "ZA": ["en_ZA", "af_ZA", "zu_ZA"],
+}
+
 COUNTRY_INFO: dict[str, tuple[str, str]] = {
     "AD": ("AND", "Andorra"),
     "AE": ("ARE", "United Arab Emirates"),
@@ -1731,6 +1837,18 @@ class LocaleGenerator:
             if normalized == self.country_code and len(code) == 3:
                 return code
         return self.country_code
+
+    def locale_code(self) -> str:
+        """Generate a locale code derived from this country.
+
+        Returns a standard locale identifier in ``language_COUNTRY`` format
+        (e.g., ``"en_US"``, ``"de_DE"``). For multilingual countries, one of
+        the country's official locale codes is selected at random.
+        """
+        codes = _COUNTRY_LOCALE_CODES.get(self.country_code, [f"en_{self.country_code}"])
+        if len(codes) == 1:
+            return codes[0]
+        return self.rng.choice(codes)
 
     def postcode(self) -> str:
         """Generate a random postal code (coherent with current location context)."""

--- a/pointblank/field.py
+++ b/pointblank/field.py
@@ -94,6 +94,7 @@ AVAILABLE_PRESETS = frozenset(
         "file_extension",
         "mime_type",
         "user_agent",
+        "locale_code",
     }
 )
 
@@ -881,7 +882,9 @@ def string_field(
     (up to 10 years back), `"time"`
 
     **Miscellaneous:** `"color_name"`, `"file_name"`, `"file_extension"`, `"mime_type"`,
-    `"user_agent"` (browser user agent string with country-specific browser weighting)
+    `"user_agent"` (browser user agent string with country-specific browser weighting),
+    `"locale_code"` (locale identifier like `"en_US"`, `"de_DE"`; multilingual countries
+    return a random official locale)
 
     Coherent Data Generation
     ------------------------

--- a/pointblank/generate/generators.py
+++ b/pointblank/generate/generators.py
@@ -162,6 +162,7 @@ def _generate_from_preset(preset: str, generator: LocaleGenerator) -> str:
         "file_extension": generator.file_extension,
         "mime_type": generator.mime_type,
         "user_agent": generator.user_agent,
+        "locale_code": generator.locale_code,
     }
 
     generator = preset_mapping.get(preset)

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -1662,6 +1662,9 @@ def generate_dataset(
       integer columns named `age` are automatically constrained to working-age range (22--65).
     - **Financial presets** (`"iban"`, `"ssn"`, `"license_plate"`): produce identifiers in the
       format used by the specified country.
+    - **Locale preset** (`"locale_code"`): returns a locale identifier (e.g., `"en_US"`,
+      `"de_DE"`) derived from the country. Multilingual countries randomly select among their
+      official locale codes (e.g., `"CH"` yields `"de_CH"`, `"fr_CH"`, or `"it_CH"`).
 
     When multiple columns in the same schema use related presets, the generated data is
     automatically coherent across those columns within each row. Person-related presets will share

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -952,6 +952,78 @@ class TestCountrySupport:
 
         assert validation.all_passed()
 
+    def test_locale_code_preset_single_language_countries(self):
+        """Test locale_code preset returns correct codes for single-language countries."""
+        pytest.importorskip("polars")
+        from pointblank import Schema, Validate, generate_dataset, string_field
+
+        schema = Schema(locale_code=string_field(preset="locale_code"))
+
+        expected = {
+            "US": ["en_US"],
+            "DE": ["de_DE"],
+            "FR": ["fr_FR"],
+            "JP": ["ja_JP"],
+            "BR": ["pt_BR"],
+            "PL": ["pl_PL"],
+            "IT": ["it_IT"],
+            "KR": ["ko_KR"],
+        }
+
+        for country, codes in expected.items():
+            df = generate_dataset(schema, n=5, seed=23, country=country)
+
+            validation = (
+                Validate(df)
+                .col_vals_not_null(columns="locale_code")
+                .col_vals_in_set(columns="locale_code", set=codes)
+                .interrogate()
+            )
+
+            assert validation.all_passed(), f"Failed for country {country}"
+
+    def test_locale_code_preset_multilingual_countries(self):
+        """Test locale_code preset returns valid codes for multilingual countries."""
+        pytest.importorskip("polars")
+        from pointblank import Schema, Validate, generate_dataset, string_field
+
+        schema = Schema(locale_code=string_field(preset="locale_code"))
+
+        multilingual = {
+            "BE": ["nl_BE", "fr_BE", "de_BE"],
+            "CH": ["de_CH", "fr_CH", "it_CH"],
+            "CA": ["en_CA", "fr_CA"],
+            "SG": ["en_SG", "zh_SG", "ms_SG", "ta_SG"],
+            "ZA": ["en_ZA", "af_ZA", "zu_ZA"],
+        }
+
+        for country, valid_codes in multilingual.items():
+            df = generate_dataset(schema, n=50, seed=23, country=country)
+
+            validation = (
+                Validate(df)
+                .col_vals_not_null(columns="locale_code")
+                .col_vals_in_set(columns="locale_code", set=valid_codes)
+                .interrogate()
+            )
+
+            assert validation.all_passed(), f"Failed for country {country}"
+
+    def test_locale_code_preset_format(self):
+        """Test locale_code values match the expected xx_XX pattern."""
+        pytest.importorskip("polars")
+        from pointblank import Schema, generate_dataset, string_field
+
+        schema = Schema(locale_code=string_field(preset="locale_code"))
+
+        for country in ["US", "DE", "CH", "JP", "IN"]:
+            df = generate_dataset(schema, n=10, seed=23, country=country)
+            for val in df["locale_code"].to_list():
+                parts = val.split("_")
+                assert len(parts) == 2, f"Bad format: {val}"
+                assert parts[0].islower(), f"Language part not lowercase: {val}"
+                assert parts[1].isupper(), f"Country part not uppercase: {val}"
+
     def test_business_presets_across_countries(self):
         """Test business data presets work across multiple countries."""
         pytest.importorskip("polars")


### PR DESCRIPTION
This PR introduces a new `"locale_code"` preset to the data generation framework, enabling the creation of locale identifiers (such as `"en_US"` or `"de_DE"`) that are coherent with the specified country. For multilingual countries, the generator randomly selects from a list of official locale codes.