### PR TITLE
feat: have credit card provider as a string preset for data generation 

### DIFF
--- a/docs/user-guide/test-data-generation.qmd
+++ b/docs/user-guide/test-data-generation.qmd
@@ -217,6 +217,7 @@ The `preset=` parameter in `string_field()` supports many data types:
 **Financial Data:**
 
 - `credit_card_number`: credit card number
+- `credit_card_provider`: card network name (Visa, Mastercard, American Express, or Discover); coherent with `credit_card_number`
 - `iban`: International Bank Account Number
 - `currency_code`: currency code (USD, EUR, etc.)
 

--- a/pointblank/countries/__init__.py
+++ b/pointblank/countries/__init__.py
@@ -2484,10 +2484,57 @@ class LocaleGenerator:
     # Financial
     # =========================================================================
 
+    # Credit card prefix caching for coherence between credit_card_number and
+    # credit_card_provider
+    _row_card_prefixes: list[str] | None = None
+
+    # Map card prefixes to provider names
+    _CARD_PREFIX_TO_PROVIDER: dict[str, str] = {
+        "4": "Visa",
+        "5": "Mastercard",
+        "37": "American Express",
+        "6011": "Discover",
+    }
+
+    # All supported card prefixes
+    _CARD_PREFIXES: list[str] = ["4", "5", "37", "6011"]
+
+    def init_row_card_prefixes(self, n_rows: int) -> None:
+        """Pre-generate card prefixes for multiple rows to ensure coherence.
+
+        When both credit_card_number and credit_card_provider are generated for each row,
+        this ensures they are consistent (e.g., a Visa card number and "Visa" provider).
+        """
+        self._row_card_prefixes = [self.rng.choice(self._CARD_PREFIXES) for _ in range(n_rows)]
+
+    def clear_row_card_prefixes(self) -> None:
+        """Clear pre-generated card prefixes."""
+        self._row_card_prefixes = None
+
+    def _get_current_card_prefix(self) -> str:
+        """Get the current card prefix, using row context if available.
+
+        When row-level coherence is active (both credit_card_number and credit_card_provider
+        in the schema), returns the pre-generated prefix for the current row.
+
+        When used standalone (without coherence), generates a fresh random prefix each call
+        so each row gets independent values.
+        """
+        # If row-level prefixes are active (coherence mode), use those
+        if self._row_card_prefixes is not None and self._current_row is not None:
+            return self._row_card_prefixes[self._current_row]
+
+        # Standalone mode: generate fresh prefix each call (no caching)
+        return self.rng.choice(self._CARD_PREFIXES)
+
     def credit_card_number(self) -> str:
-        """Generate a random credit card number (not valid for transactions)."""
-        # Generate a 16-digit number with valid Luhn checksum
-        prefix = self.rng.choice(["4", "5", "37", "6011"])  # Visa, MC, Amex, Discover
+        """Generate a random credit card number (not valid for transactions).
+
+        When used with credit_card_provider in the same schema, the card number
+        will be coherent with the provider (e.g., a Visa prefix for "Visa" provider).
+        """
+        # Use cached prefix for coherence with credit_card_provider
+        prefix = self._get_current_card_prefix()
         length = 15 if prefix == "37" else 16
 
         # Generate digits (minus check digit)
@@ -2500,6 +2547,17 @@ class LocaleGenerator:
         digits.append(str(check_digit))
 
         return "".join(digits)
