### PR TITLE
Support multi-modal inputs (images, PDFs) in `Validate.prompt()`

### DIFF
--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -2821,6 +2821,7 @@ def interrogate_prompt(
         llm_model = ai_config["llm_model"]
         batch_size = ai_config.get("batch_size", 1000)
         max_concurrent = ai_config.get("max_concurrent", 3)
+        attachments = ai_config.get("attachments", [])
 
         # Set up LLM configuration (api_key will be loaded from environment)
         llm_config = _LLMConfig(
@@ -2852,7 +2853,7 @@ def interrogate_prompt(
         prompt_builder = _PromptBuilder(prompt)
 
         # Create AI validation engine
-        engine = _AIValidationEngine(llm_config)
+        engine = _AIValidationEngine(llm_config, attachments=attachments)
 
         # Run AI validation synchronously (chatlas is synchronous)
         batch_results = engine.validate_batches(

--- a/pointblank/_utils_ai.py
+++ b/pointblank/_utils_ai.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import pathlib
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 import narwhals as nw
 
 from pointblank._constants import MODEL_PROVIDERS
+
+_IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp"})
+_PDF_EXTS = frozenset({".pdf"})
+_SUPPORTED_ATTACHMENT_EXTS = _IMAGE_EXTS | _PDF_EXTS
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +98,9 @@ EXAMPLE OUTPUT FORMAT:
   {"index": 0, "result": true},
   {"index": 1, "result": false},
   {"index": 2, "result": true}
-]"""
+]
+
+If reference attachments (images or PDFs) are provided alongside the data, use them as context when evaluating each row."""
 
     # Create httpx client with SSL verification settings
     try:
@@ -211,6 +218,63 @@ EXAMPLE OUTPUT FORMAT:
         raise ValueError(f"Unsupported provider: {provider}")
 
     return chat
+
+
+def _prepare_attachments(attachments: Optional[List[Any]]) -> List[Any]:
+    """
+    Coerce a heterogeneous list of attachment specs into chatlas Content objects.
+
+    Accepts:
+    - ``str`` or ``pathlib.Path``: auto-converted to ``content_image_*`` or ``content_pdf_*``
+      based on extension. URLs (``http://``/``https://``) use the URL variants.
+    - Pre-built chatlas ``Content`` objects: passed through untouched.
+
+    Raises ``ValueError`` for unsupported extensions and ``ImportError`` if chatlas
+    is not installed.
+    """
+    if not attachments:
+        return []
+
+    if not isinstance(attachments, (list, tuple)):
+        raise TypeError(f"attachments must be a list or tuple, got {type(attachments).__name__}")
+
+    try:
+        from chatlas import (
+            content_image_file,
+            content_image_url,
+            content_pdf_file,
+            content_pdf_url,
+        )
+    except ImportError:  # pragma: no cover
+        raise ImportError(
+            "The `chatlas` package is required for attachments support. "
+            "Please install it using `pip install chatlas`."
+        )
+
+    prepared: List[Any] = []
+    for item in attachments:
+        # If it's a string or path-like, coerce based on extension. Otherwise
+        # assume it's an already-built chatlas Content object and pass through.
+        if isinstance(item, (str, pathlib.PurePath)):
+            path_str = str(item)
+            # Strip query string before checking extension for URLs.
+            ext = pathlib.PurePosixPath(path_str.split("?", 1)[0]).suffix.lower()
+            if ext not in _SUPPORTED_ATTACHMENT_EXTS:
+                raise ValueError(
+                    f"Unsupported attachment extension {ext!r} for {path_str!r}. "
+                    f"Supported extensions: {sorted(_SUPPORTED_ATTACHMENT_EXTS)}"
+                )
+            is_url = path_str.startswith(("http://", "https://"))
+            if ext in _IMAGE_EXTS:
+                prepared.append(
+                    content_image_url(path_str) if is_url else content_image_file(path_str)
+                )
+            else:
+                prepared.append(content_pdf_url(path_str) if is_url else content_pdf_file(path_str))
+        else:
+            prepared.append(item)
+
+    return prepared
 
 
 # ============================================================================
@@ -767,7 +831,11 @@ class _ValidationResponseParser:
 class _AIValidationEngine:
     """Main engine for AI-powered validation using chatlas."""
 
-    def __init__(self, llm_config: _LLMConfig):
+    def __init__(
+        self,
+        llm_config: _LLMConfig,
+        attachments: Optional[List[Any]] = None,
+    ):
         """
         Initialize the AI validation engine.
 
@@ -775,8 +843,12 @@ class _AIValidationEngine:
         ----------
         llm_config
             Configuration for the LLM provider.
+        attachments
+            Optional list of chatlas ``Content`` objects sent as global context
+            alongside every batch's text prompt.
         """
         self.llm_config = llm_config
+        self.attachments: List[Any] = list(attachments) if attachments else []
         self.chat = _create_chat_instance(
             provider=llm_config.provider,
             model_name=llm_config.model,
@@ -823,8 +895,9 @@ class _AIValidationEngine:
                 logger.debug(prompt)
                 logger.debug("--- PROMPT END ---")
 
-                # Get response from LLM using chatlas (synchronous)
-                response = str(self.chat.chat(prompt, stream=False, echo="none"))
+                # Get response from LLM using chatlas (synchronous). Attachments
+                # ride along as global context content blocks for every batch.
+                response = str(self.chat.chat(prompt, *self.attachments, stream=False, echo="none"))
 
                 # Debug: Log the raw LLM response
                 logger.debug(f"📥 LLM Response for batch {batch['batch_id']}:")
@@ -890,8 +963,9 @@ class _AIValidationEngine:
             # Build the prompt for this batch
             prompt = prompt_builder.build_prompt(batch["data"])
 
-            # Get response from LLM using chatlas (synchronous)
-            response = str(self.chat.chat(prompt, stream=False, echo="none"))
+            # Get response from LLM using chatlas (synchronous). Attachments
+            # ride along as global context content blocks for every batch.
+            response = str(self.chat.chat(prompt, *self.attachments, stream=False, echo="none"))
 
             # Parse the response
             parser = _ValidationResponseParser(total_rows=1000)  # This will be set properly

--- a/pointblank/_utils_ai.py
+++ b/pointblank/_utils_ai.py
@@ -266,8 +266,16 @@ def _prepare_attachments(attachments: Optional[List[Any]]) -> List[Any]:
                 )
             is_url = path_str.startswith(("http://", "https://"))
             if ext in _IMAGE_EXTS:
+                # content_image_file emits MissingResizeWarning when no resize
+                # is given; pass "low" explicitly (its implicit default) to
+                # suppress it. content_image_url has no resize parameter.
+                # Users wanting higher fidelity should pre-build the Content
+                # with their preferred resize and pass it in directly (the
+                # pass-through branch below handles that).
                 prepared.append(
-                    content_image_url(path_str) if is_url else content_image_file(path_str)
+                    content_image_url(path_str)
+                    if is_url
+                    else content_image_file(path_str, resize="low")
                 )
             else:
                 prepared.append(content_pdf_url(path_str) if is_url else content_pdf_file(path_str))

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -11122,6 +11122,11 @@ class Validate:
 
         Supported extensions: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.pdf`.
 
+        Note: local image paths auto-coerced through `attachments=` use `resize="low"` (chatlas's
+        default downscale to 512x512) to keep token costs predictable. For higher fidelity,
+        pre-build the content yourself with `chatlas.content_image_file(path, resize="high")`
+        (or `"none"`) and pass that object inside `attachments=`.
+
         **Cost / batching note**: attachments are re-sent on *every* batch (one batch = one LLM API
         call). For a table that requires N batches, each attachment's input tokens are billed N
         times. To control costs:

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -10881,6 +10881,7 @@ class Validate:
         prompt: str,
         model: str,
         columns_subset: str | list[str] | None = None,
+        attachments: list | None = None,
         batch_size: int = 1000,
         max_concurrent: int = 3,
         pre: Callable | None = None,
@@ -10926,6 +10927,15 @@ class Validate:
             A single column or list of columns to include in the validation. If `None`, all columns
             will be included. Specifying fewer columns can improve performance and reduce API costs
             so try to include only the columns necessary for the validation.
+        attachments
+            An optional list of reference files (images or PDFs) to attach as global context for
+            every batch. Each item can be a local file path, a URL (`http://` / `https://`), a
+            `pathlib.Path`, or a pre-built chatlas `Content` object. Supported extensions are
+            `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, and `.pdf`. The attachments apply to the whole
+            validation step, not per-row, so they are well-suited for things like brand guides,
+            schema diagrams, or sample documents the LLM should consult when scoring each row.
+            **Cost note**: attachments are re-sent on every batch — see the *Multi-modal
+            attachments* section below for cost-management tips.
         model
             The model to be used. This should be in the form of `provider:model` (e.g.,
             `"anthropic:claude-opus-4-6"`). Supported providers are `"anthropic"`, `"openai"`,
@@ -11094,6 +11104,34 @@ class Validate:
         - "Describe the quality of each row" (asks for description, not validation)
         - "How would you improve this data?" (asks for suggestions, not pass/fail)
 
+        Multi-modal Attachments
+        -----------------------
+        Use `attachments=` to give the LLM a reference image or PDF that applies to every row. The
+        attachment is sent as global context, while each row's values are still serialized as JSON
+        and validated against your `prompt=`. Useful patterns:
+
+        - validating descriptions against a brand-style image: `attachments=["brand_guide.pdf"]`
+        - cross-referencing rows with a schema diagram: `attachments=["schema.png"]`
+        - matching free-text fields to a sample document: `attachments=["sample_invoice.pdf"]`
+
+        Accepted values per list item:
+
+        - local path strings or `pathlib.Path` objects (e.g., `"docs/diagram.png"`)
+        - URLs (e.g., `"https://example.com/diagram.png"`)
+        - pre-built chatlas `Content` objects (e.g., `chatlas.content_image_plot()`)
+
+        Supported extensions: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.pdf`.
+
+        **Cost / batching note**: attachments are re-sent on *every* batch (one batch = one LLM API
+        call). For a table that requires N batches, each attachment's input tokens are billed N
+        times. To control costs:
+
+        - keep attachments small (downscale images, crop PDFs to the relevant page)
+        - use `columns_subset=` aggressively to maximize row-signature memoization (fewer unique
+          rows means fewer batches)
+        - raise `batch_size=` when the combined system prompt, attachment, and row JSON fit
+          comfortably under the model's context window
+
         Performance Considerations
         --------------------------
         AI validation is significantly slower than traditional validation methods due to API calls
@@ -11215,6 +11253,28 @@ class Validate:
         which exceeds all threshold levels. The validation will trigger the specified error action
         since the failure rate (40%) is above the error threshold (20%). The AI can recognize
         various phone number formats and determine whether they include area codes.
+
+        **Multi-modal example with `attachments=`:**
+
+        Suppose you have a table of product descriptions and a brand-style PDF that describes the
+        approved tone and vocabulary. Pass the PDF as a global attachment so the LLM can compare
+        each description against it.
+
+        ```python
+        validation = (
+            pb.Validate(data=products)
+            .prompt(
+                prompt="Each product description must match the tone and vocabulary in the brand guide.",
+                columns_subset=["description"],
+                attachments=["docs/brand_guide.pdf"],
+                model="anthropic:claude-opus-4-6",
+            )
+            .interrogate()
+        )
+        ```
+
+        The brand guide is sent alongside the row JSON on every batch, so the LLM evaluates each
+        description with the same reference document in view.
         """
 
         assertion_type = _get_fn_name()
@@ -11241,6 +11301,13 @@ class Validate:
         if not isinstance(max_concurrent, int) or max_concurrent < 1:
             raise ValueError("max_concurrent must be a positive integer")
 
+        # Coerce `attachments=` into a list of chatlas Content objects. Fails fast
+        # on unsupported extensions so users see the error at step definition time,
+        # not deep inside interrogation.
+        from pointblank._utils_ai import _prepare_attachments
+
+        prepared_attachments = _prepare_attachments(attachments)
+
         _check_pre(pre=pre)
         _check_thresholds(thresholds=thresholds)
         _check_active_input(param=active, param_name="active")
@@ -11264,6 +11331,7 @@ class Validate:
             "llm_model": model_name,
             "batch_size": batch_size,
             "max_concurrent": max_concurrent,
+            "attachments": prepared_attachments,
         }
 
         val_info = _ValidationInfo(

--- a/pointblank/validate.pyi
+++ b/pointblank/validate.pyi
@@ -419,6 +419,7 @@ class Validate:
         prompt: str,
         model: str,
         columns_subset: str | list[str] | None = None,
+        attachments: list | None = None,
         batch_size: int = 1000,
         max_concurrent: int = 3,
         pre: Callable | None = None,

--- a/tests/test_prompt_attachments.py
+++ b/tests/test_prompt_attachments.py
@@ -1,0 +1,236 @@
+"""Tests for multi-modal ``attachments=`` support on ``Validate.prompt()``."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pandas as pd
+import pytest
+from unittest.mock import MagicMock, patch
+
+from pointblank._utils_ai import (
+    _LLMConfig,
+    _PromptBuilder,
+    _prepare_attachments,
+)
+from pointblank.validate import Validate
+
+
+# A minimal valid PDF (header + EOF marker). content_pdf_file just reads bytes
+# and base64-encodes them, so any well-formed PDF stub works.
+_PDF_BYTES = (
+    b"%PDF-1.1\n"
+    b"1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n"
+    b"2 0 obj << /Type /Pages /Kids [] /Count 0 >> endobj\n"
+    b"xref\n0 3\n0000000000 65535 f \n"
+    b"0000000009 00000 n \n"
+    b"0000000054 00000 n \n"
+    b"trailer << /Size 3 /Root 1 0 R >>\n"
+    b"startxref\n100\n%%EOF\n"
+)
+
+
+@pytest.fixture
+def png_path(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Generate a real, decodable 1x1 PNG via Pillow (pulled in by chatlas)."""
+    pil = pytest.importorskip("PIL.Image")
+    p = tmp_path / "sample.png"
+    pil.new("RGB", (1, 1), color=(255, 0, 0)).save(p, format="PNG")
+    return p
+
+
+@pytest.fixture
+def pdf_path(tmp_path: pathlib.Path) -> pathlib.Path:
+    p = tmp_path / "sample.pdf"
+    p.write_bytes(_PDF_BYTES)
+    return p
+
+
+@pytest.fixture
+def sample_data() -> pd.DataFrame:
+    return pd.DataFrame({"description": ["red apple", "yellow banana"]})
+
+
+# ============================================================================
+# _prepare_attachments unit tests
+# ============================================================================
+
+
+def test_prepare_attachments_none_returns_empty():
+    assert _prepare_attachments(None) == []
+
+
+def test_prepare_attachments_empty_list_returns_empty():
+    assert _prepare_attachments([]) == []
+
+
+def test_prepare_attachments_rejects_non_list():
+    with pytest.raises(TypeError, match="attachments must be a list or tuple"):
+        _prepare_attachments("just_a_string.png")  # type: ignore[arg-type]
+
+
+def test_prepare_attachments_rejects_unsupported_extension():
+    pytest.importorskip("chatlas")
+    with pytest.raises(ValueError, match="Unsupported attachment extension"):
+        _prepare_attachments(["report.docx"])
+
+
+def test_prepare_attachments_local_png(png_path: pathlib.Path):
+    chatlas = pytest.importorskip("chatlas")
+    result = _prepare_attachments([str(png_path)])
+    assert len(result) == 1
+    # Should be a chatlas Content image (inline, base64-encoded from disk).
+    assert isinstance(result[0], chatlas.types.Content)
+    assert "Image" in type(result[0]).__name__
+
+
+def test_prepare_attachments_local_pdf_via_pathlib(pdf_path: pathlib.Path):
+    chatlas = pytest.importorskip("chatlas")
+    result = _prepare_attachments([pdf_path])  # pathlib.Path object, not str
+    assert len(result) == 1
+    assert isinstance(result[0], chatlas.types.Content)
+    assert "PDF" in type(result[0]).__name__
+
+
+def test_prepare_attachments_image_url():
+    chatlas = pytest.importorskip("chatlas")
+    # Image URLs are lazy in chatlas (no network call), so a fake host is fine.
+    result = _prepare_attachments(["https://example.com/diagram.png"])
+    assert len(result) == 1
+    assert type(result[0]).__name__ == "ContentImageRemote"
+
+
+def test_prepare_attachments_image_url_ignores_query_string():
+    pytest.importorskip("chatlas")
+    # Extension detection must strip ``?…`` before checking the suffix.
+    result = _prepare_attachments(["https://example.com/diagram.png?cache=1"])
+    assert len(result) == 1
+
+
+def test_prepare_attachments_passes_content_through():
+    """Already-built chatlas Content objects should not be re-coerced."""
+    pytest.importorskip("chatlas")
+    sentinel = object()  # opaque non-string, non-path — must pass through
+    result = _prepare_attachments([sentinel])
+    assert result == [sentinel]
+
+
+def test_prepare_attachments_mixed_inputs(png_path: pathlib.Path):
+    """A mix of paths, pathlib.Path, and prebuilt Content should all be accepted."""
+    chatlas = pytest.importorskip("chatlas")
+    prebuilt = chatlas.content_image_url("https://example.com/x.jpg")
+    result = _prepare_attachments([str(png_path), png_path, prebuilt])
+    assert len(result) == 3
+    # First two are coerced into Content; third is the original prebuilt.
+    assert result[2] is prebuilt
+
+
+# ============================================================================
+# Validate.prompt() integration with attachments=
+# ============================================================================
+
+
+def test_prompt_stores_attachments_in_ai_config(png_path: pathlib.Path, sample_data: pd.DataFrame):
+    pytest.importorskip("chatlas")
+    v = Validate(data=sample_data).prompt(
+        prompt="Each description names a real fruit.",
+        model="anthropic:claude-opus-4-6",
+        attachments=[str(png_path)],
+    )
+    stored = v.validation_info[0].values["attachments"]
+    assert len(stored) == 1
+    assert "Image" in type(stored[0]).__name__
+
+
+def test_prompt_backwards_compatible_without_attachments(sample_data: pd.DataFrame):
+    """Existing callers that don't pass attachments= must keep working unchanged."""
+    v = Validate(data=sample_data).prompt(
+        prompt="Each description names a real fruit.",
+        model="anthropic:claude-opus-4-6",
+    )
+    # The new key exists but is empty — no chatlas dependency exercised.
+    assert v.validation_info[0].values["attachments"] == []
+
+
+def test_prompt_rejects_bad_attachment_extension_at_step_definition(
+    sample_data: pd.DataFrame,
+):
+    """Errors should surface when the step is defined, not later at interrogate()."""
+    pytest.importorskip("chatlas")
+    with pytest.raises(ValueError, match="Unsupported attachment extension"):
+        Validate(data=sample_data).prompt(
+            prompt="x",
+            model="anthropic:claude-opus-4-6",
+            attachments=["notes.txt"],
+        )
+
+
+# ============================================================================
+# _AIValidationEngine forwards attachments to chat.chat()
+# ============================================================================
+
+
+def _make_engine_with_mock_chat(attachments):
+    """Build an _AIValidationEngine whose ``chat`` is a Mock — no real chatlas call."""
+    from pointblank._utils_ai import _AIValidationEngine
+
+    cfg = _LLMConfig(provider="anthropic", model="claude-opus-4-6", api_key="test")
+    fake_chat = MagicMock()
+    fake_chat.chat.return_value = '[{"index": 0, "result": true}]'
+
+    with patch("pointblank._utils_ai._create_chat_instance", return_value=fake_chat):
+        engine = _AIValidationEngine(cfg, attachments=attachments)
+    return engine, fake_chat
+
+
+def _single_batch():
+    return {
+        "batch_id": 0,
+        "start_row": 0,
+        "end_row": 1,
+        "data": {
+            "columns": ["description"],
+            "rows": [{"description": "red apple", "_pb_row_index": 0}],
+            "batch_info": {"start_row": 0, "num_rows": 1, "columns_count": 1},
+        },
+    }
+
+
+def test_engine_passes_attachments_to_chat_chat():
+    sentinel_a, sentinel_b = object(), object()
+    engine, fake_chat = _make_engine_with_mock_chat([sentinel_a, sentinel_b])
+
+    builder = _PromptBuilder("Each row names a real fruit.")
+    engine.validate_batches([_single_batch()], builder)
+
+    fake_chat.chat.assert_called_once()
+    args, kwargs = fake_chat.chat.call_args
+    # First positional arg is the text prompt; the rest are the attachments.
+    assert isinstance(args[0], str)
+    assert "Each row names a real fruit." in args[0]
+    assert args[1] is sentinel_a
+    assert args[2] is sentinel_b
+    assert kwargs == {"stream": False, "echo": "none"}
+
+
+def test_engine_without_attachments_does_not_pass_extra_args():
+    engine, fake_chat = _make_engine_with_mock_chat(None)
+
+    builder = _PromptBuilder("Each row names a real fruit.")
+    engine.validate_batches([_single_batch()], builder)
+
+    fake_chat.chat.assert_called_once()
+    args, kwargs = fake_chat.chat.call_args
+    assert len(args) == 1  # only the prompt — backwards-compatible
+    assert kwargs == {"stream": False, "echo": "none"}
+
+
+def test_engine_validate_single_batch_passes_attachments():
+    sentinel = object()
+    engine, fake_chat = _make_engine_with_mock_chat([sentinel])
+
+    builder = _PromptBuilder("Each row names a real fruit.")
+    engine.validate_single_batch(_single_batch(), builder)
+
+    args, _ = fake_chat.chat.call_args
+    assert args[1] is sentinel

--- a/tests/test_prompt_attachments.py
+++ b/tests/test_prompt_attachments.py
@@ -92,8 +92,7 @@ def test_prepare_attachments_local_image_no_resize_warning(png_path: pathlib.Pat
         warnings.simplefilter("always")
         _prepare_attachments([str(png_path)])
     assert not any(
-        "MissingResizeWarning" in type(w.category).__name__
-        or "resize" in str(w.message).lower()
+        "MissingResizeWarning" in type(w.category).__name__ or "resize" in str(w.message).lower()
         for w in captured
     ), [str(w.message) for w in captured]
 

--- a/tests/test_prompt_attachments.py
+++ b/tests/test_prompt_attachments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import warnings
 
 import pandas as pd
 import pytest
@@ -82,6 +83,19 @@ def test_prepare_attachments_local_png(png_path: pathlib.Path):
     # Should be a chatlas Content image (inline, base64-encoded from disk).
     assert isinstance(result[0], chatlas.types.Content)
     assert "Image" in type(result[0]).__name__
+
+
+def test_prepare_attachments_local_image_no_resize_warning(png_path: pathlib.Path):
+    """Auto-coerced local images must not surface chatlas's MissingResizeWarning."""
+    pytest.importorskip("chatlas")
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        _prepare_attachments([str(png_path)])
+    assert not any(
+        "MissingResizeWarning" in type(w.category).__name__
+        or "resize" in str(w.message).lower()
+        for w in captured
+    ), [str(w.message) for w in captured]
 
 
 def test_prepare_attachments_local_pdf_via_pathlib(pdf_path: pathlib.Path):


### PR DESCRIPTION
# Summary

Adds an optional `attachments=` parameter to `Validate.prompt()` so users can pass reference images and PDFs as global context for AI-powered validation. Each attachment is sent alongside every batch's text prompt via chatlas, while existing JSON row-batching and signature memoization remain untouched.

### Common Use Cases
- Validate row descriptions against a brand-guide PDF.
- Validate input data against a project configuration file.

 Accepts file paths, `pathlib.Path` objects, URLs, and pre-built chatlas `Content` objects in the same list.


### Cost note

Attachments are re-sent on every batch (one batch = one LLM API call). Token costs scale with `ceil(unique_rows / batch_size)`. The docstring spells this out and recommends `columns_subset=`, `larger batch_size=`, and smaller attachments as mitigations.

### Minor notes

- Images pass `resize="low"` explicitly to suppress chatlas's `MissingResizeWarning`; URL images don't take a `resize=` kwarg and aren't touched.
- To use `attachments=` parameter, user needs to install chatlas/Pillow (for images). When I tested the code, I got `ImportError`s: 

chatlas
```
ImportError: The `chatlas` package is required for attachments support. Please install it using `pip install chatlas`.
```

Pillow
```
ImportError: Image resizing requires the `Pillow` package. Install it with `pip install Pillow`.
```

_I'm not sure how to include these packages as dependencies._


# Related GitHub Issues and PRs

- Ref: https://github.com/posit-dev/pointblank/issues/392

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.