### PR TITLE
fix: `rows_distinct()` shouldn't drop null rows

### DIFF
--- a/pointblank/_interrogation.py
+++ b/pointblank/_interrogation.py
@@ -2752,20 +2752,18 @@ def interrogate_rows_distinct(data_tbl: IntoFrame, columns_subset: list[str] | N
 
     # Get the column subset to use for the test
     if columns_subset is None:
-        columns_subset = tbl.columns
+        columns_subset = tbl.collect_schema().names() if is_narwhals_lazyframe(tbl) else tbl.columns
 
-    # Create a count of duplicates using group_by approach
-    # Group by the columns of interest and count occurrences
-    # Handle DataFrame and LazyFrame separately for proper type narrowing
+    # Check for duplicate rows using null-safe approaches
+    # The previous group_by + join approach failed because NULL != NULL in join semantics,
+    # causing rows with nulls to be excluded from both PASS and FAIL counts.
     if is_narwhals_dataframe(tbl):
-        count_tbl = tbl.group_by(columns_subset).agg(nw.len().alias("pb_count_"))
-        result = tbl.join(count_tbl, on=columns_subset, how="left")
-        result = result.with_columns(pb_is_good_=nw.col("pb_count_") == 1).drop("pb_count_")
+        # For DataFrames, is_duplicated() correctly treats nulls as equal
+        result = tbl.with_columns(pb_is_good_=~tbl.select(columns_subset).is_duplicated())
         return result.to_native()
     elif is_narwhals_lazyframe(tbl):
-        count_tbl = tbl.group_by(columns_subset).agg(nw.len().alias("pb_count_"))
-        result = tbl.join(count_tbl, on=columns_subset, how="left")
-        result = result.with_columns(pb_is_good_=nw.col("pb_count_") == 1).drop("pb_count_")
+        # For LazyFrames, use a window function which treats nulls as equal
+        result = tbl.with_columns(pb_is_good_=nw.len().over(columns_subset) == 1)
         return result.to_native()
     else:
         msg = f"Expected DataFrame or LazyFrame, got {type(tbl)}"

--- a/pointblank/validate.py
+++ b/pointblank/validate.py
@@ -14635,15 +14635,28 @@ class Validate:
                         column_names_subset = ["_row_num_"] + column
                         validation_extract_nw = validation_extract_nw.select(column_names_subset)
 
+                    # Use cast-to-string + fill_null before grouping to avoid issues with
+                    # null values in over() on pandas backends (nulls don't group properly
+                    # in window functions on pandas). We add temporary filled columns for
+                    # grouping only. Casting to string first avoids type mismatch errors
+                    # on backends like PySpark where fill_null requires matching types.
+                    fill_cols = [
+                        nw.col(c)
+                        .cast(nw.String)
+                        .fill_null(value="__pb_null__")
+                        .alias(f"__pb_filled_{c}__")
+                        for c in column_names
+                    ]
+                    filled_names = [f"__pb_filled_{c}__" for c in column_names]
+
                     validation_extract_nw = (
-                        validation_extract_nw.with_columns(
-                            group_min_row=nw.min("_row_num_").over(*column_names)
-                        )
+                        validation_extract_nw.with_columns(*fill_cols)
+                        .with_columns(group_min_row=nw.min("_row_num_").over(*filled_names))
                         # First sort by the columns to group duplicates and by row numbers
                         # within groups; this type of sorting will preserve the original order in a
                         # single operation
-                        .sort(by=["group_min_row"] + column_names + ["_row_num_"])
-                        .drop("group_min_row")
+                        .sort(by=["group_min_row"] + filled_names + ["_row_num_"])
+                        .drop("group_min_row", *filled_names)
                     )
 
                 # Ensure that the extract is collected and set to its native format

--- a/tests/snapshots/test_validate/test_comprehensive_validation_report_html_snap/comprehensive_validation_report.html
+++ b/tests/snapshots/test_validate/test_comprehensive_validation_report_html_snap/comprehensive_validation_report.html
@@ -1076,7 +1076,7 @@
 </svg></td>
     <td style="height: 40px; background-color: #FCFCFC; border-right: 1px solid #D3D3D3;" class="gt_row gt_center"><span style="color:#4CA64C;">&check;</span></td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px;" class="gt_row gt_right">13</td>
-    <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">9<br />0.69</td>
+    <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">11<br />0.85</td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">2<br />0.15</td>
     <td style="height: 40px; background-color: #FCFCFC; border-left: 1px solid #D3D3D3;" class="gt_row gt_center"><span style="color: #AAAAAA;">&#9679;</span></td>
     <td style="height: 40px; background-color: #FCFCFC;" class="gt_row gt_center"><span style="color: #EBBC14;">&cir;</span></td>
@@ -1121,7 +1121,7 @@
 </svg></td>
     <td style="height: 40px; background-color: #FCFCFC; border-right: 1px solid #D3D3D3;" class="gt_row gt_center"><span style="color:#4CA64C;">&check;</span></td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px;" class="gt_row gt_right">13</td>
-    <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">9<br />0.69</td>
+    <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">11<br />0.85</td>
     <td style="height: 40px; color: black;font-family: IBM Plex Mono;font-size: 11px; border-left: 1px dashed #E5E5E5;" class="gt_row gt_right">2<br />0.15</td>
     <td style="height: 40px; background-color: #FCFCFC; border-left: 1px solid #D3D3D3;" class="gt_row gt_center"><span style="color: #AAAAAA;">&#9679;</span></td>
     <td style="height: 40px; background-color: #FCFCFC;" class="gt_row gt_center"><span style="color: #EBBC14;">&cir;</span></td>

--- a/tests/test_pyspark_nulls.py
+++ b/tests/test_pyspark_nulls.py
@@ -213,9 +213,8 @@ class TestRowsDistinctNulls:
 
         # Rows: (1,a), (2,b), (1,a), (None,c), (None,c)
         # Duplicates: (1,a) appears twice, (None,c) appears twice
-        # rows_distinct counts only the *extra* occurrences as failures
-        # (i.e., n-1 for each group of n duplicates)
-        assert v.n_failed(i=1, scalar=True) == 2
+        # All rows in a duplicate group are non-distinct (fail)
+        assert v.n_failed(i=1, scalar=True) == 4
 
     def test_rows_distinct_subset_with_nulls(self, tbl_duplicates_nulls):
         """rows_distinct with column subset containing NULLs."""
@@ -223,8 +222,8 @@ class TestRowsDistinctNulls:
 
         # id values: 1, 2, 1, None, None
         # Duplicates by id: 1 appears twice, None appears twice
-        # Only extra occurrences count as failures
-        assert v.n_failed(i=1, scalar=True) == 2
+        # All rows in a duplicate group are non-distinct (fail)
+        assert v.n_failed(i=1, scalar=True) == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5228,7 +5228,56 @@ def test_rows_distinct(request, tbl_fixture) -> None:
     )
 
 
