### PR TITLE
Add AzureOpenAI as a model provider to `DraftValidation`

### DIFF
--- a/pointblank/draft.py
+++ b/pointblank/draft.py
@@ -258,9 +258,9 @@ class DraftValidation:
             )
 
         # Read the API/examples text from a file
-        with files("pointblank.data").joinpath("api-docs.txt").open(
-            encoding="utf-8"
-        ) as f:  # pragma: no cover
+        with (
+            files("pointblank.data").joinpath("api-docs.txt").open(encoding="utf-8") as f
+        ):  # pragma: no cover
             api_and_examples_text = f.read()
 
         # Get the model name from the `model` value

--- a/pointblank/draft.py
+++ b/pointblank/draft.py
@@ -22,9 +22,9 @@ class DraftValidation:
     starting point for validating a table. This can be useful when you have a new table and you
     want to get a sense of how to validate it (and adjustments could always be made later). The
     `DraftValidation` class uses the `chatlas` package to draft a validation plan for a given table
-    using an LLM from either the `"anthropic"`, `"openai"`, `"ollama"` or `"bedrock"` provider. You
-    can install all requirements for the class through an optional 'generate' install of Pointblank
-    via `pip install pointblank[generate]`.
+    using an LLM from the `"anthropic"`, `"openai"`, `"ollama"`, `"bedrock"`, or `"azure-openai"`
+    provider. You can install all requirements for the class through an optional 'generate' install
+    of Pointblank via `pip install pointblank[generate]`.
 
     :::{.callout-warning}
     The `DraftValidation` class is still experimental. Please report any issues you encounter in
@@ -38,7 +38,8 @@ class DraftValidation:
     model
         The model to be used. This should be in the form of `provider:model` (e.g.,
         `"anthropic:claude-opus-4-6"`). Supported providers are `"anthropic"`, `"openai"`,
-        `"ollama"`, and `"bedrock"`.
+        `"ollama"`, `"bedrock"`, and `"azure-openai"`. For `"azure-openai"`, the value after the
+        colon is the Azure *deployment id*, not an OpenAI model id.
     api_key
         The API key to be used for the model.
     verify_ssl
@@ -61,9 +62,15 @@ class DraftValidation:
     - `"openai"` (OpenAI)
     - `"ollama"` (Ollama)
     - `"bedrock"` (Amazon Bedrock)
+    - `"azure-openai"` (Azure OpenAI)
 
     The model name should be the specific model to be used from the provider. Model names are
     subject to change so consult the provider's documentation for the most up-to-date model names.
+    For `"azure-openai"`, the value after the colon is the Azure *deployment id* (the name you
+    assigned when deploying the model in your Azure OpenAI resource). It also requires the
+    environment variables `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT` (e.g.,
+    `https://<resource>.openai.azure.com`), and `OPENAI_API_VERSION` (e.g., `"2024-06-01"`) to
+    be set.
 
     Notes on Authentication
     -----------------------
@@ -251,7 +258,9 @@ class DraftValidation:
             )
 
         # Read the API/examples text from a file
-        with files("pointblank.data").joinpath("api-docs.txt").open() as f:  # pragma: no cover
+        with files("pointblank.data").joinpath("api-docs.txt").open(
+            encoding="utf-8"
+        ) as f:  # pragma: no cover
             api_and_examples_text = f.read()
 
         # Get the model name from the `model` value
@@ -385,6 +394,41 @@ class DraftValidation:
 
             chat = ChatBedrockAnthropic(  # pragma: no cover
                 model=model_name,
+                system_prompt="You are a terse assistant and a Python expert.",
+                kwargs={"http_client": http_client},
+            )
+
+        if provider == "azure-openai":  # pragma: no cover
+            try:
+                import openai  # noqa
+            except ImportError:  # pragma: no cover
+                raise ImportError(  # pragma: no cover
+                    "The `openai` package is required to use the `DraftValidation` class with "
+                    "the `azure-openai` provider. Please install it using `pip install openai`."
+                )
+
+            import os
+
+            endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+            api_version = os.getenv("OPENAI_API_VERSION")
+            if not endpoint:
+                raise ValueError(
+                    "AZURE_OPENAI_ENDPOINT environment variable must be set to use "
+                    "the 'azure-openai' provider."
+                )
+            if not api_version:
+                raise ValueError(
+                    "OPENAI_API_VERSION environment variable must be set to use "
+                    "the 'azure-openai' provider (e.g. '2024-06-01')."
+                )
+
+            from chatlas import ChatAzureOpenAI  # pragma: no cover
+
+            chat = ChatAzureOpenAI(  # pragma: no cover
+                endpoint=endpoint,
+                deployment_id=model_name,
+                api_version=api_version,
+                api_key=self.api_key,
                 system_prompt="You are a terse assistant and a Python expert.",
                 kwargs={"http_client": http_client},
             )

