### PR TITLE
feat: obtain a rich schema from any supported table to support synthetic data generation

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -250,10 +250,12 @@ reference:
 
     - title: Test Data Generation
       desc: >
-        Generate synthetic test data based on schema definitions. Use `generate_dataset()`
-        to create data from a Schema object.
+        Generate synthetic test data based on schema definitions. Use `generate_dataset()` to create
+        data from a Schema object, or `schema_from_tbl()` to infer a generation-ready schema from an
+        existing table (Polars, Pandas, or Ibis/DuckDB).
       contents:
         - generate_dataset
+        - schema_from_tbl
         - int_field
         - float_field
         - string_field

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -48,7 +48,7 @@ from pointblank.field import (
 from pointblank.generate.base import GeneratorConfig
 from pointblank.inspect import has_columns, has_rows
 from pointblank.integrations.otel import emit_otel
-from pointblank.schema import Schema, generate_dataset
+from pointblank.schema import Schema, generate_dataset, schema_from_df, schema_from_tbl
 from pointblank.segments import seg_group
 from pointblank.thresholds import Actions, FinalActions, Thresholds
 from pointblank.validate import (

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -48,7 +48,7 @@ from pointblank.field import (
 from pointblank.generate.base import GeneratorConfig
 from pointblank.inspect import has_columns, has_rows
 from pointblank.integrations.otel import emit_otel
-from pointblank.schema import Schema, generate_dataset, schema_from_df, schema_from_tbl
+from pointblank.schema import Schema, generate_dataset, schema_from_tbl
 from pointblank.segments import seg_group
 from pointblank.thresholds import Actions, FinalActions, Thresholds
 from pointblank.validate import (
@@ -133,6 +133,7 @@ __all__ = [
     "GeneratorConfig",
     # Data generation - convenience function
     "generate_dataset",
+    "schema_from_tbl",
     # Table inspection functions (for use with `active=`)
     "has_columns",
     "has_rows",

--- a/pointblank/generate/__init__.py
+++ b/pointblank/generate/__init__.py
@@ -9,9 +9,11 @@ from pointblank.generate.generators import (
     generate_column,
     generate_dataframe,
 )
+from pointblank.generate.inference import infer_fields_from_table
 
 __all__ = [
     "GeneratorConfig",
     "generate_column",
     "generate_dataframe",
+    "infer_fields_from_table",
 ]

--- a/pointblank/generate/inference.py
+++ b/pointblank/generate/inference.py
@@ -1,0 +1,647 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from pointblank.field import (
+    BoolField,
+    DateField,
+    DatetimeField,
+    DurationField,
+    Field,
+    FloatField,
+    IntField,
+    StringField,
+)
+
+if TYPE_CHECKING:
+    pass
+
+__all__ = ["infer_fields_from_table"]
+
+# ---------------------------------------------------------------------------
+# Preset detection: column-name heuristics
+# ---------------------------------------------------------------------------
+
+# Normalize a column name to snake_case for matching. Handles:
+# - camelCase / PascalCase: "firstName" -> "first_name"
+# - dot/space separators: "first.name", "First Name" -> "first_name"
+# - multiple separators: "First__Name" -> "first_name"
+_CAMEL_SPLIT_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+
+
+def _normalize_col_name(name: str) -> str:
+    """Normalize column name to lowercase snake_case for heuristic matching."""
+    # Insert underscores at camelCase boundaries
+    name = _CAMEL_SPLIT_RE.sub("_", name)
+    # Replace dots, spaces, dashes with underscores
+    name = re.sub(r"[\s.\-]+", "_", name)
+    # Collapse multiple underscores
+    name = re.sub(r"_+", "_", name)
+    return name.lower().strip("_")
+
+
+# Maps regex patterns (matched against normalized column names) to preset names.
+# Order matters: more specific patterns should come first. Matches across camelCase, PascalCase,
+# snake_case, dot.case, and abbreviations.
+_NAME_TO_PRESET: list[tuple[re.Pattern[str], str]] = [
+    # Identifiers
+    (re.compile(r"(?:^|_)(?:uu|gu)?id$"), None),  # bare "id" columns → role, not preset
+    (re.compile(r"(?:^|_)uuid(?:$|_|\d)"), "uuid4"),
+    (re.compile(r"(?:^|_)guid(?:$|_|\d)"), "uuid4"),
+    (re.compile(r"(?:^|_)iban(?:$|_|\d)"), "iban"),
+    (re.compile(r"(?:^|_)ssn(?:$|_|\d)"), "ssn"),
+    # Internet
+    (re.compile(r"(?:^|_)ipv6(?:$|_)"), "ipv6"),
+    (re.compile(r"(?:^|_)ipv4(?:$|_)"), "ipv4"),
+    (re.compile(r"(?:^|_)(?:ip_addr|ip_address|ip)(?:$|_)"), "ipv4"),
+    (re.compile(r"(?:^|_)(?:url|website|link|href|web|site|page|www)(?:$|_)"), "url"),
+    (re.compile(r"(?:^|_)(?:domain|domain_name)(?:$|_)"), "domain_name"),
+    (re.compile(r"(?:^|_)(?:user_?name|username|login)(?:$|_)"), "user_name"),
+    # Email (before name patterns)
+    (re.compile(r"(?:^|_)e?-?mail(?:$|_)"), "email"),
+    (re.compile(r"(?:^|_)email_?addr(?:ess)?(?:$|_)"), "email"),
+    # Phone
+    (re.compile(r"(?:^|_)(?:phone|tel|telephone|mobile|cell|fax)(?:$|_|_?num)"), "phone_number"),
+    # Address components (specific before generic)
+    (re.compile(r"(?:^|_)(?:zip|postal|postcode|zip_?code|plz)(?:$|_)"), "postcode"),
+    (
+        re.compile(r"(?:^|_)(?:state|province|prov|region|division|district|land|pref)(?:$|_)"),
+        "state",
+    ),
+    (re.compile(r"(?:^|_)(?:city|town|municipality|ort)(?:$|_)"), "city"),
+    (re.compile(r"(?:^|_)(?:address|street|addr|strasse|rue)(?:$|_)"), "address"),
+    (re.compile(r"(?:^|_)(?:country_?code|country_?cd|iso[23]|ctry)(?:$|_)"), "country_code_2"),
+    (re.compile(r"(?:^|_)country(?:$|_)"), "country"),
+    (re.compile(r"(?:^|_)(?:latitude|lat)(?:$|_)"), "latitude"),
+    (re.compile(r"(?:^|_)(?:longitude|lng|lon|long)(?:$|_)"), "longitude"),
+    # Person names (specific before generic)
+    (re.compile(r"(?:^|_)(?:first_?name|fname|given_?name|vorname)(?:$|_)"), "first_name"),
+    (
+        re.compile(r"(?:^|_)(?:last_?name|lname|surname|family_?name|nachname)(?:$|_)"),
+        "last_name",
+    ),
+    (re.compile(r"(?:^|_)(?:full_?name|name_full)(?:$|_)"), "name_full"),
+    (re.compile(r"(?:^|_)name(?:$|_)"), "name"),
+    # Business
+    (re.compile(r"(?:^|_)(?:company|org|organization|employer|firma)(?:$|_)"), "company"),
+    (re.compile(r"(?:^|_)(?:job|job_?title|position|occupation|beruf)(?:$|_)"), "job"),
+    # Financial
+    (re.compile(r"(?:^|_)(?:currency|curr|cy)(?:$|_)"), "currency_code"),
+]
+
+# Column-name patterns that indicate a role (not a preset) — used for
+# inferring uniqueness and ID-like behavior on non-string columns too.
+_ID_COLUMN_RE = re.compile(
+    r"(?:^|_)(?:uu|gu)?id(?:$|_)|"  # id, uid, guid, uuid
+    r"(?:^|_)\w+_id$|"  # user_id, order_id
+    r"^id_\w+",  # id_user
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Preset detection: value-based validators
+# ---------------------------------------------------------------------------
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+_IPV4_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+_URL_RE = re.compile(r"^https?://")
+
+
+def _validate_preset_values(preset: str, sample_values: list[str]) -> bool:
+    """Check whether a sample of values is consistent with a preset.
+
+    Uses proportion-based thresholds with different confidence levels for different presets.
+    """
+    if not sample_values:
+        return False
+
+    # Only validate presets where we have good heuristics
+    validators: dict[str, tuple[re.Pattern[str], float]] = {
+        "email": (_EMAIL_RE, 0.7),
+        "uuid4": (_UUID_RE, 0.8),
+        "ipv4": (_IPV4_RE, 0.8),
+        "url": (_URL_RE, 0.7),
+    }
+
+    entry = validators.get(preset)
+    if entry is None:
+        # No validator for this preset — trust the name heuristic
+        return True
+
+    pattern, threshold = entry
+    matches = sum(1 for v in sample_values if pattern.search(v))
+    return matches / len(sample_values) >= threshold
+
+
+def _validate_numeric_as_latitude(values: list[Any]) -> bool:
+    """Check if numeric values fall within valid latitude bounds [-90, 90]."""
+    non_null = [v for v in values if v is not None]
+    if not non_null:
+        return False
+    within = sum(1 for v in non_null if -90 <= float(v) <= 90)
+    return within / len(non_null) >= 0.9
+
+
+def _validate_numeric_as_longitude(values: list[Any]) -> bool:
+    """Check if numeric values fall within valid longitude bounds [-180, 180]."""
+    non_null = [v for v in values if v is not None]
+    if not non_null:
+        return False
+    within = sum(1 for v in non_null if -180 <= float(v) <= 180)
+    return within / len(non_null) >= 0.9
+
+
+def _detect_preset(col_name: str, sample_values: list[str]) -> str | None:
+    """Detect a preset for a string column from its name and values.
+
+    Uses a two-phase approach:
+
+    1. Name heuristics with camelCase/snake_case/dot.case normalization
+    2. Value-based validation with proportion thresholds
+    """
+    normalized = _normalize_col_name(col_name)
+
+    for pattern, preset in _NAME_TO_PRESET:
+        if preset is None:
+            continue  # role-only patterns (e.g., bare "id")
+        if pattern.search(normalized):
+            # Validate against actual values
+            if _validate_preset_values(preset, sample_values):
+                return preset
+
+    return None
+
+
+def _detect_numeric_role(col_name: str, values: list[Any]) -> str | None:
+    """Detect if a numeric column has a geographic role based on name + value bounds.
+
+    Returns 'latitude' or 'longitude' if detected, None otherwise. Checks both column name patterns
+    AND value bounds.
+    """
+    normalized = _normalize_col_name(col_name)
+
+    if re.search(r"(?:^|_)(?:latitude|lat)(?:$|_)", normalized):
+        if _validate_numeric_as_latitude(values):
+            return "latitude"
+
+    if re.search(r"(?:^|_)(?:longitude|lng|lon|long)(?:$|_)", normalized):
+        if _validate_numeric_as_longitude(values):
+            return "longitude"
+
+    return None
+
+
+def _is_id_column(col_name: str) -> bool:
+    """Detect if a column name suggests it's an identifier/primary key.
+
+    Recognizes patterns like "id", "user_id", "ID", "userId", "recordId", etc.
+    """
+    normalized = _normalize_col_name(col_name)
+    return bool(_ID_COLUMN_RE.search(normalized))
+
+
+# ---------------------------------------------------------------------------
+# Per-dtype inference
+# ---------------------------------------------------------------------------
+
+
+def _infer_int_field(
+    col_name: str,
+    values: list[Any],
+    null_count: int,
+    total_count: int,
+    categorical_threshold: int | float,
+) -> IntField:
+    """Infer an IntField from observed integer values."""
+    non_null = [v for v in values if v is not None]
+
+    kwargs: dict[str, Any] = {"dtype": "Int64"}
+
+    if non_null:
+        min_val = min(non_null)
+        max_val = max(non_null)
+        kwargs["min_val"] = int(min_val)
+        kwargs["max_val"] = int(max_val)
+
+        # Check uniqueness — also force unique if name looks like an ID column
+        is_unique = len(non_null) > 1 and len(set(non_null)) == len(non_null)
+        if is_unique or (_is_id_column(col_name) and is_unique):
+            kwargs["unique"] = True
+
+        # Categorical detection
+        unique_count = len(set(non_null))
+        threshold = (
+            categorical_threshold
+            if isinstance(categorical_threshold, int)
+            else int(categorical_threshold * total_count)
+        )
+        if unique_count <= threshold and not kwargs.get("unique", False):
+            kwargs["allowed"] = sorted(set(int(v) for v in non_null))
+            # Remove min/max when using allowed
+            kwargs.pop("min_val", None)
+            kwargs.pop("max_val", None)
+
+    # Nullability
+    if null_count > 0:
+        kwargs["nullable"] = True
+        kwargs["null_probability"] = round(null_count / total_count, 4)
+
+    return IntField(**kwargs)
+
+
+def _infer_float_field(
+    col_name: str,
+    values: list[Any],
+    null_count: int,
+    total_count: int,
+) -> FloatField | StringField:
+    """Infer a FloatField from observed float values.
+
+    May return a StringField with a preset if the column is detected as latitude/longitude,
+    following an approach that checks both column name AND value bounds for geographic roles.
+    """
+    non_null = [v for v in values if v is not None]
+
+    # Check for geographic role (name + value bounds validation)
+    geo_role = _detect_numeric_role(col_name, values)
+    if geo_role in ("latitude", "longitude"):
+        kwargs: dict[str, Any] = {"preset": geo_role}
+        if null_count > 0:
+            kwargs["nullable"] = True
+            kwargs["null_probability"] = round(null_count / total_count, 4)
+        return StringField(**kwargs)
+
+    kwargs = {"dtype": "Float64"}
+
+    if non_null:
+        kwargs["min_val"] = float(min(non_null))
+        kwargs["max_val"] = float(max(non_null))
+
+    # Nullability
+    if null_count > 0:
+        kwargs["nullable"] = True
+        kwargs["null_probability"] = round(null_count / total_count, 4)
+
+    return FloatField(**kwargs)
+
+
+def _infer_string_field(
+    col_name: str,
+    values: list[Any],
+    null_count: int,
+    total_count: int,
+    categorical_threshold: int | float,
+    detect_presets: bool,
+) -> StringField:
+    """Infer a StringField from observed string values."""
+    non_null = [str(v) for v in values if v is not None]
+
+    kwargs: dict[str, Any] = {}
+
+    # Try preset detection first
+    if detect_presets and non_null:
+        sample = non_null[:200]  # sample for validation
+        preset = _detect_preset(col_name, sample)
+        if preset is not None:
+            kwargs["preset"] = preset
+            # When using a preset, skip length/allowed inference
+            if null_count > 0:
+                kwargs["nullable"] = True
+                kwargs["null_probability"] = round(null_count / total_count, 4)
+            if len(non_null) > 1 and len(set(non_null)) == len(non_null):
+                kwargs["unique"] = True
+            return StringField(**kwargs)
+
+    # Categorical detection
+    if non_null:
+        unique_count = len(set(non_null))
+        threshold = (
+            categorical_threshold
+            if isinstance(categorical_threshold, int)
+            else int(categorical_threshold * total_count)
+        )
+        if unique_count <= threshold:
+            kwargs["allowed"] = sorted(set(non_null))
+        else:
+            # Length constraints
+            lengths = [len(s) for s in non_null]
+            kwargs["min_length"] = min(lengths)
+            kwargs["max_length"] = max(lengths)
+
+            # Uniqueness
+            if len(non_null) > 1 and unique_count == len(non_null):
+                kwargs["unique"] = True
+
+    # Nullability
+    if null_count > 0:
+        kwargs["nullable"] = True
+        kwargs["null_probability"] = round(null_count / total_count, 4)
+
+    return StringField(**kwargs)
+
+
+def _infer_bool_field(
+    values: list[Any],
+    null_count: int,
+    total_count: int,
+) -> BoolField:
+    """Infer a BoolField from observed boolean values."""
+    non_null = [v for v in values if v is not None]
+
+    kwargs: dict[str, Any] = {}
+
+    if non_null:
+        true_count = sum(1 for v in non_null if v)
+        kwargs["p_true"] = round(true_count / len(non_null), 4)
+
+    # Nullability
+    if null_count > 0:
+        kwargs["nullable"] = True
+        kwargs["null_probability"] = round(null_count / total_count, 4)
+
+    return BoolField(**kwargs)
+
+
+def _infer_date_field(
+    values: list[Any],
+    null_count: int,
+    total_count: int,
+) -> DateField:
+    """Infer a DateField from observed date values."""
+    non_null = [v for v in values if v is not None]
+
+    kwargs: dict[str, Any] = {}
+
+    if non_null:
+        kwargs["min_date"] = min(non_null)
+        kwargs["max_date"] = max(non_null)
+
+    # Nullability
+    if null_count > 0:
+        kwargs["nullable"] = True
+        kwargs["null_probability"] = round(null_count / total_count, 4)
+
+    return DateField(**kwargs)
+
+
+def _infer_datetime_field(
+    values: list[Any],
+    null_count: int,
+    total_count: int,
+) -> DatetimeField:
+    """Infer a DatetimeField from observed datetime values."""
+    non_null = [v for v in values if v is not None]
+
+    kwargs: dict[str, Any] = {}
+
+    if non_null:
+        kwargs["min_date"] = min(non_null)
+        kwargs["max_date"] = max(non_null)
+
+    # Nullability
+    if null_count > 0:
+        kwargs["nullable"] = True
+        kwargs["null_probability"] = round(null_count / total_count, 4)
+
+    return DatetimeField(**kwargs)
+
+
+def _infer_duration_field(
+    values: list[Any],
+    null_count: int,
+    total_count: int,
+) -> DurationField:
+    """Infer a DurationField from observed duration values."""
+    non_null = [v for v in values if v is not None]
+
+    kwargs: dict[str, Any] = {}
+
+    if non_null:
+        kwargs["min_duration"] = min(non_null)
+        kwargs["max_duration"] = max(non_null)
+
+    # Nullability
+    if null_count > 0:
+        kwargs["nullable"] = True
+        kwargs["null_probability"] = round(null_count / total_count, 4)
+
+    return DurationField(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Dtype classification helpers
+# ---------------------------------------------------------------------------
+
+_INT_DTYPES = {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}
+_FLOAT_DTYPES = {"float32", "float64"}
+
+
+def _classify_dtype(dtype_str: str) -> str:
+    """Classify a dtype string into a category: int, float, string, bool, date, datetime, duration."""
+    d = dtype_str.lower()
+
+    if d in _INT_DTYPES or "int" in d:
+        return "int"
+    if d in _FLOAT_DTYPES or "float" in d or d == "double":
+        return "float"
+    if d in ("bool", "boolean"):
+        return "bool"
+    if "datetime" in d or "timestamp" in d:
+        return "datetime"
+    if d == "date":
+        return "date"
+    if d == "time":
+        return "time"
+    if "duration" in d or "timedelta" in d:
+        return "duration"
+    # Default to string
+    return "string"
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def infer_fields_from_table(
+    tbl: Any,
+    *,
+    categorical_threshold: int | float = 20,
+    detect_presets: bool = True,
+    sample_size: int | None = None,
+) -> list[tuple[str, Field]]:
+    """
+    Inspect a table and infer Field objects for each column.
+
+    Parameters
+    ----------
+    tbl
+        A Polars DataFrame, Pandas DataFrame, or Ibis table (DuckDB, SQLite, etc.).
+    categorical_threshold
+        If a column has <= this many unique values (int) or this fraction of rows (float in 0..1),
+        treat as categorical with `allowed=`.
+    detect_presets
+        Attempt to match string columns to known generation presets.
+    sample_size
+        If set, sample this many rows before analysis. None uses all rows.
+
+    Returns
+    -------
+    list[tuple[str, Field]]
+        List of (column_name, Field) tuples ready for Schema construction.
+    """
+    import narwhals as nw
+
+    from pointblank._constants import IBIS_BACKENDS
+    from pointblank._utils import _get_tbl_type
+
+    table_type = _get_tbl_type(tbl)
+
+    # Convert to a common representation via Narwhals or native APIs
+    if table_type == "polars":
+        col_names, col_dtypes, col_values = _extract_polars(tbl, sample_size)
+    elif table_type == "pandas":
+        col_names, col_dtypes, col_values = _extract_pandas(tbl, sample_size)
+    elif table_type in IBIS_BACKENDS:
+        col_names, col_dtypes, col_values = _extract_ibis(tbl, sample_size)
+    else:
+        # Try via Narwhals for other backends (Ibis/DuckDB, SQLite, etc.)
+        try:
+            nw_df = nw.from_native(tbl)
+            col_names, col_dtypes, col_values = _extract_narwhals(nw_df, sample_size)
+        except Exception:
+            raise TypeError(
+                f"Cannot infer fields from table type '{table_type}'. "
+                "Supported types: Polars DataFrame, Pandas DataFrame, Ibis table."
+            )
+
+    # Infer a Field for each column
+    total_count = len(col_values[0]) if col_values else 0
+    result: list[tuple[str, Field]] = []
+
+    for i, (name, dtype_str) in enumerate(zip(col_names, col_dtypes)):
+        values = col_values[i]
+        null_count = sum(1 for v in values if v is None)
+        category = _classify_dtype(dtype_str)
+
+        if category == "int":
+            field_obj = _infer_int_field(
+                name, values, null_count, total_count, categorical_threshold
+            )
+        elif category == "float":
+            field_obj = _infer_float_field(name, values, null_count, total_count)
+        elif category == "string":
+            field_obj = _infer_string_field(
+                name, values, null_count, total_count, categorical_threshold, detect_presets
+            )
+        elif category == "bool":
+            field_obj = _infer_bool_field(values, null_count, total_count)
+        elif category == "date":
+            field_obj = _infer_date_field(values, null_count, total_count)
+        elif category == "datetime":
+            field_obj = _infer_datetime_field(values, null_count, total_count)
+        elif category == "duration":
+            field_obj = _infer_duration_field(values, null_count, total_count)
+        else:
+            # Fallback: plain string
+            field_obj = _infer_string_field(
+                name, values, null_count, total_count, categorical_threshold, detect_presets
+            )
+
+        result.append((name, field_obj))
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Table extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_polars(
+    tbl: Any, sample_size: int | None
+) -> tuple[list[str], list[str], list[list[Any]]]:
+    """Extract column info from a Polars DataFrame."""
+    if sample_size is not None and len(tbl) > sample_size:
+        tbl = tbl.sample(n=sample_size, seed=23)
+
+    col_names = tbl.columns
+    col_dtypes = [str(tbl.schema[c]) for c in col_names]
+    col_values = [tbl[c].to_list() for c in col_names]
+    return col_names, col_dtypes, col_values
+
+
+def _extract_pandas(
+    tbl: Any, sample_size: int | None
+) -> tuple[list[str], list[str], list[list[Any]]]:
+    """Extract column info from a Pandas DataFrame."""
+    if sample_size is not None and len(tbl) > sample_size:
+        tbl = tbl.sample(n=sample_size, random_state=42)
+
+    col_names = list(tbl.columns)
+    col_dtypes = [str(tbl[c].dtype) for c in col_names]
+
+    col_values = []
+    for c in col_names:
+        # Convert pandas values, replacing NaN/NaT with None
+        series = tbl[c]
+        vals = []
+        for v in series:
+            try:
+                import pandas as pd
+
+                if pd.isna(v):
+                    vals.append(None)
+                else:
+                    vals.append(v)
+            except (TypeError, ValueError):
+                vals.append(v)
+        col_values.append(vals)
+
+    return col_names, col_dtypes, col_values
+
+
+def _extract_ibis(
+    tbl: Any, sample_size: int | None
+) -> tuple[list[str], list[str], list[list[Any]]]:
+    """Extract column info from an Ibis table by executing to Pandas."""
+    if sample_size is not None:
+        tbl = tbl.head(sample_size)
+
+    # Execute the Ibis expression to a Pandas DataFrame
+    pdf = tbl.to_pandas()
+    return _extract_pandas(pdf, None)
+
+
+def _extract_narwhals(
+    nw_df: Any, sample_size: int | None
+) -> tuple[list[str], list[str], list[list[Any]]]:
+    """Extract column info from a Narwhals-wrapped DataFrame."""
+    import narwhals as nw
+
+    if sample_size is not None:
+        nw_df = nw_df.head(sample_size)
+
+    # Collect if lazy
+    if hasattr(nw_df, "collect"):
+        nw_df = nw_df.collect()
+
+    schema = dict(nw_df.schema.items())
+    col_names = list(schema.keys())
+    col_dtypes = [str(v) for v in schema.values()]
+
+    # Convert to native and extract values
+    native = nw.to_native(nw_df)
+    col_values = []
+    for c in col_names:
+        if hasattr(native, "to_list"):
+            # Polars-like
+            col_values.append(native[c].to_list())
+        else:
+            # Pandas-like
+            col_values.append(native[c].tolist())
+
+    return col_names, col_dtypes, col_values

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from pointblank.field import Field
 
-__all__ = ["Schema", "generate_dataset", "schema_from_tbl", "schema_from_df", "_check_schema_match"]
+__all__ = ["Schema", "generate_dataset", "schema_from_tbl", "_check_schema_match"]
 
 
 @dataclass
@@ -390,25 +390,6 @@ class Schema:
         instance.tbl = None
         instance.columns = [(name, field_obj) for name, field_obj in field_tuples]
         return instance
-
-    @classmethod
-    def from_dataframe(
-        cls,
-        tbl: Any,
-        *,
-        infer_constraints: bool = True,
-        categorical_threshold: int | float = 20,
-        detect_presets: bool = True,
-        sample_size: int | None = None,
-    ) -> "Schema":
-        """Deprecated alias for `Schema.from_table()`. Use `from_table()` instead."""
-        return cls.from_table(
-            tbl,
-            infer_constraints=infer_constraints,
-            categorical_threshold=categorical_threshold,
-            detect_presets=detect_presets,
-            sample_size=sample_size,
-        )
 
     def _validate_schema_inputs(self) -> None:
         if not isinstance(self.columns, list):
@@ -2009,24 +1990,6 @@ def schema_from_tbl(
     ```
     """
     return Schema.from_table(
-        tbl,
-        infer_constraints=infer_constraints,
-        categorical_threshold=categorical_threshold,
-        detect_presets=detect_presets,
-        sample_size=sample_size,
-    )
-
-
-def schema_from_df(
-    tbl: Any,
-    *,
-    infer_constraints: bool = True,
-    categorical_threshold: int | float = 20,
-    detect_presets: bool = True,
-    sample_size: int | None = None,
-) -> Schema:
-    """Deprecated alias for `schema_from_tbl()`. Use `schema_from_tbl()` instead."""
-    return schema_from_tbl(
         tbl,
         infer_constraints=infer_constraints,
         categorical_threshold=categorical_threshold,

--- a/pointblank/schema.py
+++ b/pointblank/schema.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from pointblank.field import Field
 
-__all__ = ["Schema", "generate_dataset", "_check_schema_match"]
+__all__ = ["Schema", "generate_dataset", "schema_from_tbl", "schema_from_df", "_check_schema_match"]
 
 
 @dataclass
@@ -313,6 +313,102 @@ class Schema:
         # Get the table type and store as an attribute (only if a table is provided)
         if self.tbl is not None:
             self.tbl_type = _get_tbl_type(self.tbl)
+
+    @classmethod
+    def from_table(
+        cls,
+        tbl: Any,
+        *,
+        infer_constraints: bool = True,
+        categorical_threshold: int | float = 20,
+        detect_presets: bool = True,
+        sample_size: int | None = None,
+    ) -> "Schema":
+        """
+        Create a Schema from an existing table with inferred Field constraints.
+
+        Unlike `Schema(tbl=df)` which only captures column names and dtypes, this method
+        inspects the actual values in the table to infer rich constraints suitable for
+        synthetic data generation via `schema.generate()`.
+
+        Parameters
+        ----------
+        tbl
+            A Polars DataFrame, Pandas DataFrame, or Ibis table (DuckDB, SQLite, etc.).
+        infer_constraints
+            When `True` (default), inspect values to infer min/max, uniqueness, null rates, etc.
+            When `False`, behave like `Schema(tbl=df)` (dtype only).
+        categorical_threshold
+            If a column has <= this many unique values (int) or this fraction of total rows (float
+            between 0 and 1), treat it as categorical and populate `allowed=`. Default is `20`.
+        detect_presets
+            Attempt to match string columns to known generation presets (e.g., email, url,
+            phone_number) based on column name heuristics and value validation. Default is `True`.
+        sample_size
+            If set, sample this many rows before analysis (useful for very large tables).
+            `None` means use all rows.
+
+        Returns
+        -------
+        Schema
+            A Schema populated with Field objects containing inferred constraints, ready for use
+            with `schema.generate()` or `generate_dataset()`.
+
+        Examples
+        --------
+        ```python
+        import pointblank as pb
+        import polars as pl
+
+        df = pl.DataFrame({
+            "user_id": [1, 2, 3, 4, 5],
+            "email": ["a@b.com", "c@d.com", "e@f.com", "g@h.com", "i@j.com"],
+            "age": [25, 30, 35, 40, 45],
+            "status": ["active", "active", "pending", "inactive", "active"],
+        })
+
+        schema = pb.Schema.from_table(df)
+
+        # Generate synthetic data matching the original's characteristics
+        synthetic = schema.generate(n=100, seed=23)
+        ```
+        """
+        if not infer_constraints:
+            return cls(tbl=tbl)
+
+        from pointblank.generate.inference import infer_fields_from_table
+
+        field_tuples = infer_fields_from_table(
+            tbl,
+            categorical_threshold=categorical_threshold,
+            detect_presets=detect_presets,
+            sample_size=sample_size,
+        )
+
+        # Build Schema with Field objects as column values
+        instance = cls.__new__(cls)
+        instance.tbl = None
+        instance.columns = [(name, field_obj) for name, field_obj in field_tuples]
+        return instance
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        tbl: Any,
+        *,
+        infer_constraints: bool = True,
+        categorical_threshold: int | float = 20,
+        detect_presets: bool = True,
+        sample_size: int | None = None,
+    ) -> "Schema":
+        """Deprecated alias for `Schema.from_table()`. Use `from_table()` instead."""
+        return cls.from_table(
+            tbl,
+            infer_constraints=infer_constraints,
+            categorical_threshold=categorical_threshold,
+            detect_presets=detect_presets,
+            sample_size=sample_size,
+        )
 
     def _validate_schema_inputs(self) -> None:
         if not isinstance(self.columns, list):
@@ -1848,4 +1944,92 @@ def generate_dataset(
     """
     return schema.generate(
         n=n, seed=seed, output=output, country=country, shuffle=shuffle, weighted=weighted
+    )
+
+
+def schema_from_tbl(
+    tbl: Any,
+    *,
+    infer_constraints: bool = True,
+    categorical_threshold: int | float = 20,
+    detect_presets: bool = True,
+    sample_size: int | None = None,
+) -> Schema:
+    """
+    Create a Schema from an existing table with inferred Field constraints.
+
+    This is the functional form of `Schema.from_table()`. It inspects the actual values in the
+    table to infer rich constraints (min/max, uniqueness, null rates, allowed values, presets)
+    suitable for synthetic data generation via `schema.generate()` or `generate_dataset()`.
+
+    Parameters
+    ----------
+    tbl
+        A Polars DataFrame, Pandas DataFrame, or Ibis table (DuckDB, SQLite, etc.).
+    infer_constraints
+        When `True` (default), inspect values to infer min/max, uniqueness, null rates, etc. When
+        `False`, behave like `Schema(tbl=df)` (dtype only).
+    categorical_threshold
+        If a column has <= this many unique values (int) or this fraction of total rows (float
+        between `0` and `1`), treat it as categorical and populate `allowed=`. Default is `20`.
+    detect_presets
+        Attempt to match string columns to known generation presets (e.g., email, url, phone_number)
+        based on column name heuristics and value validation. Default is `True`.
+    sample_size
+        If set, sample this many rows before analysis (useful for very large tables). `None` means
+        use all rows.
+
+    Returns
+    -------
+    Schema
+        A Schema populated with Field objects containing inferred constraints, ready for use with
+        `schema.generate()` or `generate_dataset()`.
+
+    Examples
+    --------
+    ```{python}
+    import pointblank as pb
+    import polars as pl
+
+    df = pl.DataFrame({
+        "user_id": list(range(1, 51)),
+        "email": [f"user{i}@example.com" for i in range(50)],
+        "age": [20 + i % 50 for i in range(50)],
+        "status": ["active", "pending", "inactive"] * 16 + ["active", "pending"],
+    })
+
+    schema = pb.schema_from_tbl(df)
+    print(schema)
+    ```
+
+    Generate synthetic data matching the original's characteristics:
+
+    ```{python}
+    pb.preview(schema.generate(n=10, seed=23))
+    ```
+    """
+    return Schema.from_table(
+        tbl,
+        infer_constraints=infer_constraints,
+        categorical_threshold=categorical_threshold,
+        detect_presets=detect_presets,
+        sample_size=sample_size,
+    )
+
+
+def schema_from_df(
+    tbl: Any,
+    *,
+    infer_constraints: bool = True,
+    categorical_threshold: int | float = 20,
+    detect_presets: bool = True,
+    sample_size: int | None = None,
+) -> Schema:
+    """Deprecated alias for `schema_from_tbl()`. Use `schema_from_tbl()` instead."""
+    return schema_from_tbl(
+        tbl,
+        infer_constraints=infer_constraints,
+        categorical_threshold=categorical_threshold,
+        detect_presets=detect_presets,
+        sample_size=sample_size,
     )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1702,7 +1702,7 @@ class TestGeneratorValidation:
             ]
         )
 
-        df = generate_dataset(schema, n=100, seed=42, country="US")
+        df = generate_dataset(schema, n=100, seed=23, country="US")
 
         # Map prefixes to expected providers
         PREFIX_TO_PROVIDER = {
@@ -1740,7 +1740,7 @@ class TestGeneratorValidation:
 
         # Without credit_card_number, provider should still vary per row
         schema = Schema(columns=[("provider", string_field(preset="credit_card_provider"))])
-        df = generate_dataset(schema, n=50, seed=42, country="US")
+        df = generate_dataset(schema, n=50, seed=23, country="US")
 
         providers = df["provider"].to_list()
 

--- a/tests/test_schema_from_dataframe.py
+++ b/tests/test_schema_from_dataframe.py
@@ -17,14 +17,12 @@ from pointblank.generate.inference import (
     infer_fields_from_table,
     _detect_preset,
     _classify_dtype,
-    _normalize_col_name,
-    _is_id_column,
     _validate_preset_values,
     _validate_numeric_as_latitude,
     _validate_numeric_as_longitude,
     _detect_numeric_role,
 )
-from pointblank.schema import schema_from_df, schema_from_tbl
+from pointblank.schema import schema_from_tbl
 
 
 # ---------------------------------------------------------------------------
@@ -510,22 +508,6 @@ class TestSchemaFromTblFunction:
         field = _get_field(schema, "email")
         assert isinstance(field, StringField)
         assert field.preset is None
-
-
-class TestDeprecatedAliases:
-    def test_schema_from_df_alias(self):
-        """schema_from_df() still works as a deprecated alias."""
-        df = pl.DataFrame({"x": [1, 2, 3]})
-        schema = schema_from_df(df)
-        assert schema.columns is not None
-        assert len(schema.columns) == 1
-
-    def test_from_dataframe_alias(self):
-        """Schema.from_dataframe() still works as a deprecated alias."""
-        df = pl.DataFrame({"x": [1, 2, 3]})
-        schema = Schema.from_dataframe(df)
-        assert schema.columns is not None
-        assert len(schema.columns) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_schema_from_dataframe.py
+++ b/tests/test_schema_from_dataframe.py
@@ -1,0 +1,772 @@
+import pytest
+
+import polars as pl
+import pandas as pd
+
+from pointblank.schema import Schema
+from pointblank.field import (
+    BoolField,
+    DateField,
+    DatetimeField,
+    DurationField,
+    FloatField,
+    IntField,
+    StringField,
+)
+from pointblank.generate.inference import (
+    infer_fields_from_table,
+    _detect_preset,
+    _classify_dtype,
+    _normalize_col_name,
+    _is_id_column,
+    _validate_preset_values,
+    _validate_numeric_as_latitude,
+    _validate_numeric_as_longitude,
+    _detect_numeric_role,
+)
+from pointblank.schema import schema_from_df, schema_from_tbl
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_field(schema: Schema, col_name: str):
+    """Get the Field object for a column from an inferred schema."""
+    for name, field_obj in schema.columns:
+        if name == col_name:
+            return field_obj
+    raise KeyError(f"Column '{col_name}' not found in schema")
+
+
+# ---------------------------------------------------------------------------
+# Basic smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestFromDataframeSmoke:
+    def test_polars_basic(self):
+        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        schema = Schema.from_table(df)
+        assert schema.columns is not None
+        assert len(schema.columns) == 2
+
+    def test_pandas_basic(self):
+        df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        schema = Schema.from_table(df)
+        assert schema.columns is not None
+        assert len(schema.columns) == 2
+
+    def test_infer_constraints_false(self):
+        """When infer_constraints=False, behave like Schema(tbl=df)."""
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        schema = Schema.from_table(df, infer_constraints=False)
+        # Should have dtype tuples, not Field objects
+        assert schema.columns is not None
+        name, dtype = schema.columns[0]
+        assert name == "a"
+        assert isinstance(dtype, str)
+
+
+# ---------------------------------------------------------------------------
+# Integer inference
+# ---------------------------------------------------------------------------
+
+
+class TestIntInference:
+    def test_min_max(self):
+        df = pl.DataFrame({"val": [10, 20, 30, 40, 50]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "val")
+        assert isinstance(field, IntField)
+        assert field.min_val == 10
+        assert field.max_val == 50
+
+    def test_unique_detection(self):
+        df = pl.DataFrame({"id": list(range(25))})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "id")
+        assert isinstance(field, IntField)
+        assert field.unique is True
+
+    def test_categorical_detection(self):
+        df = pl.DataFrame({"rating": [1, 2, 3, 2, 1, 3, 2, 1]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "rating")
+        assert isinstance(field, IntField)
+        assert field.allowed == [1, 2, 3]
+        assert field.min_val is None  # not set when allowed is used
+        assert field.max_val is None
+
+    def test_categorical_threshold_respected(self):
+        """Values above categorical threshold should use min/max instead."""
+        df = pl.DataFrame({"val": list(range(25))})
+        schema = Schema.from_table(df, categorical_threshold=10)
+        field = _get_field(schema, "val")
+        assert isinstance(field, IntField)
+        assert field.allowed is None
+        assert field.min_val == 0
+        assert field.max_val == 24
+
+    def test_nullable(self):
+        df = pl.DataFrame({"val": [1, 2, None, 4, None]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "val")
+        assert isinstance(field, IntField)
+        assert field.nullable is True
+        assert field.null_probability == pytest.approx(0.4, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Float inference
+# ---------------------------------------------------------------------------
+
+
+class TestFloatInference:
+    def test_min_max(self):
+        df = pl.DataFrame({"val": [1.5, 2.5, 3.5]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "val")
+        assert isinstance(field, FloatField)
+        assert field.min_val == pytest.approx(1.5)
+        assert field.max_val == pytest.approx(3.5)
+
+    def test_nullable(self):
+        df = pl.DataFrame({"val": [1.0, None, 3.0, None, 5.0]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "val")
+        assert isinstance(field, FloatField)
+        assert field.nullable is True
+        assert field.null_probability == pytest.approx(0.4, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# String inference
+# ---------------------------------------------------------------------------
+
+
+class TestStringInference:
+    def test_categorical(self):
+        df = pl.DataFrame({"status": ["active", "pending", "active", "inactive"]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "status")
+        assert isinstance(field, StringField)
+        assert field.allowed == ["active", "inactive", "pending"]
+
+    def test_length_constraints(self):
+        """Non-categorical strings get min/max length."""
+        values = [f"item_{i:04d}" for i in range(30)]
+        df = pl.DataFrame({"code": values})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "code")
+        assert isinstance(field, StringField)
+        assert field.min_length == 9
+        assert field.max_length == 9
+        assert field.allowed is None
+
+    def test_unique_detection(self):
+        values = [f"unique_{i}" for i in range(25)]
+        df = pl.DataFrame({"key": values})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "key")
+        assert isinstance(field, StringField)
+        assert field.unique is True
+
+
+# ---------------------------------------------------------------------------
+# Boolean inference
+# ---------------------------------------------------------------------------
+
+
+class TestBoolInference:
+    def test_p_true(self):
+        df = pl.DataFrame({"flag": [True, True, True, False]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "flag")
+        assert isinstance(field, BoolField)
+        assert field.p_true == pytest.approx(0.75, abs=0.01)
+
+    def test_nullable(self):
+        df = pl.DataFrame({"flag": [True, None, False, None]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "flag")
+        assert isinstance(field, BoolField)
+        assert field.nullable is True
+        assert field.null_probability == pytest.approx(0.5, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Date inference
+# ---------------------------------------------------------------------------
+
+
+class TestDateInference:
+    def test_min_max(self):
+        from datetime import date
+
+        df = pl.DataFrame({"d": [date(2020, 1, 1), date(2023, 6, 15), date(2024, 12, 31)]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "d")
+        assert isinstance(field, DateField)
+        assert field.min_date == date(2020, 1, 1)
+        assert field.max_date == date(2024, 12, 31)
+
+
+# ---------------------------------------------------------------------------
+# Preset detection
+# ---------------------------------------------------------------------------
+
+
+class TestPresetDetection:
+    def test_email_by_name(self):
+        assert _detect_preset("email", ["a@b.com", "c@d.org"]) == "email"
+        assert _detect_preset("user_email", ["a@b.com"]) == "email"
+
+    def test_email_validation_fails(self):
+        """Column named email but values don't look like emails."""
+        assert _detect_preset("email", ["not-an-email", "just-text"]) is None
+
+    def test_phone(self):
+        assert _detect_preset("phone_number", ["+1-555-1234"]) == "phone_number"
+        assert _detect_preset("telephone", ["555-0100"]) == "phone_number"
+
+    def test_url(self):
+        assert _detect_preset("url", ["https://example.com"]) == "url"
+        assert _detect_preset("website_url", ["http://test.org"]) == "url"
+
+    def test_url_validation_fails(self):
+        assert _detect_preset("url", ["/path/to/file", "relative"]) is None
+
+    def test_uuid(self):
+        assert _detect_preset("uuid", ["550e8400-e29b-41d4-a716-446655440000"]) == "uuid4"
+
+    def test_city(self):
+        assert _detect_preset("city", ["New York", "London"]) == "city"
+
+    def test_no_match(self):
+        assert _detect_preset("foobar", ["val1", "val2"]) is None
+
+    # --- CamelCase / PascalCase support (R pointblank learning) ---
+    def test_camel_case_email(self):
+        assert _detect_preset("userEmail", ["a@b.com", "c@d.org"]) == "email"
+        assert _detect_preset("EmailAddress", ["x@y.com"]) == "email"
+
+    def test_camel_case_first_name(self):
+        assert _detect_preset("firstName", ["Alice", "Bob"]) == "first_name"
+        assert _detect_preset("FirstName", ["Alice", "Bob"]) == "first_name"
+
+    def test_camel_case_last_name(self):
+        assert _detect_preset("lastName", ["Smith", "Jones"]) == "last_name"
+
+    def test_camel_case_phone(self):
+        assert _detect_preset("phoneNumber", ["555-1234"]) == "phone_number"
+        assert _detect_preset("mobilePhone", ["555-1234"]) == "phone_number"
+
+    def test_camel_case_city(self):
+        assert _detect_preset("homeCity", ["NYC"]) == "city"
+
+    def test_dot_case_email(self):
+        """Dot-separated column names (common in R data)."""
+        assert _detect_preset("user.email", ["a@b.com"]) == "email"
+
+    def test_abbreviations_from_r(self):
+        """Abbreviations recognized by R pointblank's column_roles.R."""
+        assert _detect_preset("addr", ["123 Main St"]) == "address"
+        assert _detect_preset("prov", ["Ontario"]) == "state"
+        assert _detect_preset("ctry", ["US", "CA"]) == "country_code_2"
+
+
+# ---------------------------------------------------------------------------
+# Lat/Lon numeric role detection (R pointblank learning)
+# ---------------------------------------------------------------------------
+
+
+class TestNumericRoleDetection:
+    def test_latitude_float_column(self):
+        """Float column named 'lat' with values in [-90, 90] → latitude preset."""
+        df = pl.DataFrame({"lat": [40.7, 34.0, 51.5, -33.9, 48.8]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "lat")
+        assert isinstance(field, StringField)
+        assert field.preset == "latitude"
+
+    def test_longitude_float_column(self):
+        """Float column named 'longitude' with values in [-180, 180] → longitude preset."""
+        df = pl.DataFrame({"longitude": [-74.0, -118.2, -0.1, 151.2, 2.3]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "longitude")
+        assert isinstance(field, StringField)
+        assert field.preset == "longitude"
+
+    def test_lat_out_of_bounds_no_preset(self):
+        """Values outside lat bounds should NOT trigger the preset."""
+        df = pl.DataFrame({"lat": [100.0, 200.0, 300.0, 400.0, 500.0]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "lat")
+        # Should fall back to FloatField since values aren't valid latitudes
+        assert isinstance(field, FloatField)
+
+    def test_generic_float_not_affected(self):
+        """A float column without a geo name should stay FloatField."""
+        df = pl.DataFrame({"price": [9.99, 19.99, 29.99]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "price")
+        assert isinstance(field, FloatField)
+
+
+# ---------------------------------------------------------------------------
+# ID column detection (R pointblank learning)
+# ---------------------------------------------------------------------------
+
+
+class TestIdColumnDetection:
+    def test_user_id_unique(self):
+        """Columns with 'id' in name + unique values → unique=True."""
+        df = pl.DataFrame({"user_id": list(range(1, 51))})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "user_id")
+        assert isinstance(field, IntField)
+        assert field.unique is True
+
+    def test_record_id_camel_case(self):
+        """CamelCase ID columns detected."""
+        df = pl.DataFrame({"recordId": list(range(100, 150))})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "recordId")
+        assert isinstance(field, IntField)
+        assert field.unique is True
+
+
+# ---------------------------------------------------------------------------
+# Dtype classification
+# ---------------------------------------------------------------------------
+
+
+class TestDtypeClassification:
+    @pytest.mark.parametrize(
+        "dtype_str,expected",
+        [
+            ("Int64", "int"),
+            ("int32", "int"),
+            ("UInt8", "int"),
+            ("Float64", "float"),
+            ("float32", "float"),
+            ("String", "string"),
+            ("Utf8", "string"),
+            ("Boolean", "bool"),
+            ("Date", "date"),
+            ("Datetime", "datetime"),
+            ("Duration", "duration"),
+            ("object", "string"),
+        ],
+    )
+    def test_classification(self, dtype_str, expected):
+        assert _classify_dtype(dtype_str) == expected
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: from_table -> generate
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_generate_produces_valid_data(self):
+        df = pl.DataFrame(
+            {
+                "id": list(range(1, 51)),
+                "name": [f"person_{i}" for i in range(50)],
+                "score": [float(i) * 1.5 for i in range(50)],
+                "active": [i % 3 != 0 for i in range(50)],
+            }
+        )
+        schema = Schema.from_table(df)
+        result = schema.generate(n=20, seed=123)
+
+        assert result.shape == (20, 4)
+        assert "id" in result.columns
+        assert "name" in result.columns
+        assert "score" in result.columns
+        assert "active" in result.columns
+
+    def test_generate_respects_constraints(self):
+        df = pl.DataFrame(
+            {
+                "val": list(range(100, 200)),
+                "status": ["a", "b", "c"] * 33 + ["a"],
+            }
+        )
+        schema = Schema.from_table(df)
+        result = schema.generate(n=50, seed=7)
+
+        # Integer values should be within inferred range
+        assert result["val"].min() >= 100
+        assert result["val"].max() <= 199
+
+        # Status should only contain allowed values
+        assert set(result["status"].to_list()).issubset({"a", "b", "c"})
+
+    def test_sample_size_parameter(self):
+        """sample_size should not raise and should still produce a valid schema."""
+        df = pl.DataFrame({"x": list(range(1000))})
+        schema = Schema.from_table(df, sample_size=50)
+        field = _get_field(schema, "x")
+        assert isinstance(field, IntField)
+        # With sampling, the range might be narrower, but it should still work
+        result = schema.generate(n=10, seed=1)
+        assert result.shape == (10, 1)
+
+    def test_pandas_round_trip(self):
+        df = pd.DataFrame(
+            {
+                "a": list(range(1, 31)),
+                "b": [float(i) * 0.5 for i in range(30)],
+                "c": ["x", "y", "z"] * 10,
+            }
+        )
+        schema = Schema.from_table(df)
+        result = schema.generate(n=10, seed=23)
+        assert result.shape == (10, 3)
+
+
+# ---------------------------------------------------------------------------
+# Datetime inference
+# ---------------------------------------------------------------------------
+
+
+class TestDatetimeInference:
+    def test_min_max(self):
+        from datetime import datetime
+
+        df = pl.DataFrame({"ts": [datetime(2020, 1, 1, 12, 0), datetime(2023, 6, 15, 18, 30)]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "ts")
+        assert isinstance(field, DatetimeField)
+        assert field.min_date == datetime(2020, 1, 1, 12, 0)
+        assert field.max_date == datetime(2023, 6, 15, 18, 30)
+
+    def test_nullable(self):
+        from datetime import datetime
+
+        df = pl.DataFrame({"ts": [datetime(2022, 1, 1), None, datetime(2022, 12, 31)]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "ts")
+        assert isinstance(field, DatetimeField)
+        assert field.nullable is True
+        assert field.null_probability > 0
+
+
+# ---------------------------------------------------------------------------
+# Duration inference
+# ---------------------------------------------------------------------------
+
+
+class TestDurationInference:
+    def test_min_max(self):
+        from datetime import timedelta
+
+        df = pl.DataFrame({"elapsed": [timedelta(hours=1), timedelta(hours=5), timedelta(days=2)]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "elapsed")
+        assert isinstance(field, DurationField)
+        assert field.min_duration == timedelta(hours=1)
+        assert field.max_duration == timedelta(days=2)
+
+    def test_nullable(self):
+        from datetime import timedelta
+
+        df = pl.DataFrame({"elapsed": [timedelta(seconds=30), None, timedelta(minutes=10)]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "elapsed")
+        assert isinstance(field, DurationField)
+        assert field.nullable is True
+        assert field.null_probability > 0
+
+
+# ---------------------------------------------------------------------------
+# schema_from_tbl() functional form
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaFromTblFunction:
+    def test_basic(self):
+        df = pl.DataFrame({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+        schema = schema_from_tbl(df)
+        assert schema.columns is not None
+        assert len(schema.columns) == 2
+
+    def test_passes_kwargs(self):
+        """Ensure keyword arguments are forwarded to from_table."""
+        df = pl.DataFrame({"val": [1, 2, 3, 4, 5] * 10})
+        schema = schema_from_tbl(df, categorical_threshold=10)
+        field = _get_field(schema, "val")
+        assert isinstance(field, IntField)
+        assert field.allowed == [1, 2, 3, 4, 5]
+
+    def test_detect_presets_false(self):
+        """schema_from_tbl with detect_presets=False skips preset detection."""
+        df = pl.DataFrame({"email": [f"user{i}@test.com" for i in range(50)]})
+        schema = schema_from_tbl(df, detect_presets=False)
+        field = _get_field(schema, "email")
+        assert isinstance(field, StringField)
+        assert field.preset is None
+
+
+class TestDeprecatedAliases:
+    def test_schema_from_df_alias(self):
+        """schema_from_df() still works as a deprecated alias."""
+        df = pl.DataFrame({"x": [1, 2, 3]})
+        schema = schema_from_df(df)
+        assert schema.columns is not None
+        assert len(schema.columns) == 1
+
+    def test_from_dataframe_alias(self):
+        """Schema.from_dataframe() still works as a deprecated alias."""
+        df = pl.DataFrame({"x": [1, 2, 3]})
+        schema = Schema.from_dataframe(df)
+        assert schema.columns is not None
+        assert len(schema.columns) == 1
+
+
+# ---------------------------------------------------------------------------
+# detect_presets=False on from_dataframe
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPresetsDisabled:
+    def test_string_column_no_preset(self):
+        """With detect_presets=False, string columns get length constraints instead of presets."""
+        df = pl.DataFrame({"phone": [f"+1-555-{i:04d}" for i in range(100)]})
+        schema = Schema.from_table(df, detect_presets=False)
+        field = _get_field(schema, "phone")
+        assert isinstance(field, StringField)
+        assert field.preset is None
+        # Should have length constraints instead
+        assert field.min_length is not None or field.max_length is not None
+
+
+# ---------------------------------------------------------------------------
+# Fractional categorical_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestFractionalCategoricalThreshold:
+    def test_fraction_of_rows(self):
+        """A float threshold is treated as fraction of total rows."""
+        # 100 rows, 10 unique values → 10% of rows = threshold of 10 at 0.1
+        df = pl.DataFrame({"x": list(range(10)) * 10})
+        schema = Schema.from_table(df, categorical_threshold=0.1)
+        field = _get_field(schema, "x")
+        assert isinstance(field, IntField)
+        assert field.allowed == list(range(10))
+
+    def test_fraction_below_unique_count(self):
+        """When unique count exceeds fractional threshold, use min/max instead."""
+        # 50 rows, 25 unique → 0.1 * 50 = threshold of 5, so NOT categorical
+        df = pl.DataFrame({"x": list(range(25)) * 2})
+        schema = Schema.from_table(df, categorical_threshold=0.1)
+        field = _get_field(schema, "x")
+        assert isinstance(field, IntField)
+        assert field.allowed is None
+        assert field.min_val == 0
+        assert field.max_val == 24
+
+
+# ---------------------------------------------------------------------------
+# Nullable lat/lon
+# ---------------------------------------------------------------------------
+
+
+class TestNullableLatLon:
+    def test_nullable_latitude(self):
+        """Lat column with nulls still detects preset and records null_probability."""
+        df = pl.DataFrame({"lat": [40.7, None, 51.5, None, -33.9]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "lat")
+        assert isinstance(field, StringField)
+        assert field.preset == "latitude"
+        assert field.nullable is True
+        assert field.null_probability > 0
+
+    def test_nullable_longitude(self):
+        """Lon column with nulls still detects preset and records null_probability."""
+        df = pl.DataFrame({"longitude": [-74.0, None, 139.7, 13.4, None]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "longitude")
+        assert isinstance(field, StringField)
+        assert field.preset == "longitude"
+        assert field.nullable is True
+
+
+# ---------------------------------------------------------------------------
+# _validate_preset_values edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePresetValues:
+    def test_empty_list_returns_false(self):
+        assert _validate_preset_values("email", []) is False
+
+    def test_email_valid(self):
+        assert _validate_preset_values("email", ["a@b.com", "c@d.org", "x@y.io"]) is True
+
+    def test_email_invalid_below_threshold(self):
+        # Only 1/4 matches → 25% < 70% threshold
+        assert _validate_preset_values("email", ["a@b.com", "nope", "bad", "wrong"]) is False
+
+    def test_uuid_valid(self):
+        uuids = ["550e8400-e29b-41d4-a716-446655440000"] * 5
+        assert _validate_preset_values("uuid4", uuids) is True
+
+    def test_uuid_invalid(self):
+        assert _validate_preset_values("uuid4", ["not-a-uuid", "also-not"]) is False
+
+    def test_ipv4_valid(self):
+        assert _validate_preset_values("ipv4", ["192.168.1.1", "10.0.0.1"]) is True
+
+    def test_ipv4_invalid(self):
+        assert _validate_preset_values("ipv4", ["hello", "world"]) is False
+
+    def test_url_valid(self):
+        assert _validate_preset_values("url", ["https://x.com", "http://y.org"]) is True
+
+    def test_url_invalid(self):
+        assert _validate_preset_values("url", ["/path/to", "relative"]) is False
+
+    def test_unknown_preset_trusts_name(self):
+        """Presets without a validator return True (trust name heuristic)."""
+        assert _validate_preset_values("city", ["New York", "London"]) is True
+        assert _validate_preset_values("first_name", ["Alice", "Bob"]) is True
+
+
+# ---------------------------------------------------------------------------
+# _validate_numeric_as_latitude / _validate_numeric_as_longitude
+# ---------------------------------------------------------------------------
+
+
+class TestValidateNumericGeographic:
+    def test_latitude_valid(self):
+        assert _validate_numeric_as_latitude([40.7, -33.9, 51.5, 0.0]) is True
+
+    def test_latitude_invalid(self):
+        assert _validate_numeric_as_latitude([100.0, 200.0, 300.0]) is False
+
+    def test_latitude_empty(self):
+        assert _validate_numeric_as_latitude([]) is False
+
+    def test_latitude_all_none(self):
+        assert _validate_numeric_as_latitude([None, None]) is False
+
+    def test_latitude_mixed_with_none(self):
+        """Nones are filtered out; only non-null values are checked."""
+        assert _validate_numeric_as_latitude([40.7, None, -33.9, None]) is True
+
+    def test_longitude_valid(self):
+        assert _validate_numeric_as_longitude([-74.0, 139.7, 0.0, 180.0]) is True
+
+    def test_longitude_invalid(self):
+        assert _validate_numeric_as_longitude([200.0, 300.0, -200.0]) is False
+
+    def test_longitude_empty(self):
+        assert _validate_numeric_as_longitude([]) is False
+
+
+# ---------------------------------------------------------------------------
+# _detect_numeric_role
+# ---------------------------------------------------------------------------
+
+
+class TestDetectNumericRole:
+    def test_latitude_detected(self):
+        assert _detect_numeric_role("lat", [40.7, -33.9]) == "latitude"
+
+    def test_longitude_detected(self):
+        assert _detect_numeric_role("lon", [-74.0, 139.7]) == "longitude"
+
+    def test_lat_out_of_bounds(self):
+        assert _detect_numeric_role("lat", [200.0, 300.0]) is None
+
+    def test_non_geo_name(self):
+        assert _detect_numeric_role("price", [40.7, -33.9]) is None
+
+    def test_camel_case_latitude(self):
+        assert _detect_numeric_role("userLatitude", [45.0, -10.0]) == "latitude"
+
+
+# ---------------------------------------------------------------------------
+# Unsupported table type error
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedTableType:
+    def test_raises_type_error(self):
+        """Passing a non-DataFrame object raises TypeError."""
+        with pytest.raises(TypeError, match="not a DataFrame"):
+            infer_fields_from_table({"not": "a dataframe"})
+
+
+# ---------------------------------------------------------------------------
+# Pandas null-handling edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPandasNullHandling:
+    def test_nan_treated_as_none(self):
+        """Pandas NaN values should be treated as nulls."""
+        import numpy as np
+
+        df = pd.DataFrame({"x": [1.0, np.nan, 3.0, np.nan, 5.0]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "x")
+        assert isinstance(field, FloatField)
+        assert field.nullable is True
+        assert field.null_probability == pytest.approx(0.4, abs=0.01)
+
+    def test_nat_treated_as_none(self):
+        """Pandas NaT values in datetime columns should be treated as nulls."""
+        df = pd.DataFrame({"ts": pd.to_datetime(["2020-01-01", pd.NaT, "2022-12-31"])})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "ts")
+        assert isinstance(field, DatetimeField)
+        assert field.nullable is True
+
+    def test_string_column_with_none(self):
+        """Pandas string columns with None should record null_probability."""
+        df = pd.DataFrame({"name": ["Alice", None, "Charlie", None, "Eve"]})
+        schema = Schema.from_table(df)
+        field = _get_field(schema, "name")
+        assert isinstance(field, StringField)
+        assert field.nullable is True
+        assert field.null_probability == pytest.approx(0.4, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Ibis/DuckDB table inference
+# ---------------------------------------------------------------------------
+
+
+class TestIbisTableInference:
+    def test_duckdb_memtable(self):
+        """Ibis memtable (DuckDB backend) should work with from_table."""
+        ibis = pytest.importorskip("ibis")
+        df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": ["a", "b", "c", "a", "b"]})
+        tbl = ibis.memtable(df)
+        schema = Schema.from_table(tbl)
+        assert schema.columns is not None
+        assert len(schema.columns) == 2
+        field_x = _get_field(schema, "x")
+        assert isinstance(field_x, IntField)
+
+    def test_duckdb_table(self):
+        """DuckDB native table should work with schema_from_tbl."""
+        ibis = pytest.importorskip("ibis")
+        conn = ibis.duckdb.connect()
+        df = pd.DataFrame({"id": list(range(1, 21)), "value": [float(i) * 1.5 for i in range(20)]})
+        conn.create_table("test_infer", df, overwrite=True)
+        tbl = conn.table("test_infer")
+        schema = schema_from_tbl(tbl)
+        assert schema.columns is not None
+        field_id = _get_field(schema, "id")
+        assert isinstance(field_id, IntField)
+        field_val = _get_field(schema, "value")
+        assert isinstance(field_val, FloatField)


### PR DESCRIPTION
This PR introduces new functionality for inferring synthetic data generation schemas directly from existing tables, along with several related improvements and API enhancements. The new `schema_from_tbl()` function (and the corresponding `Schema.from_table()` class method) analyzes a table's values to infer constraints, making it much easier to generate realistic synthetic datasets.

Fixes: https://github.com/posit-dev/pointblank/issues/390