### PR TITLE
feat: data generation with gender string field

### DIFF
--- a/docs/user-guide/test-data-generation.qmd
+++ b/docs/user-guide/test-data-generation.qmd
@@ -183,6 +183,7 @@ The `preset=` parameter in `string_field()` supports many data types:
 - `name_full`: full name with optional prefix/suffix (e.g., "Dr. Ana Sousa", "Prof. Tanaka Yuki")
 - `first_name`: first name only
 - `last_name`: last name only
+- `gender`: person's gender (`"male"` or `"female"`), coherent with name fields
 - `email`: email address
 - `phone_number`: phone number in country-specific format
 

--- a/pointblank/countries/__init__.py
+++ b/pointblank/countries/__init__.py
@@ -1262,6 +1262,16 @@ class LocaleGenerator:
         person = self._get_current_person()
         return person.get("last_name", "Smith")
 
+    def gender(self) -> str:
+        """Return the gender of the current person (coherent with other person fields).
+
+        Returns 'male' or 'female' based on the current person context. When used
+        alongside other person-related presets (first_name, last_name, email, etc.),
+        the gender will be coherent with those fields.
+        """
+        person = self._get_current_person()
+        return person.get("gender", "female")
+
     def name(self, gender: str | None = None) -> str:
         """Generate a simple full name (first + last, coherent with current person context).
 

--- a/pointblank/field.py
+++ b/pointblank/field.py
@@ -39,6 +39,7 @@ AVAILABLE_PRESETS = frozenset(
         "name_full",
         "first_name",
         "last_name",
+        "gender",
         "email",
         "phone_number",
         "address",

--- a/pointblank/field.py
+++ b/pointblank/field.py
@@ -857,8 +857,9 @@ def string_field(
     for region-specific formatting (e.g., address formats, phone number patterns).
 
     **Personal:** `"name"` (first + last name), `"name_full"` (full name with possible prefix
-    or suffix), `"first_name"`, `"last_name"`, `"email"` (realistic email address),
-    `"phone_number"`, `"address"` (full street address), `"city"`, `"state"`, `"country"`,
+    or suffix), `"first_name"`, `"last_name"`, `"gender"` (person's gender, coherent with
+    name), `"email"` (realistic email address), `"phone_number"`, `"address"` (full street
+    address), `"city"`, `"state"`, `"country"`,
     `"country_code_2"` (ISO 3166-1 alpha-2 code, e.g., `"US"`), `"country_code_3"` (ISO
     3166-1 alpha-3 code, e.g., `"USA"`), `"postcode"`, `"latitude"`, `"longitude"`
 
@@ -893,7 +894,8 @@ def string_field(
     coherent across those columns within each row. Specifically:
 
     - **Person-related presets** (`"name"`, `"name_full"`, `"first_name"`, `"last_name"`,
-      `"email"`, `"user_name"`): the email and username will be derived from the person's name.
+      `"gender"`, `"email"`, `"user_name"`): the email and username will be derived from the
+      person's name, and `"gender"` will match the person's first name.
     - **Address-related presets** (`"address"`, `"city"`, `"state"`, `"postcode"`,
       `"phone_number"`, `"latitude"`, `"longitude"`): the city, state, and postcode will
       correspond to the same location within the address.

--- a/pointblank/generate/generators.py
+++ b/pointblank/generate/generators.py
@@ -107,6 +107,7 @@ def _generate_from_preset(preset: str, generator: LocaleGenerator) -> str:
         "name_full": generator.name_full,
         "first_name": generator.first_name,
         "last_name": generator.last_name,
+        "gender": generator.gender,
         "email": generator.email,
         "phone_number": generator.phone_number,
         "address": generator.address,
@@ -464,7 +465,15 @@ ADDRESS_RELATED_PRESETS = {
     "longitude",
     "license_plate",
 }
-PERSON_RELATED_PRESETS = {"name", "name_full", "first_name", "last_name", "email", "user_name"}
+PERSON_RELATED_PRESETS = {
+    "name",
+    "name_full",
+    "first_name",
+    "last_name",
+    "gender",
+    "email",
+    "user_name",
+}
 BUSINESS_RELATED_PRESETS = {"job", "company"}
 
 # Default working-age bounds applied when business coherence is active


### PR DESCRIPTION
This PR adds support for generating a person's gender as a coherent preset in test data generation, ensuring that the gender field aligns with other person-related fields like name. The changes update documentation, code logic, and preset handling to integrate the new `"gender"` string preset.