--- a/tests/test_draft.py
+++ b/tests/test_draft.py
@@ -18,3 +18,23 @@ def test_draft_fail_invalid_provider():
 
     with pytest.raises(ValueError):
         DraftValidation(data=small_table, model="invalid:model")
+
+
+def test_draft_fail_azure_openai_missing_endpoint(monkeypatch):
+    pytest.importorskip("openai")
+    pytest.importorskip("chatlas")
+    monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+    monkeypatch.setenv("OPENAI_API_VERSION", "2024-06-01")
+    small_table = load_dataset(dataset="small_table")
+    with pytest.raises(ValueError, match="AZURE_OPENAI_ENDPOINT"):
+        DraftValidation(data=small_table, model="azure-openai:my-deployment")
+
+
+def test_draft_fail_azure_openai_missing_api_version(monkeypatch):
+    pytest.importorskip("openai")
+    pytest.importorskip("chatlas")
+    monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+    monkeypatch.delenv("OPENAI_API_VERSION", raising=False)
+    small_table = load_dataset(dataset="small_table")
+    with pytest.raises(ValueError, match="OPENAI_API_VERSION"):
+        DraftValidation(data=small_table, model="azure-openai:my-deployment")

--- a/user_guide/02-advanced-validation/04-draft-validation.qmd
+++ b/user_guide/02-advanced-validation/04-draft-validation.qmd
@@ -49,6 +49,7 @@ The `DraftValidation` class supports multiple LLM providers:
 - **OpenAI** (GPT models)
 - **Ollama** (local LLMs)
 - **Amazon Bedrock** (AWS-hosted models)
+- **Azure OpenAI** (OpenAI models deployed on Azure)
 
 Each provider has different capabilities and performance characteristics, but all can be used to
 generate validation plans through a consistent interface.
@@ -171,6 +172,11 @@ You can also store API keys in a `.env` file in your project's root directory:
 # Contents of .env file
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
+
+# For Azure OpenAI, three variables are required:
+AZURE_OPENAI_API_KEY=your_azure_openai_api_key_here
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+OPENAI_API_VERSION=2025-03-01-preview
 ```
 
 If your API keys have standard names (like `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`),
@@ -280,6 +286,10 @@ pb.DraftValidation(data=data, model="ollama:llama3:latest")
 
 # Using Amazon Bedrock
 pb.DraftValidation(data=data, model="bedrock:anthropic.claude-3-sonnet-20240229-v1:0")
+
+# Using Azure OpenAI (the value after the colon is the Azure deployment id, not an OpenAI model id;
+# requires AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, and OPENAI_API_VERSION env vars)
+pb.DraftValidation(data=data, model="azure-openai:my-gpt4-deployment")
 ```
 
 ### Model Performance and Privacy


### PR DESCRIPTION
# Summary

- `pointblank/draft.py`: new `azure-openai` branch in `__post_init__` after the bedrock block, mirroring the `_utils_ai.py` pattern but using `self.api_key` and the draft-specific system prompt. Docstring updated in three places: class summary, model parameter description, and the "Constructing the model Argument" block (now lists five providers and explains the :deployment_id convention plus required env vars).
- `pointblank/draft.py:254`: fixed an unrelated latent Windows bug where api-docs.txt was being read with the platform default encoding (cp1252 on Windows), which crashed on non-latin1 bytes. Now uses encoding="utf-8". This only surfaced because the new tests reach further into `__post_init__` than the old ones.
- `user_guide/02-advanced-validation/04-draft-validation.qmd`: added Azure OpenAI to the supported-providers list, to the `.env` sample, and to the model-specification examples.
- `tests/test_draft.py`: two new tests covering the missing-endpoint and missing-api-version ValueError paths, following the existing `monkeypatch/importorskip` style from `test__utils_ai.py`.