-def test_conjointly_polars_native() -> None:
+@pytest.mark.parametrize(
+    "tbl_type",
+    ["polars", "pandas"],
+)
+def test_rows_distinct_with_nulls(tbl_type) -> None:
+    """Test that rows_distinct correctly handles rows containing null values (GH#397)."""
+    if tbl_type == "polars":
+        import polars as pl
+
+        df = pl.DataFrame(
+            {"id": ["A", "B", "C"], "name": ["Alice", "Bob", "Charlie"], "score": [100, None, 100]}
+        )
+    else:
+        import pandas as pd
+
+        df = pd.DataFrame(
+            {"id": ["A", "B", "C"], "name": ["Alice", "Bob", "Charlie"], "score": [100, None, 100]}
+        )
+
+    # All 3 rows are distinct — null should not cause exclusion
+    v = Validate(df).rows_distinct().interrogate()
+    assert v.n_passed(i=1, scalar=True) == 3
+    assert v.n_failed(i=1, scalar=True) == 0
+
+    # Column subset without nulls
+    v2 = Validate(df).rows_distinct(columns_subset=["id"]).interrogate()
+    assert v2.n_passed(i=1, scalar=True) == 3
+    assert v2.n_failed(i=1, scalar=True) == 0
+
+    # Actual duplicates with nulls should still be detected
+    if tbl_type == "polars":
+        df_dup = pl.DataFrame(
+            {
+                "id": ["A", "A", "C"],
+                "name": ["Alice", "Alice", "Charlie"],
+                "score": [None, None, 100],
+            }
+        )
+    else:
+        df_dup = pd.DataFrame(
+            {
+                "id": ["A", "A", "C"],
+                "name": ["Alice", "Alice", "Charlie"],
+                "score": [None, None, 100],
+            }
+        )
+
+    v3 = Validate(df_dup).rows_distinct().interrogate()
+    assert v3.n_passed(i=1, scalar=True) == 1
+    assert v3.n_failed(i=1, scalar=True) == 2
     tbl = load_dataset(dataset="small_table", tbl_type="polars")
 
     validation = (


### PR DESCRIPTION
This PR addresses the handling of duplicate row detection, especially in the presence of null values. This improves both correctness and cross-backend consistency. The changes update the implementation to treat nulls as equal when checking for duplicates, revise the test expectations accordingly, and enhance test coverage for both Polars and Pandas backends. Additionally, the validation logic is updated to ensure proper grouping even when nulls are present.

Fixes: #397 