+
+    def credit_card_provider(self) -> str:
+        """Return the credit card provider/network name.
+
+        Returns one of: "Visa", "Mastercard", "American Express", "Discover".
+
+        When used with credit_card_number in the same schema, the provider will be
+        coherent with the card number (e.g., "Visa" for a card starting with "4").
+        """
+        prefix = self._get_current_card_prefix()
+        return self._CARD_PREFIX_TO_PROVIDER[prefix]
 
     def _luhn_checksum(self, digits: list[str]) -> int:
         """Calculate Luhn check digit for a partial card number.

--- a/pointblank/field.py
+++ b/pointblank/field.py
@@ -69,6 +69,7 @@ AVAILABLE_PRESETS = frozenset(
         "word",
         # Financial
         "credit_card_number",
+        "credit_card_provider",
         "iban",
         "currency_code",
         # Identifiers
@@ -869,7 +870,8 @@ def string_field(
 
     **Text:** `"text"` (paragraph of text), `"sentence"`, `"paragraph"`, `"word"`
 
-    **Financial:** `"credit_card_number"`, `"iban"`, `"currency_code"`
+    **Financial:** `"credit_card_number"`, `"credit_card_provider"` (Visa, Mastercard,
+    American Express, or Discover), `"iban"`, `"currency_code"`
 
     **Identifiers:** `"uuid4"`, `"md5"` (MD5 hash, 32 hex chars), `"sha1"` (SHA-1 hash,
     40 hex chars), `"sha256"` (SHA-256 hash, 64 hex chars), `"ssn"` (social security number),
@@ -899,6 +901,8 @@ def string_field(
     - **Address-related presets** (`"address"`, `"city"`, `"state"`, `"postcode"`,
       `"phone_number"`, `"latitude"`, `"longitude"`): the city, state, and postcode will
       correspond to the same location within the address.
+    - **Credit card presets** (`"credit_card_number"`, `"credit_card_provider"`): the card
+      number prefix and provider name will be consistent (e.g., "Visa" with a "4"-prefixed number).
 
     This coherence is automatic and requires no additional configuration.
 

--- a/pointblank/generate/generators.py
+++ b/pointblank/generate/generators.py
@@ -137,6 +137,7 @@ def _generate_from_preset(preset: str, generator: LocaleGenerator) -> str:
         "word": generator.word,
         # Financial
         "credit_card_number": generator.credit_card_number,
+        "credit_card_provider": generator.credit_card_provider,
         "iban": generator.iban,
         "currency_code": generator.currency_code,
         # Identifiers
@@ -475,6 +476,7 @@ PERSON_RELATED_PRESETS = {
     "user_name",
 }
 BUSINESS_RELATED_PRESETS = {"job", "company"}
+CREDIT_CARD_RELATED_PRESETS = {"credit_card_number", "credit_card_provider"}
 
 # Default working-age bounds applied when business coherence is active
 _WORKING_AGE_MIN = 22
@@ -484,14 +486,17 @@ _WORKING_AGE_MAX = 65
 _AGE_COLUMN_RE = re.compile(r"(?:^|_)age(?:$|_)", re.IGNORECASE)
 
 
-def _get_coherence_needs(fields: dict[str, Field]) -> tuple[bool, bool, bool]:
+def _get_coherence_needs(fields: dict[str, Field]) -> tuple[bool, bool, bool, bool]:
     """Check what coherence is needed for the given fields."""
     needs_address = False
     needs_person = False
     needs_business = False
+    needs_credit_card = False
 
     found_job = False
     found_company = False
+    found_card_number = False
+    found_card_provider = False
 
     for field in fields.values():
         preset = getattr(field, "preset", None)
@@ -503,12 +508,20 @@ def _get_coherence_needs(fields: dict[str, Field]) -> tuple[bool, bool, bool]:
             found_job = True
         if preset == "company":
             found_company = True
+        if preset == "credit_card_number":
+            found_card_number = True
+        if preset == "credit_card_provider":
+            found_card_provider = True
 
     # Business coherence only needed when BOTH job and company are present
     if found_job and found_company:
         needs_business = True
 
-    return needs_address, needs_person, needs_business
+    # Credit card coherence only needed when BOTH number and provider are present
+    if found_card_number and found_card_provider:
+        needs_credit_card = True
+
+    return needs_address, needs_person, needs_business, needs_credit_card
 
 
 def _generate_column_with_row_context(
@@ -587,8 +600,8 @@ def _generate_single_country(
 ) -> dict[str, list[Any]]:
     """Generate data for a single country (original code path)."""
     # Check what coherence is needed
-    needs_address, needs_person, needs_business = _get_coherence_needs(fields)
-    needs_coherence = needs_address or needs_person or needs_business
+    needs_address, needs_person, needs_business, needs_credit_card = _get_coherence_needs(fields)
+    needs_coherence = needs_address or needs_person or needs_business or needs_credit_card
 
     # Set up shared locale generator if any coherence is needed
     shared_locale_gen = None
@@ -604,6 +617,8 @@ def _generate_single_country(
             if not needs_address:
                 shared_locale_gen.init_row_locations(config.n)
             shared_locale_gen.init_row_employers(config.n)
+        if needs_credit_card:
+            shared_locale_gen.init_row_card_prefixes(config.n)
 
     # Determine which presets need row context
     coherent_presets = set()
@@ -613,6 +628,8 @@ def _generate_single_country(
         coherent_presets.update(PERSON_RELATED_PRESETS)
     if needs_business:
         coherent_presets.update(BUSINESS_RELATED_PRESETS)
+    if needs_credit_card:
+        coherent_presets.update(CREDIT_CARD_RELATED_PRESETS)
 
     # When business coherence is active, constrain age-like integer columns to
     # working-age range so generated data doesn't have 15-year-old professionals
@@ -652,6 +669,8 @@ def _generate_single_country(
             shared_locale_gen.clear_row_persons()
         if needs_business:
             shared_locale_gen.clear_row_employers()
+        if needs_credit_card:
+            shared_locale_gen.clear_row_card_prefixes()
 
     return data
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1666,6 +1666,106 @@ class TestGeneratorValidation:
 
         assert validation.all_passed()
 
+    def test_credit_card_provider_returns_valid_providers(self):
+        """Ensure credit_card_provider returns valid card network names."""
+        pytest.importorskip("polars")
+        from pointblank import Schema, Validate, generate_dataset, string_field
+
+        schema = Schema(columns=[("provider", string_field(preset="credit_card_provider"))])
+        df = generate_dataset(schema, n=100, seed=23, country="US")
+
+        valid_providers = {"Visa", "Mastercard", "American Express", "Discover"}
+
+        # Validate all providers are in the expected set
+        validation = (
+            Validate(df)
+            .col_vals_not_null(columns="provider")
+            .col_vals_in_set(columns="provider", set=valid_providers)
+            .interrogate()
+        )
+
+        assert validation.all_passed()
+
+        # Verify we get a variety of providers (not all the same)
+        unique_providers = set(df["provider"].unique().to_list())
+        assert len(unique_providers) > 1, "Expected multiple different providers"
+
+    def test_credit_card_provider_and_number_coherence(self):
+        """Ensure credit_card_provider matches credit_card_number prefix."""
+        pytest.importorskip("polars")
+        from pointblank import Schema, generate_dataset, string_field
+
+        schema = Schema(
+            columns=[
+                ("card_number", string_field(preset="credit_card_number")),
+                ("card_provider", string_field(preset="credit_card_provider")),
+            ]
+        )
+
+        df = generate_dataset(schema, n=100, seed=42, country="US")
+
+        # Map prefixes to expected providers
+        PREFIX_TO_PROVIDER = {
+            "4": "Visa",
+            "5": "Mastercard",
+            "37": "American Express",
+            "6011": "Discover",
+        }
+
+        # Verify coherence: each card number prefix should match its provider
+        for i, row in enumerate(df.iter_rows()):
+            card_number, provider = row
+
+            # Determine expected provider from card number prefix
+            if card_number.startswith("4"):
+                expected = "Visa"
+            elif card_number.startswith("5"):
+                expected = "Mastercard"
+            elif card_number.startswith("37"):
+                expected = "American Express"
+            elif card_number.startswith("6011"):
+                expected = "Discover"
+            else:
+                expected = None
+
+            assert provider == expected, (
+                f"Row {i}: card_number={card_number[:6]}... has provider={provider}, "
+                f"expected={expected}"
+            )
+
+    def test_credit_card_provider_standalone_varies(self):
+        """Ensure standalone credit_card_provider generates varied values."""
+        pytest.importorskip("polars")
+        from pointblank import Schema, generate_dataset, string_field
+
+        # Without credit_card_number, provider should still vary per row
+        schema = Schema(columns=[("provider", string_field(preset="credit_card_provider"))])
+        df = generate_dataset(schema, n=50, seed=42, country="US")
+
+        providers = df["provider"].to_list()
+
+        # Should not all be the same value
+        unique_count = len(set(providers))
+        assert unique_count > 1, "Standalone credit_card_provider should vary per row"
+
+    def test_credit_card_provider_reproducible_with_seed(self):
+        """Same seed produces same credit card providers."""
+        pytest.importorskip("polars")
+        from pointblank import Schema, generate_dataset, string_field
+
+        schema = Schema(
+            columns=[
+                ("card_number", string_field(preset="credit_card_number")),
+                ("card_provider", string_field(preset="credit_card_provider")),
+            ]
+        )
+
+        df1 = generate_dataset(schema, n=20, seed=99, country="US")
+        df2 = generate_dataset(schema, n=20, seed=99, country="US")
+
+        assert df1["card_number"].to_list() == df2["card_number"].to_list()
+        assert df1["card_provider"].to_list() == df2["card_provider"].to_list()
+
 
 class TestUserAgentPreset:
     """Tests for the user_agent preset with country-specific browser weighting."""


### PR DESCRIPTION
This PR introduces a new `credit_card_provider` preset for generating coherent credit card provider data alongside credit card numbers. The changes ensure that when both `credit_card_number` and `credit_card_provider` are used in a schema, their values are consistent (e.g., a Visa card number is paired with "Visa" as the provider). The implementation also adds tests and updates documentation to reflect the new feature.