# Example Usage

Reproducible Test Code
```
import pointblank as pb
import os
from dotenv import load_dotenv

load_dotenv(override=True)

api_key = os.getenv("AZURE_OPENAI_API_KEY")

data = pb.load_dataset(dataset="global_sales", tbl_type="polars")

# Generate a validation plan
pb.DraftValidation(
    data=data,
    model="azure-openai:gpt-5.4",
    api_key=api_key
)
```

Expected Output
```
import pointblank as pb

# Define schema based on column names and dtypes
schema = pb.Schema(
    columns=[
        ("product_id", "String"),
        ("product_category", "String"),
        ("customer_id", "String"),
        ("customer_segment", "String"),
        ("region", "String"),
        ("country", "String"),
        ("city", "String"),
        ("timestamp", "Datetime(time_unit='us', time_zone=None)"),
        ("quarter", "String"),
        ("month", "Int64"),
        ("year", "Int64"),
        ("price", "Float64"),
        ("quantity", "Int64"),
        ("status", "String"),
        ("email", "String"),
        ("revenue", "Float64"),
        ("tax", "Float64"),
        ("total", "Float64"),
        ("payment_method", "String"),
        ("sales_channel", "String"),
    ]
)

# The validation plan
validation = (
    pb.Validate(
        data=your_data,  # Replace your_data with the actual data variable
        label="Draft Validation",
        thresholds=pb.Thresholds(warning=0.10, error=0.25, critical=0.35)
    )
    .col_schema_match(schema=schema)
    .col_count_match(count=20)
    .row_count_match(count=50000)
    .rows_distinct()
    .col_vals_not_null(
        columns=[
            "product_category",
            "customer_segment",
            "region",
            "country",
            "month",
            "year",
            "price",
            "quantity",
            "status",
            "email",
            "revenue",
            "tax",
            "total",
            "payment_method",
            "sales_channel",
        ]
    )
    .col_vals_between(
        columns="month",
        left=1,
        right=12,
        na_pass=True
    )
    .col_vals_between(
        columns="year",
        left=2021,
        right=2023,
        na_pass=True
    )
    .col_vals_gt(
        columns="price",
        value=0,
        na_pass=False
    )
    .col_vals_gt(
        columns="quantity",
        value=0,
        na_pass=False
    )
    .col_vals_in_set(
        columns="status",
        set=[
            "pending",
            "processing",
            "shipped",
            "delivered",
            "returned",
            "cancelled",
        ]
    )
    .col_vals_within_spec(
        columns="email",
        spec="email"
    )
    .col_vals_gt(
        columns="revenue",
        value=0,
        na_pass=False
    )
    .col_vals_ge(
        columns="tax",
        value=0,
        na_pass=False
    )
    .col_vals_ge(
        columns="total",
        value=0,
        na_pass=False
    )
    .col_vals_in_set(
        columns="quarter",
        set=[
            "2021-Q1",
            "2021-Q2",
            "2021-Q3",
            "2021-Q4",
            "2022-Q1",
            "2022-Q2",
            "2022-Q3",
            "2022-Q4",
            "2023-Q1",
            "2023-Q2",
            "2023-Q3",
            "2023-Q4",
        ]
    )
    .col_vals_in_set(
        columns="region",
        set=[
            "North America",
            "Europe",
            "Asia Pacific",
        ]
    )
    .col_vals_in_set(
        columns="payment_method",
        set=[
            "Credit Card",
            "PayPal",
            "Bank Transfer",
            "Apple Pay",
            "Google Pay",
        ]
    )
    .col_vals_in_set(
        columns="sales_channel",
        set=[
            "Online",
            "Retail",
            "Distributor",
            "Partner",
            "Phone",
        ]
    )
    .interrogate()
)

validation
```


# Note

Make sure `OPENAI_API_VERSION` is set to `2025-03-01-preview` or later — the Azure OpenAI Responses API is only available on these versions.

# Related GitHub Issues and PRs

Fixes: https://github.com/posit-dev/pointblank/issues/386

# Checklist

- [ x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [ x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [ x] I have added **pytest** unit tests for any new functionality.
