### PR TITLE
feat: schema enforcement API

### DIFF
--- a/blog/validation-libs-2025/index.qmd
+++ b/blog/validation-libs-2025/index.qmd
@@ -350,7 +350,7 @@ creating custom validation classes that fit into its modular validation catalog.
 
 ### Unique Strengths and When to Use
 
-- beautiful, interactive HTML reports perfect for sharing with stakeholders
+- beautiful, interactive HTML reports that are great for sharing with stakeholders
 - threshold-based alerting system with configurable actions
 - segmented validation for analyzing subsets of data
 - LLM-powered validation suggestions via `DraftValidation`

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -148,6 +148,22 @@ reference:
         - name: PipelineResult
           members: true
 
+    - title: Contract Import/Export
+      desc: >
+        Import external schema definitions (JSON Schema, Frictionless Table Schema, and more)
+        into Pointblank validation workflows, or export Pointblank contracts to those formats.
+        Use `import_contract()` as the entry point, `export_contract()` for the reverse, and
+        `register_adapter()` to add support for custom formats.
+      contents:
+        - import_contract
+        - export_contract
+        - list_adapters
+        - register_adapter
+        - name: ContractImport
+          members: true
+        - name: ContractAdapter
+          members: true
+
     - title: Validation Steps
       desc: >
         Validation steps are sequential validations on the target data. Call Validate's

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -10,6 +10,14 @@ except PackageNotFoundError:  # pragma: no cover
 
 # Import objects from the module
 from pointblank.actions import send_slack_notification
+from pointblank.adapters import (
+    ContractAdapter,
+    ContractImport,
+    export_contract,
+    import_contract,
+    list_adapters,
+    register_adapter,
+)
 from pointblank.assistant import assistant
 from pointblank.column import (
     col,

--- a/pointblank/__init__.py
+++ b/pointblank/__init__.py
@@ -155,4 +155,11 @@ __all__ = [
     "yaml_interrogate",
     "validate_yaml",
     "yaml_to_python",
+    # Contract import/export
+    "ContractAdapter",
+    "ContractImport",
+    "import_contract",
+    "export_contract",
+    "list_adapters",
+    "register_adapter",
 ]

--- a/pointblank/adapters/__init__.py
+++ b/pointblank/adapters/__init__.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pointblank.adapters._frictionless  # noqa: F401
+
+# Import adapter modules to trigger registration via @register_adapter
+import pointblank.adapters._json_schema  # noqa: F401
+from pointblank.adapters._api import export_contract, import_contract
+from pointblank.adapters._base import ContractAdapter, ContractImport, MappedConstraint
+from pointblank.adapters._registry import (
+    get_adapter,
+    list_adapters,
+    register_adapter,
+)
+
+__all__ = [
+    "ContractAdapter",
+    "ContractImport",
+    "MappedConstraint",
+    "export_contract",
+    "get_adapter",
+    "import_contract",
+    "list_adapters",
+    "register_adapter",
+]

--- a/pointblank/adapters/_api.py
+++ b/pointblank/adapters/_api.py
@@ -70,3 +70,49 @@ def import_contract(source: Any, *, format: str | None = None, **kwargs: Any) ->
     return adapter.import_contract(source, **kwargs)
 
 
+def export_contract(
+    validation_or_contract: Any,
+    destination: str | None = None,
+    *,
+    format: str,
+    **kwargs: Any,
+) -> str | dict[str, Any]:
+    """Export a Pointblank validation or contract to an external format.
+
+    Parameters
+    ----------
+    validation_or_contract
+        A `Validate` or `Contract` object to export.
+    destination
+        Optional file path to write the output. If None, the result is returned without writing to
+        disk.
+    format
+        The target format identifier (e.g., `"json_schema"`, `"frictionless"`, `"dbt"`, etc.).
+    **kwargs
+        Format-specific options passed to the adapter.
+
+    Returns
+    -------
+    str | dict
+        The exported content.
+
+    Raises
+    ------
+    ValueError
+        If no adapter is registered for the format, or the adapter doesn't support export.
+
+    Examples
+    --------
+    ```python
+    import pointblank as pb
+
+    validation = pb.Validate(data=df).col_vals_gt(columns="age", value=0).interrogate()
+    pb.export_contract(validation, "output.schema.json", format="json_schema")
+    ```
+    """
+    adapter = get_adapter(format)
+
+    if not adapter.supports_export:
+        raise ValueError(f"Adapter '{format}' does not support export.")
+
+    return adapter.export_contract(validation_or_contract, destination, **kwargs)

--- a/pointblank/adapters/_api.py
+++ b/pointblank/adapters/_api.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pointblank.adapters._base import ContractImport
+from pointblank.adapters._registry import _detect_format, get_adapter
+
+
+def import_contract(source: Any, *, format: str | None = None, **kwargs: Any) -> ContractImport:
+    """Import a contract/schema from an external format.
+
+    Reads an external schema definition (JSON Schema, Frictionless Table Schema, dbt schema.yml,
+    Pandera schema, Pydantic model, etc.) and produces a `ContractImport` with validation steps
+    mapped to Pointblank methods.
+
+    Parameters
+    ----------
+    source
+        The source to import from. Can be: (1) a file path (str) to a schema/contract file, (2) a
+        Python dict with schema content already loaded, or (3) a Python object (e.g., a Pandera
+        `DataFrameSchema` or Pydantic model class).
+    format
+        The format identifier (e.g., `"json_schema"`, `"frictionless"`, `"dbt"`, etc.). If `None`,
+        the format is auto-detected from file extension or content.
+    **kwargs
+        Format-specific options passed to the adapter.
+
+    Returns
+    -------
+    ContractImport
+        An object containing the imported columns, constraints, and methods to generate `Validate`
+        objects, `Contract` objects, Python code, or YAML.
+
+    Raises
+    ------
+    ValueError
+        If the format cannot be detected or no adapter is registered for it.
+
+    Examples
+    --------
+    ```python
+    import pointblank as pb
+
+    # Import from JSON Schema
+    result = pb.import_contract("user_profile.schema.json", format="json_schema")
+    validation = result.to_validate(data=my_df)
+    validation.interrogate()
+
+    # Auto-detect format
+    result = pb.import_contract("datapackage.json")
+
+    # Import from a dict
+    schema_dict = {"type": "object", "properties": {"age": {"type": "integer", "minimum": 0}}}
+    result = pb.import_contract(schema_dict, format="json_schema")
+    ```
+    """
+    if format is None:
+        format = _detect_format(source)
+        if format is None:
+            raise ValueError(
+                f"Could not auto-detect format for source: {source!r}. "
+                "Please specify the format explicitly using the format= parameter."
+            )
+
+    adapter = get_adapter(format)
+
+    if not adapter.supports_import:
+        raise ValueError(f"Adapter '{format}' does not support import.")
+
+    return adapter.import_contract(source, **kwargs)
+
+

--- a/pointblank/adapters/_base.py
+++ b/pointblank/adapters/_base.py
@@ -142,6 +142,93 @@ class ContractImport:
         contract_kwargs.update(kwargs)
         return Contract(**contract_kwargs)
 
+    def to_python(self) -> str:
+        """Generate Python code string for the validation workflow.
+
+        Returns
+        -------
+        str
+            Python source code that recreates the validation.
+        """
+        lines = ["import pointblank as pb", "", "validation = (", "    pb.Validate(data=data)"]
+
+        # Schema step
+        schema_cols = {name: dtype for name, dtype in self.columns if dtype is not None}
+        if schema_cols:
+            schema_args = ", ".join(f'{name}="{dtype}"' for name, dtype in schema_cols.items())
+            lines.append(f"    .col_schema_match(schema=pb.Schema({schema_args}))")
+
+        # Constraint steps
+        for constraint in self.constraints:
+            kwargs_str = ", ".join(f"{k}={v!r}" for k, v in constraint.kwargs.items())
+            lines.append(f"    .{constraint.method}({kwargs_str})")
+
+        lines.append(")")
+        lines.append("")
+        lines.append("validation.interrogate()")
+        return "\n".join(lines)
+
+    def to_yaml(self) -> str:
+        """Generate Pointblank YAML configuration string.
+
+        Returns
+        -------
+        str
+            YAML representation of the validation.
+        """
+        import yaml
+
+        steps_list = []
+
+        # Schema step
+        schema_cols = {name: dtype for name, dtype in self.columns if dtype is not None}
+        if schema_cols:
+            steps_list.append({"col_schema_match": {"schema": schema_cols}})
+
+        # Constraint steps
+        for constraint in self.constraints:
+            steps_list.append({constraint.method: dict(constraint.kwargs)})
+
+        doc = {"validation": {"steps": steps_list}}
+        return yaml.dump(doc, default_flow_style=False, sort_keys=False)
+
+    def summary(self) -> str:
+        """Return a human-readable summary of what was imported.
+
+        Returns
+        -------
+        str
+            A formatted summary string.
+        """
+        lines = [
+            "Contract Import Summary",
+            f"  Format: {self.source_format}",
+        ]
+        if self.source_path:
+            lines.append(f"  Source: {self.source_path}")
+        if self.source_version:
+            lines.append(f"  Format version: {self.source_version}")
+
+        lines.append(f"  Columns detected: {len(self.columns)}")
+        lines.append(f"  Constraints mapped: {len(self.constraints)}")
+        lines.append(f"  Coverage: {self.coverage:.0%}")
+
+        if self.warnings:
+            lines.append(f"  Warnings ({len(self.warnings)}):")
+            for w in self.warnings:
+                lines.append(f"    - {w}")
+
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return (
+            f"ContractImport(format={self.source_format!r}, "
+            f"columns={len(self.columns)}, "
+            f"constraints={len(self.constraints)}, "
+            f"coverage={self.coverage:.0%})"
+        )
+
+
 class ContractAdapter:
     """Base class for contract import/export adapters.
 

--- a/pointblank/adapters/_base.py
+++ b/pointblank/adapters/_base.py
@@ -67,3 +67,39 @@ class ContractImport:
     warnings: list[str] = field(default_factory=list)
     coverage: float = 1.0
 
+    def to_validate(self, data: Any, **kwargs: Any) -> Validate:
+        """Build a Validate object from the imported contract.
+
+        Parameters
+        ----------
+        data
+            The data table to validate.
+        **kwargs
+            Additional keyword arguments passed to the Validate constructor.
+
+        Returns
+        -------
+        Validate
+            A Validate object with all imported checks applied (not yet interrogated).
+        """
+        from pointblank.schema import Schema
+        from pointblank.validate import Validate
+
+        validation = Validate(data=data, **kwargs)
+
+        # Add schema check if columns with types were detected
+        schema_cols = {name: dtype for name, dtype in self.columns if dtype is not None}
+        if schema_cols:
+            schema = Schema(**schema_cols)
+            validation = validation.col_schema_match(schema=schema)
+
+        # Add each mapped constraint as a validation step
+        for constraint in self.constraints:
+            method = getattr(validation, constraint.method, None)
+            if method is None:
+                self.warnings.append(f"Validate has no method '{constraint.method}' — skipped.")
+                continue
+            validation = method(**constraint.kwargs)
+
+        return validation
+

--- a/pointblank/adapters/_base.py
+++ b/pointblank/adapters/_base.py
@@ -142,3 +142,41 @@ class ContractImport:
         contract_kwargs.update(kwargs)
         return Contract(**contract_kwargs)
 
+class ContractAdapter:
+    """Base class for contract import/export adapters.
+
+    Subclass this to add support for a new external format.
+
+    Attributes
+    ----------
+    format_name
+        Short identifier for this format (e.g., `"json_schema"`).
+    file_extensions
+        File extensions associated with this format (e.g., `[".json"]`).
+    supports_import
+        Whether this adapter supports importing from the format.
+    supports_export
+        Whether this adapter supports exporting to the format.
+    """
+
+    format_name: str = ""
+    file_extensions: list[str] = []
+    supports_import: bool = True
+    supports_export: bool = True
+
+    @staticmethod
+    def detect(source: Any) -> bool:
+        """Return True if this adapter can handle the given source.
+
+        Parameters
+        ----------
+        source
+            A file path string, dict, or Python object to inspect.
+
+        Returns
+        -------
+        bool
+            True if this adapter can handle the source.
+        """
+        raise NotImplementedError
+

--- a/pointblank/adapters/_base.py
+++ b/pointblank/adapters/_base.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pointblank.contract import Contract
+    from pointblank.validate import Validate
+
+
+@dataclass
+class MappedConstraint:
+    """A single constraint from an external format mapped to a Pointblank validation step.
+
+    Parameters
+    ----------
+    method
+        The Pointblank Validate method name (e.g., `"col_vals_gt"`).
+    kwargs
+        The keyword arguments to pass to that method.
+    source_description
+        Human-readable description of the original constraint in the source format.
+    """
+
+    method: str
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    source_description: str = ""
+
+    def __repr__(self) -> str:
+        kwargs_str = ", ".join(f"{k}={v!r}" for k, v in self.kwargs.items())
+        return f"MappedConstraint({self.method!r}, {kwargs_str})"
+
+

--- a/pointblank/adapters/_base.py
+++ b/pointblank/adapters/_base.py
@@ -103,3 +103,42 @@ class ContractImport:
 
         return validation
 
+    def to_contract(self, name: str = "imported_contract", **kwargs: Any) -> Contract:
+        """Build a Contract object from the imported data.
+
+        Parameters
+        ----------
+        name
+            Name for the created `Contract`.
+        **kwargs
+            Additional keyword arguments passed to the `Contract` constructor.
+
+        Returns
+        -------
+        Contract
+            A Contract object with schema and steps derived from the import.
+        """
+        from pointblank.contract import Contract, Step
+        from pointblank.schema import Schema
+
+        # Build schema from columns
+        schema = None
+        schema_cols = {col_name: dtype for col_name, dtype in self.columns if dtype is not None}
+        if schema_cols:
+            schema = Schema(**schema_cols)
+
+        # Build steps from constraints
+        steps = [Step(c.method, **c.kwargs) for c in self.constraints]
+
+        contract_kwargs: dict[str, Any] = {
+            "name": name,
+            "schema": schema,
+            "steps": steps,
+        }
+        # Merge in any metadata as description
+        if "description" in self.metadata and "description" not in kwargs:
+            contract_kwargs["description"] = self.metadata["description"]
+
+        contract_kwargs.update(kwargs)
+        return Contract(**contract_kwargs)
+

--- a/pointblank/adapters/_base.py
+++ b/pointblank/adapters/_base.py
@@ -31,3 +31,39 @@ class MappedConstraint:
         return f"MappedConstraint({self.method!r}, {kwargs_str})"
 
 
+@dataclass
+class ContractImport:
+    """Result of importing an external contract/schema.
+
+    Contains the parsed schema information, mapped validation steps, and any warnings about
+    constraints that couldn't be fully translated.
+
+    Parameters
+    ----------
+    source_format
+        The adapter format name (e.g., `"json_schema"`, `"frictionless"`, etc.).
+    source_path
+        File path if loaded from a file, else None.
+    source_version
+        Version of the source format specification, if detectable.
+    columns
+        List of (column_name, dtype_string_or_None) tuples detected from the source.
+    constraints
+        List of MappedConstraint objects ready for translation to Validate steps.
+    metadata
+        Any additional metadata from the source (title, description, etc.).
+    warnings
+        Messages about constraints that couldn't be mapped.
+    coverage
+        Fraction of source constraints successfully mapped (`0.0` to `1.0`).
+    """
+
+    source_format: str
+    source_path: str | None = None
+    source_version: str | None = None
+    columns: list[tuple[str, str | None]] = field(default_factory=list)
+    constraints: list[MappedConstraint] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+    coverage: float = 1.0
+

--- a/pointblank/adapters/_base.py
+++ b/pointblank/adapters/_base.py
@@ -180,3 +180,43 @@ class ContractAdapter:
         """
         raise NotImplementedError
 
+    def import_contract(self, source: Any, **kwargs: Any) -> ContractImport:
+        """Import from the external format.
+
+        Parameters
+        ----------
+        source
+            The source to import from (file path, dict, or Python object).
+        **kwargs
+            Format-specific options.
+
+        Returns
+        -------
+        ContractImport
+            The import result with columns, constraints, and metadata.
+        """
+        raise NotImplementedError
+
+    def export_contract(
+        self,
+        validation_or_contract: Any,
+        destination: str | None = None,
+        **kwargs: Any,
+    ) -> str | dict[str, Any]:
+        """Export to the external format.
+
+        Parameters
+        ----------
+        validation_or_contract
+            A `Validate` or `Contract` object to export.
+        destination
+            Optional file path to write the output. If `None`, returns the result.
+        **kwargs
+            Format-specific options.
+
+        Returns
+        -------
+        str | dict
+            The exported content (string or dict), also written to file if destination given.
+        """
+        raise NotImplementedError

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -392,3 +392,25 @@ class FrictionlessAdapter(ContractAdapter):
         return {"fields": fields}
 
 
+def _pb_dtype_to_frictionless_type(dtype: str) -> str | None:
+    """Map a Pointblank/Narwhals dtype to a Frictionless field type."""
+    dtype_lower = dtype.lower()
+    if "int" in dtype_lower:
+        return "integer"
+    if "float" in dtype_lower or "double" in dtype_lower or "decimal" in dtype_lower:
+        return "number"
+    if "str" in dtype_lower or "utf8" in dtype_lower or "object" in dtype_lower:
+        return "string"
+    if "bool" in dtype_lower:
+        return "boolean"
+    if "datetime" in dtype_lower or "timestamp" in dtype_lower:
+        return "datetime"
+    if "date" in dtype_lower:
+        return "date"
+    if "time" in dtype_lower:
+        return "time"
+    if "duration" in dtype_lower:
+        return "duration"
+    return None
+
+

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -151,3 +151,51 @@ class FrictionlessAdapter(ContractAdapter):
 
         return table_schema
 
+    def _extract_table_schema(self, doc: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        """Extract the Table Schema from a Data Package or standalone schema."""
+        # If it's already a Table Schema (has "fields")
+        if "fields" in doc and isinstance(doc["fields"], list):
+            return doc
+
+        # If it's a Data Package (has "resources")
+        if "resources" in doc:
+            resources = doc["resources"]
+            if not resources:
+                raise ValueError("Data Package has no resources.")
+
+            resource_key = kwargs.get("resource")
+
+            if resource_key is None:
+                # Use first resource
+                resource = resources[0]
+            elif isinstance(resource_key, int):
+                if resource_key >= len(resources):
+                    raise IndexError(
+                        f"Resource index {resource_key} out of range "
+                        f"(package has {len(resources)} resources)."
+                    )
+                resource = resources[resource_key]
+            elif isinstance(resource_key, str):
+                # Find by name
+                resource = None
+                for r in resources:
+                    if r.get("name") == resource_key:
+                        resource = r
+                        break
+                if resource is None:
+                    available = [r.get("name", f"<index {i}>") for i, r in enumerate(resources)]
+                    raise ValueError(f"Resource '{resource_key}' not found. Available: {available}")
+            else:
+                raise TypeError(f"resource must be str or int, got {type(resource_key).__name__}")
+
+            schema = resource.get("schema", {})
+            if "fields" not in schema:
+                raise ValueError(
+                    f"Resource has no 'schema.fields'. Got keys: {list(schema.keys())}"
+                )
+            return schema
+
+        raise ValueError(
+            "Document is neither a Table Schema (no 'fields') nor a Data Package (no 'resources')."
+        )
+

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -458,3 +458,20 @@ def _apply_step_to_fields(
             constraints["pattern"] = kwargs.get("pattern")
 
 
+def _extract_validate_step_kwargs_from_info(step_info: Any) -> dict[str, Any]:
+    """Extract kwargs from a _ValidationInfo object."""
+    kwargs: dict[str, Any] = {}
+    if hasattr(step_info, "column") and step_info.column:
+        kwargs["columns"] = step_info.column
+    if hasattr(step_info, "values") and step_info.values is not None:
+        val = step_info.values
+        if isinstance(val, (list, tuple)):
+            kwargs["set"] = list(val)
+        else:
+            kwargs["value"] = val
+    if hasattr(step_info, "val_info") and step_info.val_info:
+        val_info = step_info.val_info
+        if isinstance(val_info, dict):
+            if "pattern" in val_info:
+                kwargs["pattern"] = val_info["pattern"]
+    return kwargs

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pointblank.adapters._base import ContractAdapter, ContractImport, MappedConstraint
+from pointblank.adapters._registry import register_adapter
+
+# Mapping from Frictionless field types to Pointblank/Narwhals dtype strings
+_FRICTIONLESS_TYPE_MAP: dict[str, str] = {
+    "integer": "Int64",
+    "number": "Float64",
+    "string": "String",
+    "boolean": "Boolean",
+    "date": "Date",
+    "datetime": "Datetime",
+    "time": "Time",
+    "duration": "Duration",
+    "year": "Int64",
+    "yearmonth": "String",
+    "object": "String",
+    "array": "String",
+    "geopoint": "String",
+    "geojson": "String",
+    "any": None,
+}
+
+

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -68,3 +68,43 @@ class FrictionlessAdapter(ContractAdapter):
 
         return False
 
+    def import_contract(self, source: Any, **kwargs: Any) -> ContractImport:
+        """Import a Frictionless Table Schema or Data Package.
+
+        Parameters
+        ----------
+        source
+            A file path (str) to a JSON file, or a dict with the schema content.
+        resource
+            For Data Packages with multiple resources, the name or index of the resource to import.
+            Defaults to the first resource.
+        **kwargs
+            Additional options (e.g., `resource="my_table"`).
+
+        Returns
+        -------
+        ContractImport
+            The import result.
+        """
+        source_path = None
+
+        if isinstance(source, str):
+            source_path = source
+            path = Path(source)
+            if not path.exists():
+                raise FileNotFoundError(f"Frictionless schema file not found: {source}")
+            with open(path) as f:
+                doc = json.load(f)
+        elif isinstance(source, dict):
+            doc = source
+        else:
+            raise TypeError(
+                f"Frictionless source must be a file path (str) or dict, "
+                f"got {type(source).__name__}"
+            )
+
+        # If it's a Data Package, extract the Table Schema from a resource
+        table_schema = self._extract_table_schema(doc, **kwargs)
+
+        return self._parse_table_schema(table_schema, source_path=source_path)
+

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -108,3 +108,46 @@ class FrictionlessAdapter(ContractAdapter):
 
         return self._parse_table_schema(table_schema, source_path=source_path)
 
+    def export_contract(
+        self,
+        validation_or_contract: Any,
+        destination: str | None = None,
+        **kwargs: Any,
+    ) -> str | dict[str, Any]:
+        """Export a Validate or Contract to Frictionless Table Schema format.
+
+        Parameters
+        ----------
+        validation_or_contract
+            A `Validate` or `Contract` object.
+        destination
+            Optional file path to write the Table Schema JSON.
+        **kwargs
+            Not currently used.
+
+        Returns
+        -------
+        dict
+            The Frictionless Table Schema as a dict.
+        """
+        from pointblank.contract import Contract
+        from pointblank.validate import Validate
+
+        if isinstance(validation_or_contract, Contract):
+            table_schema = self._export_from_contract(validation_or_contract)
+        elif isinstance(validation_or_contract, Validate):
+            table_schema = self._export_from_validate(validation_or_contract)
+        else:
+            raise TypeError(
+                f"Expected a Validate or Contract object, "
+                f"got {type(validation_or_contract).__name__}"
+            )
+
+        if destination is not None:
+            path = Path(destination)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w") as f:
+                json.dump(table_schema, f, indent=2)
+
+        return table_schema
+

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -199,3 +199,155 @@ class FrictionlessAdapter(ContractAdapter):
             "Document is neither a Table Schema (no 'fields') nor a Data Package (no 'resources')."
         )
 
+    def _parse_table_schema(
+        self, table_schema: dict[str, Any], source_path: str | None = None
+    ) -> ContractImport:
+        """Parse a Frictionless Table Schema dict into a ContractImport."""
+        columns: list[tuple[str, str | None]] = []
+        constraints: list[MappedConstraint] = []
+        warnings: list[str] = []
+        metadata: dict[str, Any] = {}
+
+        fields = table_schema.get("fields", [])
+        primary_key = table_schema.get("primaryKey", [])
+        if isinstance(primary_key, str):
+            primary_key = [primary_key]
+
+        # Metadata
+        if "description" in table_schema:
+            metadata["description"] = table_schema["description"]
+
+        total_constraints = 0
+
+        for field_def in fields:
+            field_name = field_def.get("name", "")
+            field_type = field_def.get("type", "any")
+            dtype = _FRICTIONLESS_TYPE_MAP.get(field_type)
+
+            columns.append((field_name, dtype))
+
+            # Constraints
+            field_constraints = field_def.get("constraints", {})
+
+            # required
+            if field_constraints.get("required", False):
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_not_null",
+                        kwargs={"columns": field_name},
+                        source_description=f"constraints.required: {field_name}",
+                    )
+                )
+
+            # unique
+            if field_constraints.get("unique", False):
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="rows_distinct",
+                        kwargs={"columns_subset": field_name},
+                        source_description=f"constraints.unique: {field_name}",
+                    )
+                )
+
+            # minimum
+            if "minimum" in field_constraints:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_ge",
+                        kwargs={"columns": field_name, "value": field_constraints["minimum"]},
+                        source_description=f"constraints.minimum: {field_constraints['minimum']}",
+                    )
+                )
+
+            # maximum
+            if "maximum" in field_constraints:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_le",
+                        kwargs={"columns": field_name, "value": field_constraints["maximum"]},
+                        source_description=f"constraints.maximum: {field_constraints['maximum']}",
+                    )
+                )
+
+            # enum
+            if "enum" in field_constraints:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_in_set",
+                        kwargs={"columns": field_name, "set": field_constraints["enum"]},
+                        source_description=f"constraints.enum: {field_constraints['enum']}",
+                    )
+                )
+
+            # pattern
+            if "pattern" in field_constraints:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_regex",
+                        kwargs={"columns": field_name, "pattern": field_constraints["pattern"]},
+                        source_description=f"constraints.pattern: {field_constraints['pattern']}",
+                    )
+                )
+
+        # Primary key -> not_null + distinct
+        if primary_key:
+            for pk_col in primary_key:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_not_null",
+                        kwargs={"columns": pk_col},
+                        source_description=f"primaryKey: {pk_col} (not null)",
+                    )
+                )
+            total_constraints += 1
+            if len(primary_key) == 1:
+                constraints.append(
+                    MappedConstraint(
+                        method="rows_distinct",
+                        kwargs={"columns_subset": primary_key[0]},
+                        source_description=f"primaryKey: {primary_key[0]} (unique)",
+                    )
+                )
+            else:
+                constraints.append(
+                    MappedConstraint(
+                        method="rows_distinct",
+                        kwargs={"columns_subset": primary_key},
+                        source_description=f"primaryKey: {primary_key} (composite unique)",
+                    )
+                )
+
+        # Foreign keys -> warnings (cross-table not supported yet)
+        foreign_keys = table_schema.get("foreignKeys", [])
+        for fk in foreign_keys:
+            total_constraints += 1
+            warnings.append(
+                f"Foreign key constraint skipped (cross-table validation not supported): "
+                f"{fk.get('fields', '?')} → {fk.get('reference', {}).get('resource', '?')}."
+                f"{fk.get('reference', {}).get('fields', '?')}"
+            )
+
+        # Calculate coverage
+        coverage = 1.0
+        if total_constraints > 0:
+            mapped_count = total_constraints - len(warnings)
+            coverage = mapped_count / total_constraints
+
+        return ContractImport(
+            source_format="frictionless",
+            source_path=source_path,
+            source_version=None,
+            columns=columns,
+            constraints=constraints,
+            metadata=metadata,
+            warnings=warnings,
+            coverage=coverage,
+        )
+

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -27,3 +27,44 @@ _FRICTIONLESS_TYPE_MAP: dict[str, str] = {
 }
 
 
+@register_adapter("frictionless")
+class FrictionlessAdapter(ContractAdapter):
+    """Adapter for Frictionless Data Table Schema.
+
+    Supports import from Frictionless Table Schema (standalone or within a Data Package descriptor),
+    and export back to Table Schema format.
+
+    Take a look at https://specs.frictionlessdata.io/table-schema/ for the specification details.
+    """
+
+    format_name = "frictionless"
+    file_extensions = [".resource.json", ".datapackage.json"]
+    supports_import = True
+    supports_export = True
+
+    @staticmethod
+    def detect(source: Any) -> bool:
+        """Detect if the source is a Frictionless Table Schema or Data Package."""
+        if isinstance(source, dict):
+            # Table Schema has "fields" at top level
+            if "fields" in source and isinstance(source["fields"], list):
+                return True
+            # Data Package has "resources"
+            if "resources" in source:
+                return True
+            return False
+
+        if isinstance(source, str):
+            path = Path(source)
+            if path.suffix == ".json" and path.exists():
+                try:
+                    with open(path) as f:
+                        data = json.load(f)
+                    return (
+                        "fields" in data and isinstance(data.get("fields"), list)
+                    ) or "resources" in data
+                except (json.JSONDecodeError, OSError):
+                    return False
+
+        return False
+

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -414,3 +414,47 @@ def _pb_dtype_to_frictionless_type(dtype: str) -> str | None:
     return None
 
 
+def _apply_step_to_fields(
+    method: str,
+    kwargs: dict[str, Any],
+    field_map: dict[str, dict[str, Any]],
+    fields: list[dict[str, Any]],
+) -> None:
+    """Apply a validation step to Frictionless field definitions."""
+    columns = kwargs.get("columns", kwargs.get("column", kwargs.get("columns_subset")))
+    if columns is None:
+        return
+
+    if isinstance(columns, str):
+        col_list = [columns]
+    elif isinstance(columns, list):
+        col_list = columns
+    else:
+        return
+
+    for col in col_list:
+        if col not in field_map:
+            field_def: dict[str, Any] = {"name": col}
+            fields.append(field_def)
+            field_map[col] = field_def
+
+        field_def = field_map[col]
+        if "constraints" not in field_def:
+            field_def["constraints"] = {}
+
+        constraints = field_def["constraints"]
+
+        if method == "col_vals_not_null":
+            constraints["required"] = True
+        elif method == "rows_distinct":
+            constraints["unique"] = True
+        elif method == "col_vals_ge":
+            constraints["minimum"] = kwargs.get("value")
+        elif method == "col_vals_le":
+            constraints["maximum"] = kwargs.get("value")
+        elif method == "col_vals_in_set":
+            constraints["enum"] = kwargs.get("set")
+        elif method == "col_vals_regex":
+            constraints["pattern"] = kwargs.get("pattern")
+
+

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -373,3 +373,22 @@ class FrictionlessAdapter(ContractAdapter):
         table_schema: dict[str, Any] = {"fields": fields}
         return table_schema
 
+    def _export_from_validate(self, validation: Any) -> dict[str, Any]:
+        """Export a Validate to Frictionless Table Schema (best-effort)."""
+        fields: list[dict[str, Any]] = []
+        field_map: dict[str, dict[str, Any]] = {}
+
+        for step in validation.validation_info:
+            method = step.assertion_type
+            col = step.column
+            if col and col not in field_map:
+                field_def: dict[str, Any] = {"name": col}
+                fields.append(field_def)
+                field_map[col] = field_def
+
+            kwargs = _extract_validate_step_kwargs_from_info(step)
+            _apply_step_to_fields(method, kwargs, field_map, fields)
+
+        return {"fields": fields}
+
+

--- a/pointblank/adapters/_frictionless.py
+++ b/pointblank/adapters/_frictionless.py
@@ -351,3 +351,25 @@ class FrictionlessAdapter(ContractAdapter):
             coverage=coverage,
         )
 
+    def _export_from_contract(self, contract: Any) -> dict[str, Any]:
+        """Export a Contract to Frictionless Table Schema."""
+        fields: list[dict[str, Any]] = []
+
+        # Build fields from schema
+        if contract.schema is not None and contract.schema.columns is not None:
+            for col_name, col_dtype in contract.schema.columns:
+                field_def: dict[str, Any] = {"name": col_name}
+                if col_dtype:
+                    fl_type = _pb_dtype_to_frictionless_type(str(col_dtype))
+                    if fl_type:
+                        field_def["type"] = fl_type
+                fields.append(field_def)
+
+        # Apply step constraints
+        field_map = {f["name"]: f for f in fields}
+        for step in contract.steps:
+            _apply_step_to_fields(step.method, step.kwargs, field_map, fields)
+
+        table_schema: dict[str, Any] = {"fields": fields}
+        return table_schema
+

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -15,7 +15,7 @@ _JSON_SCHEMA_TYPE_MAP: dict[str, str] = {
     "boolean": "Boolean",
 }
 
-# Mapping from JSON Schema "format" to col_vals_within_spec specs
+# Mapping from JSON Schema "format" to `col_vals_within_spec()` specs
 _JSON_SCHEMA_FORMAT_MAP: dict[str, str] = {
     "email": "email",
     "uri": "url",

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -25,3 +25,34 @@ _JSON_SCHEMA_FORMAT_MAP: dict[str, str] = {
 }
 
 
+@register_adapter("json_schema")
+class JSONSchemaAdapter(ContractAdapter):
+    """Adapter for JSON Schema (Draft 2020-12 and earlier drafts).
+
+    Supports import from JSON Schema files or dicts, and export of Pointblank validations back to
+    JSON Schema format.
+    """
+
+    format_name = "json_schema"
+    file_extensions = [".schema.json"]
+    supports_import = True
+    supports_export = True
+
+    @staticmethod
+    def detect(source: Any) -> bool:
+        """Detect if the source is a JSON Schema document."""
+        if isinstance(source, dict):
+            return "$schema" in source or ("type" in source and "properties" in source)
+
+        if isinstance(source, str):
+            path = Path(source)
+            if path.suffix == ".json" and path.exists():
+                try:
+                    with open(path) as f:
+                        data = json.load(f)
+                    return "$schema" in data or ("type" in data and "properties" in data)
+                except (json.JSONDecodeError, OSError):
+                    return False
+
+        return False
+

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -300,3 +300,39 @@ class JSONSchemaAdapter(ContractAdapter):
             coverage=coverage,
         )
 
+    def _export_from_contract(self, contract: Any) -> dict[str, Any]:
+        """Export a Contract object to JSON Schema."""
+
+        schema_doc: dict[str, Any] = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "title": contract.name,
+        }
+
+        if contract.description:
+            schema_doc["description"] = contract.description
+
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+
+        # From the contract's Schema
+        if contract.schema is not None and contract.schema.columns is not None:
+            for col_name, col_dtype in contract.schema.columns:
+                prop: dict[str, Any] = {}
+                if col_dtype:
+                    json_type = _pb_dtype_to_json_type(str(col_dtype))
+                    if json_type:
+                        prop["type"] = json_type
+                properties[col_name] = prop
+
+        # From the contract's Steps
+        for step in contract.steps:
+            _apply_step_to_properties(step.method, step.kwargs, properties, required)
+
+        if properties:
+            schema_doc["properties"] = properties
+        if required:
+            schema_doc["required"] = required
+
+        return schema_doc
+

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -89,3 +89,45 @@ class JSONSchemaAdapter(ContractAdapter):
 
         return self._parse_schema(schema_doc, source_path=source_path)
 
+    def export_contract(
+        self,
+        validation_or_contract: Any,
+        destination: str | None = None,
+        **kwargs: Any,
+    ) -> str | dict[str, Any]:
+        """Export a Validate or Contract to JSON Schema format.
+
+        Parameters
+        ----------
+        validation_or_contract
+            A `Validate` or `Contract` object.
+        destination
+            Optional file path to write the JSON Schema.
+        **kwargs
+            Not currently used.
+
+        Returns
+        -------
+        dict
+            The JSON Schema document as a dict.
+        """
+        from pointblank.contract import Contract
+        from pointblank.validate import Validate
+
+        if isinstance(validation_or_contract, Contract):
+            schema_doc = self._export_from_contract(validation_or_contract)
+        elif isinstance(validation_or_contract, Validate):
+            schema_doc = self._export_from_validate(validation_or_contract)
+        else:
+            raise TypeError(
+                f"Expected a Validate or Contract object, got {type(validation_or_contract).__name__}"
+            )
+
+        if destination is not None:
+            path = Path(destination)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w") as f:
+                json.dump(schema_doc, f, indent=2)
+
+        return schema_doc
+

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pointblank.adapters._base import ContractAdapter, ContractImport, MappedConstraint
+from pointblank.adapters._registry import register_adapter
+
+# Mapping from JSON Schema types to Pointblank/Narwhals dtype strings
+_JSON_SCHEMA_TYPE_MAP: dict[str, str] = {
+    "integer": "Int64",
+    "number": "Float64",
+    "string": "String",
+    "boolean": "Boolean",
+}
+
+# Mapping from JSON Schema "format" to col_vals_within_spec specs
+_JSON_SCHEMA_FORMAT_MAP: dict[str, str] = {
+    "email": "email",
+    "uri": "url",
+    "uri-reference": "url",
+    "ipv4": "ipv4",
+    "ipv6": "ipv6",
+}
+
+

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -430,3 +430,27 @@ def _apply_step_to_properties(
             properties[col]["const"] = kwargs.get("value")
 
 
+def _extract_step_kwargs_from_info(step_info: Any) -> dict[str, Any]:
+    """Extract kwargs-like dict from a `_ValidationInfo` object."""
+    kwargs: dict[str, Any] = {}
+
+    if hasattr(step_info, "column") and step_info.column:
+        kwargs["columns"] = step_info.column
+
+    if hasattr(step_info, "values") and step_info.values is not None:
+        val = step_info.values
+        if isinstance(val, (list, tuple)):
+            kwargs["set"] = list(val)
+        else:
+            kwargs["value"] = val
+
+    # Check val_info for pattern/spec
+    if hasattr(step_info, "val_info") and step_info.val_info:
+        val_info = step_info.val_info
+        if isinstance(val_info, dict):
+            if "pattern" in val_info:
+                kwargs["pattern"] = val_info["pattern"]
+            if "spec" in val_info:
+                kwargs["spec"] = val_info["spec"]
+
+    return kwargs

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -367,3 +367,17 @@ class JSONSchemaAdapter(ContractAdapter):
         return schema_doc
 
 
+def _pb_dtype_to_json_type(dtype: str) -> str | None:
+    """Map a Pointblank/Narwhals dtype string to a JSON Schema type."""
+    dtype_lower = dtype.lower()
+    if "int" in dtype_lower:
+        return "integer"
+    if "float" in dtype_lower or "double" in dtype_lower or "decimal" in dtype_lower:
+        return "number"
+    if "str" in dtype_lower or "utf8" in dtype_lower or "object" in dtype_lower:
+        return "string"
+    if "bool" in dtype_lower:
+        return "boolean"
+    return None
+
+

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -381,3 +381,52 @@ def _pb_dtype_to_json_type(dtype: str) -> str | None:
     return None
 
 
+def _apply_step_to_properties(
+    method: str,
+    kwargs: dict[str, Any],
+    properties: dict[str, Any],
+    required: list[str],
+) -> None:
+    """Apply a validation step's information to the JSON Schema properties dict."""
+    columns = kwargs.get("columns", kwargs.get("column", kwargs.get("columns_subset")))
+    if columns is None:
+        return
+
+    # Normalize to list
+    if isinstance(columns, str):
+        col_list = [columns]
+    elif isinstance(columns, list):
+        col_list = columns
+    else:
+        return
+
+    for col in col_list:
+        if col not in properties:
+            properties[col] = {}
+
+        if method == "col_vals_not_null":
+            if col not in required:
+                required.append(col)
+        elif method == "col_vals_ge":
+            properties[col]["minimum"] = kwargs.get("value")
+        elif method == "col_vals_le":
+            properties[col]["maximum"] = kwargs.get("value")
+        elif method == "col_vals_gt":
+            properties[col]["exclusiveMinimum"] = kwargs.get("value")
+        elif method == "col_vals_lt":
+            properties[col]["exclusiveMaximum"] = kwargs.get("value")
+        elif method == "col_vals_in_set":
+            properties[col]["enum"] = kwargs.get("set")
+        elif method == "col_vals_regex":
+            properties[col]["pattern"] = kwargs.get("pattern")
+        elif method == "col_vals_within_spec":
+            spec = kwargs.get("spec", "")
+            # Reverse map
+            for json_fmt, pb_spec in _JSON_SCHEMA_FORMAT_MAP.items():
+                if pb_spec == spec:
+                    properties[col]["format"] = json_fmt
+                    break
+        elif method == "col_vals_eq":
+            properties[col]["const"] = kwargs.get("value")
+
+

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -131,3 +131,172 @@ class JSONSchemaAdapter(ContractAdapter):
 
         return schema_doc
 
+    def _parse_schema(
+        self, schema_doc: dict[str, Any], source_path: str | None = None
+    ) -> ContractImport:
+        """Parse a JSON Schema dict into a ContractImport."""
+        columns: list[tuple[str, str | None]] = []
+        constraints: list[MappedConstraint] = []
+        warnings: list[str] = []
+        metadata: dict[str, Any] = {}
+
+        # Extract metadata
+        if "title" in schema_doc:
+            metadata["title"] = schema_doc["title"]
+        if "description" in schema_doc:
+            metadata["description"] = schema_doc["description"]
+
+        # Detect schema version
+        source_version = schema_doc.get("$schema")
+
+        # Extract properties (the main column definitions)
+        properties = schema_doc.get("properties", {})
+        required_fields = set(schema_doc.get("required", []))
+
+        total_constraints = 0
+
+        for prop_name, prop_schema in properties.items():
+            # Determine dtype from type
+            prop_type = prop_schema.get("type")
+            dtype = None
+            if isinstance(prop_type, str):
+                dtype = _JSON_SCHEMA_TYPE_MAP.get(prop_type)
+            elif isinstance(prop_type, list):
+                # Union type like ["string", "null"] — use the non-null type
+                non_null = [t for t in prop_type if t != "null"]
+                if non_null:
+                    dtype = _JSON_SCHEMA_TYPE_MAP.get(non_null[0])
+
+            columns.append((prop_name, dtype))
+
+            # Required fields -> col_vals_not_null
+            if prop_name in required_fields:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_not_null",
+                        kwargs={"columns": prop_name},
+                        source_description=f"required field: {prop_name}",
+                    )
+                )
+
+            # minimum -> col_vals_ge
+            if "minimum" in prop_schema:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_ge",
+                        kwargs={"columns": prop_name, "value": prop_schema["minimum"]},
+                        source_description=f"minimum: {prop_schema['minimum']}",
+                    )
+                )
+
+            # maximum -> col_vals_le
+            if "maximum" in prop_schema:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_le",
+                        kwargs={"columns": prop_name, "value": prop_schema["maximum"]},
+                        source_description=f"maximum: {prop_schema['maximum']}",
+                    )
+                )
+
+            # exclusiveMinimum -> col_vals_gt
+            if "exclusiveMinimum" in prop_schema:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_gt",
+                        kwargs={
+                            "columns": prop_name,
+                            "value": prop_schema["exclusiveMinimum"],
+                        },
+                        source_description=f"exclusiveMinimum: {prop_schema['exclusiveMinimum']}",
+                    )
+                )
+
+            # exclusiveMaximum -> col_vals_lt
+            if "exclusiveMaximum" in prop_schema:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_lt",
+                        kwargs={
+                            "columns": prop_name,
+                            "value": prop_schema["exclusiveMaximum"],
+                        },
+                        source_description=f"exclusiveMaximum: {prop_schema['exclusiveMaximum']}",
+                    )
+                )
+
+            # enum -> col_vals_in_set
+            if "enum" in prop_schema:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_in_set",
+                        kwargs={"columns": prop_name, "set": prop_schema["enum"]},
+                        source_description=f"enum: {prop_schema['enum']}",
+                    )
+                )
+
+            # pattern -> col_vals_regex
+            if "pattern" in prop_schema:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_regex",
+                        kwargs={"columns": prop_name, "pattern": prop_schema["pattern"]},
+                        source_description=f"pattern: {prop_schema['pattern']}",
+                    )
+                )
+
+            # format -> col_vals_within_spec (where applicable)
+            if "format" in prop_schema:
+                fmt = prop_schema["format"]
+                spec = _JSON_SCHEMA_FORMAT_MAP.get(fmt)
+                if spec:
+                    total_constraints += 1
+                    constraints.append(
+                        MappedConstraint(
+                            method="col_vals_within_spec",
+                            kwargs={"columns": prop_name, "spec": spec},
+                            source_description=f"format: {fmt}",
+                        )
+                    )
+                else:
+                    total_constraints += 1
+                    warnings.append(
+                        f"Column '{prop_name}': JSON Schema format '{fmt}' has no "
+                        f"Pointblank equivalent — skipped."
+                    )
+
+            # const -> col_vals_eq
+            if "const" in prop_schema:
+                total_constraints += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_eq",
+                        kwargs={"columns": prop_name, "value": prop_schema["const"]},
+                        source_description=f"const: {prop_schema['const']}",
+                    )
+                )
+
+        # Calculate coverage
+        coverage = 1.0
+        if total_constraints > 0:
+            mapped_count = total_constraints - len(warnings)
+            coverage = mapped_count / total_constraints
+
+        return ContractImport(
+            source_format="json_schema",
+            source_path=source_path,
+            source_version=source_version,
+            columns=columns,
+            constraints=constraints,
+            metadata=metadata,
+            warnings=warnings,
+            coverage=coverage,
+        )
+

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -336,3 +336,34 @@ class JSONSchemaAdapter(ContractAdapter):
 
         return schema_doc
 
+    def _export_from_validate(self, validation: Any) -> dict[str, Any]:
+        """Export a Validate object to JSON Schema.
+
+        This is a best-effort export. It scans the validation steps and maps them back to JSON
+        Schema constraints where possible.
+        """
+        schema_doc: dict[str, Any] = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+        }
+
+        if hasattr(validation, "_tbl_name") and validation._tbl_name:
+            schema_doc["title"] = validation._tbl_name
+
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+
+        # Walk through validation steps
+        for step in validation.validation_info:
+            method = step.assertion_type
+            kwargs = _extract_step_kwargs_from_info(step)
+            _apply_step_to_properties(method, kwargs, properties, required)
+
+        if properties:
+            schema_doc["properties"] = properties
+        if required:
+            schema_doc["required"] = required
+
+        return schema_doc
+
+

--- a/pointblank/adapters/_json_schema.py
+++ b/pointblank/adapters/_json_schema.py
@@ -56,3 +56,36 @@ class JSONSchemaAdapter(ContractAdapter):
 
         return False
 
+    def import_contract(self, source: Any, **kwargs: Any) -> ContractImport:
+        """Import a JSON Schema document into a ContractImport.
+
+        Parameters
+        ----------
+        source
+            A file path (str) to a .json file, or a dict with the schema content.
+        **kwargs
+            Not currently used.
+
+        Returns
+        -------
+        ContractImport
+            The import result.
+        """
+        source_path = None
+
+        if isinstance(source, str):
+            source_path = source
+            path = Path(source)
+            if not path.exists():
+                raise FileNotFoundError(f"JSON Schema file not found: {source}")
+            with open(path) as f:
+                schema_doc = json.load(f)
+        elif isinstance(source, dict):
+            schema_doc = source
+        else:
+            raise TypeError(
+                f"JSON Schema source must be a file path (str) or dict, got {type(source).__name__}"
+            )
+
+        return self._parse_schema(schema_doc, source_path=source_path)
+

--- a/pointblank/adapters/_registry.py
+++ b/pointblank/adapters/_registry.py
@@ -78,3 +78,27 @@ def get_adapter(format_name: str) -> ContractAdapter:
     return _ADAPTER_REGISTRY[format_name]
 
 
+def list_adapters() -> dict[str, dict[str, Any]]:
+    """List all registered adapters with their capabilities.
+
+    Returns
+    -------
+    dict
+        A dictionary mapping format names to adapter info dicts with keys:
+
+        - "class": the adapter class name
+        - "file_extensions": associated file extensions
+        - "supports_import": whether import is supported
+        - "supports_export": whether export is supported
+    """
+    result = {}
+    for name, adapter in sorted(_ADAPTER_REGISTRY.items()):
+        result[name] = {
+            "class": type(adapter).__name__,
+            "file_extensions": adapter.file_extensions,
+            "supports_import": adapter.supports_import,
+            "supports_export": adapter.supports_export,
+        }
+    return result
+
+

--- a/pointblank/adapters/_registry.py
+++ b/pointblank/adapters/_registry.py
@@ -102,3 +102,35 @@ def list_adapters() -> dict[str, dict[str, Any]]:
     return result
 
 
+def _detect_format(source: Any) -> str | None:
+    """Attempt to auto-detect the format of a source.
+
+    Tries each registered adapter's `detect()` method.
+
+    Parameters
+    ----------
+    source
+        The source to detect (file path, dict, or object).
+
+    Returns
+    -------
+    str | None
+        The format name if detected, else `None`.
+    """
+    # First try extension-based detection for file paths
+    if isinstance(source, str):
+        source_lower = source.lower()
+        for name, adapter in _ADAPTER_REGISTRY.items():
+            for ext in adapter.file_extensions:
+                if source_lower.endswith(ext):
+                    return name
+
+    # Then try content-based detection
+    for name, adapter in _ADAPTER_REGISTRY.items():
+        try:
+            if adapter.detect(source):
+                return name
+        except (NotImplementedError, Exception):
+            continue
+
+    return None

--- a/pointblank/adapters/_registry.py
+++ b/pointblank/adapters/_registry.py
@@ -52,3 +52,29 @@ def register_adapter(format_name: str | None = None):
     return decorator
 
 
+def get_adapter(format_name: str) -> ContractAdapter:
+    """Get a registered adapter by format name.
+
+    Parameters
+    ----------
+    format_name
+        The format identifier (e.g., `"json_schema"`, `"frictionless"`).
+
+    Returns
+    -------
+    ContractAdapter
+        The registered adapter instance.
+
+    Raises
+    ------
+    ValueError
+        If no adapter is registered for the given format.
+    """
+    if format_name not in _ADAPTER_REGISTRY:
+        available = ", ".join(sorted(_ADAPTER_REGISTRY.keys())) or "(none)"
+        raise ValueError(
+            f"No adapter registered for format '{format_name}'. Available adapters: {available}"
+        )
+    return _ADAPTER_REGISTRY[format_name]
+
+

--- a/pointblank/adapters/_registry.py
+++ b/pointblank/adapters/_registry.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pointblank.adapters._base import ContractAdapter
+
+# Global adapter registry: format_name -> adapter instance
+_ADAPTER_REGISTRY: dict[str, ContractAdapter] = {}
+
+
+def register_adapter(format_name: str | None = None):
+    """Register a contract adapter class.
+
+    Can be used as a decorator (with or without arguments) or called directly.
+
+    Parameters
+    ----------
+    format_name
+        The format name to register under. If `None`, uses the class's `format_name` attribute.
+
+    Returns
+    -------
+    type
+        The adapter class (unmodified), enabling use as a decorator.
+
+    Examples
+    --------
+    ```python
+    @pb.register_adapter("my_format")
+    class MyAdapter(pb.ContractAdapter):
+        format_name = "my_format"
+        ...
+    ```
+    """
+
+    def decorator(cls: type[ContractAdapter]) -> type[ContractAdapter]:
+        name = format_name or cls.format_name
+        if not name:
+            raise ValueError(
+                f"Adapter {cls.__name__} must have a `format_name` or be registered with one."
+            )
+        _ADAPTER_REGISTRY[name] = cls()
+        return cls
+
+    # Allow use as @register_adapter (no parentheses) or @register_adapter("name")
+    if isinstance(format_name, type):
+        # Called as @register_adapter without arguments, format_name is actually the class
+        cls = format_name
+        format_name = None
+        return decorator(cls)
+
+    return decorator
+
+

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -171,3 +171,95 @@ class TestRegistry:
         del _ADAPTER_REGISTRY["test_custom"]
 
 
+class TestContractImport:
+    def test_to_validate(self, simple_df):
+        result = ContractImport(
+            source_format="test",
+            columns=[("age", "Int64"), ("name", "String")],
+            constraints=[
+                MappedConstraint(
+                    method="col_vals_ge",
+                    kwargs={"columns": "age", "value": 0},
+                ),
+                MappedConstraint(
+                    method="col_vals_not_null",
+                    kwargs={"columns": "name"},
+                ),
+            ],
+        )
+        validation = result.to_validate(data=simple_df)
+        # Should have schema check + 2 constraint steps
+        assert len(validation.validation_info) == 3
+
+    def test_to_contract(self):
+        result = ContractImport(
+            source_format="test",
+            columns=[("age", "Int64")],
+            constraints=[
+                MappedConstraint(
+                    method="col_vals_ge",
+                    kwargs={"columns": "age", "value": 0},
+                ),
+            ],
+            metadata={"description": "Test contract"},
+        )
+        contract = result.to_contract(name="my_contract")
+        assert contract.name == "my_contract"
+        assert contract.description == "Test contract"
+        assert contract.schema is not None
+        assert len(contract.steps) == 1
+        assert contract.steps[0].method == "col_vals_ge"
+
+    def test_to_python(self):
+        result = ContractImport(
+            source_format="test",
+            columns=[("age", "Int64")],
+            constraints=[
+                MappedConstraint(method="col_vals_ge", kwargs={"columns": "age", "value": 0}),
+            ],
+        )
+        code = result.to_python()
+        assert "import pointblank as pb" in code
+        assert "pb.Validate(data=data)" in code
+        assert ".col_vals_ge(" in code
+        assert "pb.Schema(" in code
+
+    def test_to_yaml(self):
+        result = ContractImport(
+            source_format="test",
+            columns=[("age", "Int64")],
+            constraints=[
+                MappedConstraint(method="col_vals_ge", kwargs={"columns": "age", "value": 0}),
+            ],
+        )
+        yaml_str = result.to_yaml()
+        assert "col_schema_match" in yaml_str
+        assert "col_vals_ge" in yaml_str
+
+    def test_summary(self):
+        result = ContractImport(
+            source_format="json_schema",
+            source_path="/path/to/file.json",
+            columns=[("a", "Int64"), ("b", "String")],
+            constraints=[MappedConstraint(method="col_vals_ge", kwargs={})],
+            warnings=["Some warning"],
+            coverage=0.8,
+        )
+        summary = result.summary()
+        assert "json_schema" in summary
+        assert "Columns detected: 2" in summary
+        assert "Constraints mapped: 1" in summary
+        assert "80%" in summary
+        assert "Some warning" in summary
+
+    def test_repr(self):
+        result = ContractImport(
+            source_format="json_schema",
+            columns=[("a", "Int64")],
+            constraints=[MappedConstraint(method="col_vals_ge", kwargs={})],
+            coverage=1.0,
+        )
+        assert "json_schema" in repr(result)
+        assert "columns=1" in repr(result)
+
+

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import json
 import tempfile

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -540,3 +540,125 @@ class TestFrictionlessImport:
         assert result.source_format == "frictionless"
 
 
+class TestFrictionlessExport:
+    def test_export_from_contract(self):
+        contract = pb.Contract(
+            name="test_export",
+            schema=pb.Schema(id="Int64", name="String", age="Int64"),
+            steps=[
+                pb.Step("col_vals_not_null", columns="id"),
+                pb.Step("rows_distinct", columns="id"),
+                pb.Step("col_vals_ge", columns="age", value=0),
+            ],
+        )
+        result = export_contract(contract, format="frictionless")
+
+        assert "fields" in result
+        fields = result["fields"]
+        assert len(fields) == 3
+
+        # Check field types
+        field_map = {f["name"]: f for f in fields}
+        assert field_map["id"]["type"] == "integer"
+        assert field_map["name"]["type"] == "string"
+        assert field_map["id"]["constraints"]["required"] is True
+        assert field_map["id"]["constraints"]["unique"] is True
+        assert field_map["age"]["constraints"]["minimum"] == 0
+
+    def test_export_to_file(self):
+        contract = pb.Contract(
+            name="test",
+            schema=pb.Schema(x="Int64"),
+            steps=[],
+        )
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            export_contract(contract, f.name, format="frictionless")
+
+        with open(f.name) as fh:
+            data = json.load(fh)
+        assert "fields" in data
+
+
+class TestImportContractAPI:
+    def test_format_required_or_detectable(self):
+        """Should raise if format can't be detected."""
+        with pytest.raises(ValueError, match="Could not auto-detect"):
+            import_contract({"random": "data"})
+
+    def test_unsupported_format_raises(self):
+        with pytest.raises(ValueError, match="No adapter registered"):
+            import_contract("file.txt", format="made_up_format")
+
+
+class TestExportContractAPI:
+    def test_unsupported_format_raises(self):
+        with pytest.raises(ValueError, match="No adapter registered"):
+            export_contract(pb.Contract(name="x"), format="made_up_format")
+
+
+class TestRoundTrip:
+    def test_json_schema_roundtrip(self):
+        """Import JSON Schema -> export -> re-import should produce equivalent constraints."""
+        original_schema = {
+            "type": "object",
+            "properties": {
+                "age": {"type": "integer", "minimum": 0, "maximum": 150},
+                "status": {"type": "string", "enum": ["active", "inactive"]},
+            },
+            "required": ["age"],
+        }
+
+        # Import
+        imported = import_contract(original_schema, format="json_schema")
+
+        # Create a contract from it
+        contract = imported.to_contract(name="roundtrip_test")
+
+        # Export back to JSON Schema
+        exported = export_contract(contract, format="json_schema")
+
+        # Re-import
+        reimported = import_contract(exported, format="json_schema")
+
+        # Verify same constraints exist (use frozenset for list values)
+        def _hashable_kwargs(kwargs):
+            items = []
+            for k, v in sorted(kwargs.items()):
+                items.append((k, tuple(v) if isinstance(v, list) else v))
+            return tuple(items)
+
+        original_methods = {(c.method, _hashable_kwargs(c.kwargs)) for c in imported.constraints}
+        roundtrip_methods = {(c.method, _hashable_kwargs(c.kwargs)) for c in reimported.constraints}
+        assert original_methods == roundtrip_methods
+
+    def test_frictionless_roundtrip(self):
+        """Import Frictionless -> export -> re-import should produce equivalent constraints."""
+        original_schema = {
+            "fields": [
+                {
+                    "name": "age",
+                    "type": "integer",
+                    "constraints": {"required": True, "minimum": 0},
+                },
+                {
+                    "name": "status",
+                    "type": "string",
+                    "constraints": {"enum": ["active", "inactive"]},
+                },
+            ],
+        }
+
+        imported = import_contract(original_schema, format="frictionless")
+        contract = imported.to_contract(name="roundtrip_test")
+        exported = export_contract(contract, format="frictionless")
+        reimported = import_contract(exported, format="frictionless")
+
+        def _hashable_kwargs(kwargs):
+            items = []
+            for k, v in sorted(kwargs.items()):
+                items.append((k, tuple(v) if isinstance(v, list) else v))
+            return tuple(items)
+
+        original_methods = {(c.method, _hashable_kwargs(c.kwargs)) for c in imported.constraints}
+        roundtrip_methods = {(c.method, _hashable_kwargs(c.kwargs)) for c in reimported.constraints}
+        assert original_methods == roundtrip_methods

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -119,3 +119,55 @@ def frictionless_datapackage_dict(frictionless_schema_dict):
     }
 
 
+class TestRegistry:
+    def test_builtin_adapters_registered(self):
+        """Built-in adapters should be registered on import."""
+        adapters = list_adapters()
+        assert "json_schema" in adapters
+        assert "frictionless" in adapters
+
+    def test_get_adapter_json_schema(self):
+        adapter = get_adapter("json_schema")
+        assert adapter.format_name == "json_schema"
+        assert adapter.supports_import is True
+        assert adapter.supports_export is True
+
+    def test_get_adapter_frictionless(self):
+        adapter = get_adapter("frictionless")
+        assert adapter.format_name == "frictionless"
+
+    def test_get_adapter_unknown_raises(self):
+        with pytest.raises(ValueError, match="No adapter registered"):
+            get_adapter("nonexistent_format")
+
+    def test_list_adapters_info(self):
+        adapters = list_adapters()
+        for name, info in adapters.items():
+            assert "class" in info
+            assert "file_extensions" in info
+            assert "supports_import" in info
+            assert "supports_export" in info
+
+    def test_register_custom_adapter(self):
+        """Custom adapters can be registered via decorator."""
+
+        @register_adapter("test_custom")
+        class TestCustomAdapter(ContractAdapter):
+            format_name = "test_custom"
+            file_extensions = [".custom"]
+
+            @staticmethod
+            def detect(source):
+                return False
+
+            def import_contract(self, source, **kwargs):
+                return ContractImport(source_format="test_custom")
+
+        assert "test_custom" in list_adapters()
+        adapter = get_adapter("test_custom")
+        assert adapter.format_name == "test_custom"
+
+        # Cleanup
+        del _ADAPTER_REGISTRY["test_custom"]
+
+

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -376,3 +376,167 @@ class TestJSONSchemaImport:
         assert col_map["nickname"] == "String"
 
 
+class TestJSONSchemaExport:
+    def test_export_from_contract(self):
+        contract = pb.Contract(
+            name="test_export",
+            schema=pb.Schema(age="Int64", name="String"),
+            steps=[
+                pb.Step("col_vals_ge", columns="age", value=0),
+                pb.Step("col_vals_not_null", columns="name"),
+            ],
+        )
+        result = export_contract(contract, format="json_schema")
+
+        assert result["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        assert result["title"] == "test_export"
+        assert "properties" in result
+        assert result["properties"]["age"]["type"] == "integer"
+        assert result["properties"]["age"]["minimum"] == 0
+        assert "name" in result["required"]
+
+    def test_export_to_file(self):
+        contract = pb.Contract(
+            name="test_file_export",
+            schema=pb.Schema(id="Int64"),
+            steps=[],
+        )
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            export_contract(contract, f.name, format="json_schema")
+            f.flush()
+
+        with open(f.name) as fh:
+            data = json.load(fh)
+
+        assert data["title"] == "test_file_export"
+        assert "properties" in data
+
+    def test_export_invalid_type_raises(self):
+        with pytest.raises(TypeError, match="Expected a Validate or Contract"):
+            export_contract("not a contract", format="json_schema")
+
+
+class TestFrictionlessImport:
+    def test_import_from_dict(self, frictionless_schema_dict):
+        result = import_contract(frictionless_schema_dict, format="frictionless")
+
+        assert result.source_format == "frictionless"
+        assert len(result.columns) == 5
+
+        col_map = dict(result.columns)
+        assert col_map["id"] == "Int64"
+        assert col_map["name"] == "String"
+        assert col_map["age"] == "Int64"
+        assert col_map["status"] == "String"
+
+    def test_import_constraints_required(self, frictionless_schema_dict):
+        result = import_contract(frictionless_schema_dict, format="frictionless")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        assert ("col_vals_not_null", {"columns": "id"}) in methods
+        assert ("col_vals_not_null", {"columns": "name"}) in methods
+
+    def test_import_constraints_unique(self, frictionless_schema_dict):
+        result = import_contract(frictionless_schema_dict, format="frictionless")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        assert ("rows_distinct", {"columns_subset": "id"}) in methods
+
+    def test_import_constraints_min_max(self, frictionless_schema_dict):
+        result = import_contract(frictionless_schema_dict, format="frictionless")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        assert ("col_vals_ge", {"columns": "age", "value": 0}) in methods
+        assert ("col_vals_le", {"columns": "age", "value": 150}) in methods
+
+    def test_import_constraints_enum(self, frictionless_schema_dict):
+        result = import_contract(frictionless_schema_dict, format="frictionless")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        assert (
+            "col_vals_in_set",
+            {"columns": "status", "set": ["active", "inactive"]},
+        ) in methods
+
+    def test_import_constraints_pattern(self, frictionless_schema_dict):
+        result = import_contract(frictionless_schema_dict, format="frictionless")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        assert (
+            "col_vals_regex",
+            {"columns": "email", "pattern": r"^[^@]+@[^@]+\.[^@]+$"},
+        ) in methods
+
+    def test_import_primary_key(self, frictionless_schema_dict):
+        """Primary key should generate not_null + distinct constraints."""
+        result = import_contract(frictionless_schema_dict, format="frictionless")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        # Primary key "id" should have not_null
+        not_null_cols = [
+            c.kwargs["columns"] for c in result.constraints if c.method == "col_vals_not_null"
+        ]
+        assert "id" in not_null_cols
+
+    def test_import_from_datapackage(self, frictionless_datapackage_dict):
+        """Import from a Data Package selects the first resource by default."""
+        result = import_contract(frictionless_datapackage_dict, format="frictionless")
+        assert len(result.columns) == 5  # users table
+
+    def test_import_from_datapackage_by_name(self, frictionless_datapackage_dict):
+        """Import a specific resource by name."""
+        result = import_contract(
+            frictionless_datapackage_dict, format="frictionless", resource="orders"
+        )
+        assert len(result.columns) == 2
+        col_names = [name for name, _ in result.columns]
+        assert "order_id" in col_names
+
+    def test_import_from_datapackage_by_index(self, frictionless_datapackage_dict):
+        result = import_contract(frictionless_datapackage_dict, format="frictionless", resource=1)
+        assert len(result.columns) == 2
+
+    def test_import_from_datapackage_invalid_name(self, frictionless_datapackage_dict):
+        with pytest.raises(ValueError, match="not found"):
+            import_contract(
+                frictionless_datapackage_dict, format="frictionless", resource="nonexistent"
+            )
+
+    def test_import_from_file(self, frictionless_schema_dict):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(frictionless_schema_dict, f)
+            f.flush()
+            result = import_contract(f.name, format="frictionless")
+
+        assert result.source_format == "frictionless"
+        assert result.source_path == f.name
+
+    def test_import_foreign_key_warning(self):
+        """Foreign keys should produce a warning since cross-table is unsupported."""
+        schema = {
+            "fields": [
+                {"name": "user_id", "type": "integer"},
+            ],
+            "foreignKeys": [
+                {
+                    "fields": ["user_id"],
+                    "reference": {"resource": "users", "fields": ["id"]},
+                }
+            ],
+        }
+        result = import_contract(schema, format="frictionless")
+        assert len(result.warnings) == 1
+        assert "Foreign key" in result.warnings[0]
+        assert result.coverage < 1.0
+
+    def test_to_validate_end_to_end(self, frictionless_schema_dict, simple_df):
+        result = import_contract(frictionless_schema_dict, format="frictionless")
+        validation = result.to_validate(data=simple_df)
+        validation.interrogate()
+
+    def test_auto_detect_frictionless(self, frictionless_schema_dict):
+        """Auto-detection works for Frictionless dicts."""
+        result = import_contract(frictionless_schema_dict)
+        assert result.source_format == "frictionless"
+
+

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,120 @@
+
+import json
+import tempfile
+
+import polars as pl
+import pytest
+
+import pointblank as pb
+from pointblank.adapters import (
+    ContractAdapter,
+    ContractImport,
+    MappedConstraint,
+    export_contract,
+    get_adapter,
+    import_contract,
+    list_adapters,
+    register_adapter,
+)
+from pointblank.adapters._registry import _ADAPTER_REGISTRY
+
+
+@pytest.fixture
+def simple_df():
+    """Simple DataFrame for testing."""
+    return pl.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "name": ["Alice", "Bob", "Charlie", "Dave", "Eve"],
+            "age": [25, 30, 35, 40, 45],
+            "email": [
+                "alice@example.com",
+                "bob@example.com",
+                "charlie@example.com",
+                "dave@example.com",
+                "eve@example.com",
+            ],
+            "status": ["active", "active", "inactive", "active", "inactive"],
+        }
+    )
+
+
+@pytest.fixture
+def json_schema_dict():
+    """A JSON Schema document as a dict."""
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "User Profile",
+        "description": "Schema for user profile data",
+        "type": "object",
+        "properties": {
+            "age": {"type": "integer", "minimum": 0, "maximum": 150},
+            "email": {"type": "string", "format": "email"},
+            "status": {"type": "string", "enum": ["active", "inactive", "pending"]},
+            "name": {"type": "string", "pattern": "^[A-Za-z ]+$"},
+            "score": {"type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 100},
+        },
+        "required": ["age", "email"],
+    }
+
+
+@pytest.fixture
+def frictionless_schema_dict():
+    """A Frictionless Table Schema as a dict."""
+    return {
+        "fields": [
+            {
+                "name": "id",
+                "type": "integer",
+                "constraints": {"required": True, "unique": True},
+            },
+            {
+                "name": "name",
+                "type": "string",
+                "constraints": {"required": True},
+            },
+            {
+                "name": "age",
+                "type": "integer",
+                "constraints": {"minimum": 0, "maximum": 150},
+            },
+            {
+                "name": "status",
+                "type": "string",
+                "constraints": {"enum": ["active", "inactive"]},
+            },
+            {
+                "name": "email",
+                "type": "string",
+                "constraints": {"pattern": r"^[^@]+@[^@]+\.[^@]+$"},
+            },
+        ],
+        "primaryKey": "id",
+    }
+
+
+@pytest.fixture
+def frictionless_datapackage_dict(frictionless_schema_dict):
+    """A Frictionless Data Package with one resource."""
+    return {
+        "name": "my-package",
+        "resources": [
+            {
+                "name": "users",
+                "path": "users.csv",
+                "schema": frictionless_schema_dict,
+            },
+            {
+                "name": "orders",
+                "path": "orders.csv",
+                "schema": {
+                    "fields": [
+                        {"name": "order_id", "type": "integer"},
+                        {"name": "user_id", "type": "integer"},
+                    ]
+                },
+            },
+        ],
+    }
+
+

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -263,3 +263,116 @@ class TestContractImport:
         assert "columns=1" in repr(result)
 
 
+class TestJSONSchemaImport:
+    def test_import_from_dict(self, json_schema_dict):
+        result = import_contract(json_schema_dict, format="json_schema")
+
+        assert result.source_format == "json_schema"
+        assert len(result.columns) == 5
+        assert result.metadata.get("title") == "User Profile"
+        assert result.metadata.get("description") == "Schema for user profile data"
+
+        # Check column dtypes
+        col_map = dict(result.columns)
+        assert col_map["age"] == "Int64"
+        assert col_map["email"] == "String"
+        assert col_map["status"] == "String"
+        assert col_map["score"] == "Float64"
+
+    def test_import_constraints_minimum_maximum(self, json_schema_dict):
+        result = import_contract(json_schema_dict, format="json_schema")
+
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        # age has minimum=0, maximum=150
+        assert ("col_vals_ge", {"columns": "age", "value": 0}) in methods
+        assert ("col_vals_le", {"columns": "age", "value": 150}) in methods
+
+    def test_import_constraints_exclusive(self, json_schema_dict):
+        result = import_contract(json_schema_dict, format="json_schema")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        # score has exclusiveMinimum=0, exclusiveMaximum=100
+        assert ("col_vals_gt", {"columns": "score", "value": 0}) in methods
+        assert ("col_vals_lt", {"columns": "score", "value": 100}) in methods
+
+    def test_import_constraints_enum(self, json_schema_dict):
+        result = import_contract(json_schema_dict, format="json_schema")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        assert (
+            "col_vals_in_set",
+            {"columns": "status", "set": ["active", "inactive", "pending"]},
+        ) in methods
+
+    def test_import_constraints_required(self, json_schema_dict):
+        result = import_contract(json_schema_dict, format="json_schema")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        assert ("col_vals_not_null", {"columns": "age"}) in methods
+        assert ("col_vals_not_null", {"columns": "email"}) in methods
+
+    def test_import_constraints_pattern(self, json_schema_dict):
+        result = import_contract(json_schema_dict, format="json_schema")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        assert ("col_vals_regex", {"columns": "name", "pattern": "^[A-Za-z ]+$"}) in methods
+
+    def test_import_constraints_format_email(self, json_schema_dict):
+        result = import_contract(json_schema_dict, format="json_schema")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+
+        assert ("col_vals_within_spec", {"columns": "email", "spec": "email"}) in methods
+
+    def test_import_from_file(self, json_schema_dict):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".schema.json", delete=False) as f:
+            json.dump(json_schema_dict, f)
+            f.flush()
+            result = import_contract(f.name, format="json_schema")
+
+        assert result.source_format == "json_schema"
+        assert result.source_path == f.name
+        assert len(result.columns) == 5
+
+    def test_import_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            import_contract("/nonexistent/file.schema.json", format="json_schema")
+
+    def test_import_invalid_type(self):
+        with pytest.raises(TypeError, match="must be a file path"):
+            import_contract(12345, format="json_schema")
+
+    def test_to_validate_end_to_end(self, json_schema_dict, simple_df):
+        result = import_contract(json_schema_dict, format="json_schema")
+        validation = result.to_validate(data=simple_df)
+        validation.interrogate()
+        # Should complete without error
+
+    def test_auto_detect_json_schema(self, json_schema_dict):
+        """Auto-detection works for JSON Schema dicts."""
+        result = import_contract(json_schema_dict)  # no format specified
+        assert result.source_format == "json_schema"
+
+    def test_const_constraint(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "version": {"type": "string", "const": "v2"},
+            },
+        }
+        result = import_contract(schema, format="json_schema")
+        methods = [(c.method, c.kwargs) for c in result.constraints]
+        assert ("col_vals_eq", {"columns": "version", "value": "v2"}) in methods
+
+    def test_nullable_union_type(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "nickname": {"type": ["string", "null"]},
+            },
+        }
+        result = import_contract(schema, format="json_schema")
+        col_map = dict(result.columns)
+        assert col_map["nickname"] == "String"
+
+

--- a/user_guide/00-getting-started/02-installation.qmd
+++ b/user_guide/00-getting-started/02-installation.qmd
@@ -236,7 +236,7 @@ pb validate small_table --check col-exists --column a
 pb validate small_table --check col-vals-lt --column a --value 10
 ```
 
-The CLI is perfect for:
+The CLI is useful for:
 
 - quick data quality checks in CI/CD pipelines
 - exploratory data analysis from the terminal

--- a/user_guide/07-the-pointblank-cli/02-cli-data-validation.qmd
+++ b/user_guide/07-the-pointblank-cli/02-cli-data-validation.qmd
@@ -24,7 +24,7 @@ command line.
 ## `pb validate`: Quick, One-Line Data Checks
 
 The `pb validate` command is your go-to for running common validation checks directly on your data
-source. It’s perfect for quick, one-off checks or for use in automated pipelines. You specify
+source. It’s great for quick, one-off checks or for use in automated pipelines. You specify
 exactly which check you want to run using the `--check` option, making your intent clear and your
 validation explicit.
 

--- a/user_guide/09-integrations/01-otel-integration.qmd
+++ b/user_guide/09-integrations/01-otel-integration.qmd
@@ -163,8 +163,8 @@ emitted (no external collector needed).
 ### Setup
 
 Before exporting any signals we need OTel providers to receive them. The SDK's in-memory providers
-are perfect for exploration: they capture every metric, span, and log record in Python lists so we
-can print them without running a collector.
+are very useful for exploration: they capture every metric, span, and log record in Python lists so
+we can print them without running a collector.
 
 ```{python}
 #| eval: false

--- a/user_guide/10-contracts-and-pipelines/03-yaml-contracts.qmd
+++ b/user_guide/10-contracts-and-pipelines/03-yaml-contracts.qmd
@@ -12,7 +12,7 @@ pb.config(report_incl_footer_timings=False)
 ```
 
 Contracts and pipelines are designed to be **data, not code**. They serialize cleanly to YAML,
-making them ideal for version control, team collaboration, and configuration-driven workflows. This
+making them useful for version control, team collaboration, and configuration-driven workflows. This
 guide covers how to write, load, and use YAML-based contracts and pipelines.
 
 When you define a contract in Python, it lives inside your application code. That's fine for quick
@@ -107,7 +107,7 @@ case.
 | `consumers` | No | List of teams or systems that depend on data conforming to this contract |
 | `description` | No | Longer prose describing the contract's purpose and context |
 | `on_violation` | No | Behavior when validation fails: `"warn"` (default), `"raise"`, or `"log"` |
-| `schema` | No | Column name → data type mapping; triggers a `col_schema_match()` check |
+| `schema` | No | Column name -> data type mapping; triggers a `col_schema_match()` check |
 | `steps` | No | Ordered list of validation steps to execute |
 | `thresholds` | No | Threshold levels (`warning`, `error`, `critical`) as fractions or absolute counts |
 
@@ -581,8 +581,8 @@ The table below summarizes the key operations and how they map between the Pytho
 | Save | `.to_yaml("path.yaml")` | --- |
 | Load contract | `pb.Contract.from_yaml("path.yaml")` | --- |
 | Load pipeline | `pb.Pipeline.from_yaml("path.yaml")` | --- |
-| Validate | `.validate(data)` | Load → validate in Python |
-| Run pipeline | `.run(data, transform)` | Load → run in Python |
+| Validate | `.validate(data)` | Load -> validate in Python |
+| Run pipeline | `.run(data, transform)` | Load -> run in Python |
 
 YAML contracts and pipelines give you the best of both worlds: declarative, reviewable
 specifications that integrate seamlessly with Pointblank's Python execution engine. The separation

--- a/user_guide/10-contracts-and-pipelines/04-importing-contracts.qmd
+++ b/user_guide/10-contracts-and-pipelines/04-importing-contracts.qmd
@@ -1,0 +1,612 @@
+---
+title: Importing External Schemas
+jupyter: python3
+html-table-processing: none
+---
+
+```{python}
+#| echo: false
+#| output: false
+import pointblank as pb
+pb.config(report_incl_footer_timings=False)
+```
+
+Many teams already have data schemas defined in other tools: JSON Schema files for API validation,
+Frictionless Table Schemas for open data, dbt `schema.yml` files for analytics pipelines, or
+Pandera/Pydantic models in application code. Rather than manually rewriting these specifications as
+Pointblank validation steps, you can **import** them directly.
+
+The `import_contract()` function reads an external schema definition and produces a `ContractImport`
+object containing everything Pointblank needs to validate data: column types, constraints, and
+mapped validation steps. From there you can create a `Validate` workflow, a `Contract` object,
+generate equivalent Python code, or produce a YAML definition, all with a single function call.
+
+## Quick Start
+
+The fastest path from an external schema to running validation:
+
+```{python}
+import pointblank as pb
+import polars as pl
+
+# Define a JSON Schema (could also be loaded from a file)
+user_schema = {
+    "type": "object",
+    "properties": {
+        "user_id": {"type": "integer"},
+        "email": {"type": "string", "format": "email"},
+        "age": {"type": "integer", "minimum": 0, "maximum": 150},
+        "status": {"type": "string", "enum": ["active", "inactive", "pending"]},
+    },
+    "required": ["user_id", "email"],
+}
+
+# Import the schema
+result = pb.import_contract(user_schema, format="json_schema")
+
+# Create sample data and validate
+users = pl.DataFrame(
+    {
+        "user_id": [1, 2, 3, 4, 5],
+        "email": [
+            "alice@example.com",
+            "bob@corp.io",
+            "charlie@mail.org",
+            "dave@startup.co",
+            "eve@company.net",
+        ],
+        "age": [28, 34, 45, 22, 31],
+        "status": ["active", "active", "inactive", "pending", "active"],
+    }
+)
+
+result.to_validate(data=users).interrogate()
+```
+
+That's it. The JSON Schema `minimum`, `maximum`, `enum`, `format`, and `required` keywords were
+automatically translated into the appropriate Pointblank validation steps. Each keyword becomes a
+dedicated validation check: `minimum` becomes `col_vals_ge()`, `maximum` becomes `col_vals_le()`,
+`enum` becomes `col_vals_in_set()`, and so on. The schema's `required` array generates
+`col_vals_not_null()` steps for each listed field, ensuring that null values are caught at
+validation time.
+
+## How It Works
+
+The import process has three stages:
+
+1. **Parse**: the external schema is read (from a file path, a dict, or a Python object)
+2. **Map**: each constraint in the source format is translated to a Pointblank validation method
+3. **Package**: the results are stored in a `ContractImport` object with multiple output options
+
+```{mermaid}
+flowchart LR
+    A[External Schema] --> B[import_contract]
+    B --> C[ContractImport]
+    C --> D[.to_validate‹data›]
+    C --> E[.to_contract‹›]
+    C --> F[.to_python‹›]
+    C --> G[.to_yaml‹›]
+```
+
+The `ContractImport` object is your bridge between the external world and Pointblank. It doesn't
+execute anything on its own. Rather, it holds the *translated specification* and lets you choose
+how to use it. This separation is intentional: you can inspect the translation results, check
+for any warnings, and decide how to proceed before committing to a particular output format.
+
+## The `ContractImport` Object
+
+After calling `import_contract()`, you get back a `ContractImport` with these key attributes and
+methods:
+
+| Attribute / Method | Description |
+|---|---|
+| `.columns` | List of `(column_name, dtype)` tuples detected from the source |
+| `.constraints` | List of `MappedConstraint` objects (method + kwargs) |
+| `.warnings` | Messages about constraints that couldn't be translated |
+| `.coverage` | Fraction of source constraints successfully mapped (0.0–1.0) |
+| `.metadata` | Extra metadata (title, description) from the source |
+| `.to_validate(data)` | Build a `Validate` object ready for `.interrogate()` |
+| `.to_contract(name)` | Build a `Contract` object for pipeline use |
+| `.to_python()` | Generate equivalent Python code as a string |
+| `.to_yaml()` | Generate Pointblank YAML configuration |
+| `.summary()` | Return a human-readable summary |
+
+### Inspecting What Was Imported
+
+Before running validation, it's often useful to inspect what the import produced:
+
+```{python}
+result = pb.import_contract(user_schema, format="json_schema")
+print(result.summary())
+```
+
+If any constraints couldn't be mapped, they appear in `.warnings`:
+
+```{python}
+# A schema with an unmappable format
+schema_with_date = {
+    "type": "object",
+    "properties": {
+        "created_at": {"type": "string", "format": "date-time"},
+    },
+}
+result = pb.import_contract(schema_with_date, format="json_schema")
+
+if result.warnings:
+    for w in result.warnings:
+        print(f"⚠ {w}")
+
+print(f"\nCoverage: {result.coverage:.0%}")
+```
+
+The `coverage` metric tells you what fraction of the source constraints were successfully
+translated. A coverage of 100% means everything mapped cleanly; lower values mean some constraints
+were skipped (with details in `warnings`). This transparency is important because no translation
+between formats is perfect. By checking `coverage` and `warnings` before running validation, you
+can be confident about exactly which parts of your original schema are being enforced and which
+parts might need manual attention.
+
+## Supported Formats
+
+Pointblank ships with adapters for the two most universal tabular schema formats. Additional
+adapters (dbt, Pydantic, Pandera) are planned for future releases.
+
+```{python}
+pb.list_adapters()
+```
+
+### JSON Schema
+
+[JSON Schema](https://json-schema.org/) is a widely used format for describing the structure of JSON
+data. Because tabular data (DataFrames) can be modeled as arrays of JSON objects, JSON Schema is a
+natural fit for defining column-level constraints.
+
+**Constraint mapping:**
+
+| JSON Schema Keyword | Pointblank Method |
+|---|---|
+| `type: "integer"` / `"number"` / `"string"` / `"boolean"` | Schema dtype check |
+| `minimum` | `col_vals_ge()` |
+| `maximum` | `col_vals_le()` |
+| `exclusiveMinimum` | `col_vals_gt()` |
+| `exclusiveMaximum` | `col_vals_lt()` |
+| `enum` | `col_vals_in_set()` |
+| `pattern` | `col_vals_regex()` |
+| `format: "email"` | `col_vals_within_spec(spec="email")` |
+| `format: "uri"` | `col_vals_within_spec(spec="url")` |
+| `format: "ipv4"` / `"ipv6"` | `col_vals_within_spec(spec="ipv4"/"ipv6")` |
+| `const` | `col_vals_eq()` |
+| `required` (array of field names) | `col_vals_not_null()` |
+
+**Importing from a file:**
+
+```python
+# File-based import (auto-detects .schema.json extension)
+result = pb.import_contract("models/user_profile.schema.json")
+```
+
+**Importing from a dict:**
+
+```{python}
+product_schema = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Product Catalog",
+    "description": "Expected structure for product data",
+    "type": "object",
+    "properties": {
+        "sku": {"type": "string", "pattern": "^[A-Z]{3}-[0-9]{4}$"},
+        "price": {"type": "number", "exclusiveMinimum": 0},
+        "category": {"type": "string", "enum": ["electronics", "clothing", "food", "other"]},
+        "in_stock": {"type": "boolean"},
+    },
+    "required": ["sku", "price", "category"],
+}
+
+result = pb.import_contract(product_schema, format="json_schema")
+
+# Inspect what was mapped
+for c in result.constraints:
+    print(f"  {c.method}({c.kwargs})")
+```
+
+Each constraint from the JSON Schema has been translated into the corresponding Pointblank method
+call. The `pattern` keyword on the `sku` field became a `col_vals_regex()` step, `exclusiveMinimum`
+became `col_vals_gt()` (note the strict inequality), and the three `required` fields each generated
+a `col_vals_not_null()` step. You can iterate over `result.constraints` like this to verify the
+translation before running any validation.
+
+### Frictionless Data Table Schema
+
+[Frictionless Data](https://frictionlessdata.io/) is a set of standards for describing and
+packaging data. The **Table Schema** format is particularly well-suited for tabular data validation,
+with explicit support for column types, constraints, and primary/foreign keys.
+
+**Constraint mapping:**
+
+| Frictionless Feature | Pointblank Method |
+|---|---|
+| `type` | Schema dtype check |
+| `constraints.required: true` | `col_vals_not_null()` |
+| `constraints.unique: true` | `rows_distinct()` |
+| `constraints.minimum` / `maximum` | `col_vals_ge()` / `col_vals_le()` |
+| `constraints.enum` | `col_vals_in_set()` |
+| `constraints.pattern` | `col_vals_regex()` |
+| `primaryKey` | `col_vals_not_null()` + `rows_distinct()` |
+| `foreignKeys` | ⚠ Warning (cross-table not yet supported) |
+
+**Importing a standalone Table Schema:**
+
+```{python}
+inventory_schema = {
+    "fields": [
+        {"name": "item_id", "type": "integer", "constraints": {"required": True, "unique": True}},
+        {"name": "name", "type": "string", "constraints": {"required": True}},
+        {"name": "quantity", "type": "integer", "constraints": {"minimum": 0}},
+        {"name": "warehouse", "type": "string", "constraints": {"enum": ["NYC", "LAX", "ORD"]}},
+    ],
+    "primaryKey": "item_id",
+}
+
+result = pb.import_contract(inventory_schema, format="frictionless")
+print(result.summary())
+```
+
+Notice how the `primaryKey` field generates both a not-null check and a uniqueness check for
+`item_id`. This is the correct semantic interpretation: a primary key must always be present and
+must uniquely identify each row. The field-level `constraints.required` and `constraints.unique`
+also contribute their own checks, so the adapter deduplicates where appropriate.
+
+**Importing from a Data Package:**
+
+Data Packages bundle multiple resources (tables) together. You can select which resource to import
+by name or index:
+
+```{python}
+data_package = {
+    "name": "ecommerce-data",
+    "resources": [
+        {
+            "name": "customers",
+            "path": "customers.csv",
+            "schema": {
+                "fields": [
+                    {"name": "id", "type": "integer", "constraints": {"required": True}},
+                    {"name": "email", "type": "string"},
+                ],
+            },
+        },
+        {
+            "name": "orders",
+            "path": "orders.csv",
+            "schema": {
+                "fields": [
+                    {"name": "order_id", "type": "integer", "constraints": {"required": True}},
+                    {"name": "amount", "type": "number", "constraints": {"minimum": 0}},
+                ],
+            },
+        },
+    ],
+}
+
+# Import a specific resource by name
+orders_import = pb.import_contract(data_package, format="frictionless", resource="orders")
+print(f"Columns: {[name for name, _ in orders_import.columns]}")
+print(f"Constraints: {len(orders_import.constraints)}")
+```
+
+The `resource=` parameter accepts either a string (the resource name) or an integer (the resource
+index). When omitted, the first resource in the package is used. This makes it straightforward to
+work with multi-table data packages where each table has its own schema definition.
+
+## Output Options
+
+Once you have a `ContractImport`, you can use it in several ways depending on your workflow.
+
+### Direct Validation with `.to_validate()`
+
+The most common path is to get a `Validate` object, pass your data, and run it:
+
+```{python}
+schema = {
+    "type": "object",
+    "properties": {
+        "temperature": {"type": "number", "minimum": -50, "maximum": 60},
+        "humidity": {"type": "number", "minimum": 0, "maximum": 100},
+        "station_id": {"type": "string"},
+    },
+    "required": ["temperature", "humidity", "station_id"],
+}
+
+weather_data = pl.DataFrame(
+    {
+        "temperature": [22.5, 18.3, -5.1, 35.0, 28.7],
+        "humidity": [45.0, 78.2, 30.0, 92.5, 55.0],
+        "station_id": ["WX-001", "WX-002", "WX-003", "WX-001", "WX-004"],
+    }
+)
+
+imported = pb.import_contract(schema, format="json_schema")
+imported.to_validate(data=weather_data).interrogate()
+```
+
+The `.to_validate()` method returns a fully configured `Validate` object with all imported
+constraints already applied as validation steps. You get the familiar validation report showing
+pass/fail counts for each check. Because the `Validate` object is not yet interrogated when
+created, you also have the option of adding additional validation steps before calling
+`.interrogate()`.
+
+You can also pass additional arguments to the `Validate` constructor:
+
+```python
+imported.to_validate(
+    data=weather_data,
+    tbl_name="weather_readings",
+    label="Daily sensor check",
+    thresholds=pb.Thresholds(warning=0.05, error=0.10),
+)
+```
+
+Any keyword argument accepted by the `Validate` class can be passed through here, including
+`tbl_name`, `label`, `thresholds`, `owner`, and `consumers`. This gives you full control over
+how the validation is configured without needing to modify the import result.
+
+### Creating a Reusable Contract with `.to_contract()`
+
+If you want to store the imported schema as a Pointblank `Contract` for use in pipelines or
+repeated validation:
+
+```{python}
+imported = pb.import_contract(inventory_schema, format="frictionless")
+contract = imported.to_contract(name="inventory_check", version="1.0.0", owner="warehouse-team")
+print(contract)
+```
+
+The resulting `Contract` can be serialized to YAML, used in `Pipeline`, or shared with other teams.
+This is particularly valuable when you want to maintain a stable contract definition that outlives
+the original external schema file. The `Contract` object carries all the metadata (version, owner,
+description) that makes it suitable for team workflows and CI/CD pipelines.
+
+### Generating Python Code with `.to_python()`
+
+When you want to see (or save) the equivalent Pointblank Python code that would be generated from
+the import:
+
+```{python}
+imported = pb.import_contract(user_schema, format="json_schema")
+print(imported.to_python())
+```
+
+The generated code is syntactically valid Python that you can copy directly into a script or
+notebook. It uses the standard Pointblank method-chaining style, making it easy to read and modify.
+This is especially useful for:
+
+- understanding exactly what validation steps an import produces
+- generating starter code that you can then customize
+- documentation and onboarding (show teams what their schema "means" in validation terms)
+
+Once you have the generated code, you can paste it into your project and modify it freely. Add
+extra validation steps, remove checks that don't apply, or adjust parameter values. The generated
+code has no dependency on the original schema file, so it serves as a clean handoff point between
+the schema world and your Python codebase.
+
+### Generating YAML with `.to_yaml()`
+
+For workflows that use Pointblank's YAML-based validation:
+
+```{python}
+imported = pb.import_contract(user_schema, format="json_schema")
+print(imported.to_yaml())
+```
+
+The YAML output follows Pointblank's validation YAML format, with each constraint appearing as a
+separate step entry. You can save this output to a file and use it with `pb.yaml_interrogate()` or
+`pb.validate_yaml()` for configuration-driven workflows where validation rules are managed as YAML
+files rather than Python code.
+
+## Exporting Contracts
+
+The reverse operation (taking a Pointblank `Contract` or `Validate` object and writing it out in
+an external format) is handled by `export_contract()`:
+
+```{python}
+# Create a contract
+contract = pb.Contract(
+    name="sensor_data",
+    schema=pb.Schema(temperature="Float64", humidity="Float64", station_id="String"),
+    steps=[
+        pb.Step("col_vals_ge", columns="temperature", value=-50),
+        pb.Step("col_vals_le", columns="temperature", value=60),
+        pb.Step("col_vals_ge", columns="humidity", value=0),
+        pb.Step("col_vals_le", columns="humidity", value=100),
+        pb.Step("col_vals_not_null", columns=["temperature", "humidity", "station_id"]),
+    ],
+)
+
+# Export to JSON Schema
+json_schema = pb.export_contract(contract, format="json_schema")
+json_schema
+```
+
+```{python}
+# Export to Frictionless Table Schema
+table_schema = pb.export_contract(contract, format="frictionless")
+table_schema
+```
+
+Each format produces the output structure that is native to that standard. JSON Schema export
+creates a valid `$schema`-annotated document with `properties`, `type`, and `required` fields.
+Frictionless export creates a Table Schema with `fields` and `constraints` entries. Both formats
+can be fed directly into tools that consume those standards, such as form validators, data catalogs,
+or documentation generators.
+
+You can also write directly to a file:
+
+```python
+pb.export_contract(contract, "output/sensor_data.schema.json", format="json_schema")
+pb.export_contract(contract, "output/sensor_data.resource.json", format="frictionless")
+```
+
+When a `destination` path is provided, the output is written to that file (creating parent
+directories as needed) and also returned from the function. This makes it convenient to both
+persist the output and inspect it in the same call.
+
+## Round-Trip Fidelity
+
+Importing a schema and then exporting it back should produce an equivalent result. This is
+important for workflows where you maintain schemas in an external format but want to validate with
+Pointblank:
+
+```{python}
+# Start with a JSON Schema
+original = {
+    "type": "object",
+    "properties": {
+        "score": {"type": "integer", "minimum": 0, "maximum": 100},
+        "grade": {"type": "string", "enum": ["A", "B", "C", "D", "F"]},
+    },
+    "required": ["score"],
+}
+
+# Import → Contract → Export
+imported = pb.import_contract(original, format="json_schema")
+contract = imported.to_contract(name="grades")
+exported = pb.export_contract(contract, format="json_schema")
+
+# The exported schema preserves the constraints
+print(f"Original constraints on 'score': minimum={original['properties']['score']['minimum']}, "
+      f"maximum={original['properties']['score']['maximum']}")
+print(f"Exported constraints on 'score': minimum={exported['properties']['score'].get('minimum')}, "
+      f"maximum={exported['properties']['score'].get('maximum')}")
+```
+
+Round-trip fidelity is tested as part of Pointblank's test suite. The general guarantee is that
+any constraint that can be expressed in both Pointblank and the target format will survive the
+round trip. Constraints that are unique to one format (like JSON Schema's `$ref` or Pointblank's
+`pre=` argument) may not survive, but the core numeric bounds, enum checks, null checks, and
+pattern constraints will always round-trip cleanly.
+
+## Auto-Detection
+
+When the format is obvious from the source content, you can omit the `format=` parameter:
+
+```{python}
+# JSON Schema: detected by presence of "$schema" or "type" + "properties"
+result = pb.import_contract({"type": "object", "properties": {"x": {"type": "integer"}}})
+print(f"Detected: {result.source_format}")
+
+# Frictionless: detected by presence of "fields" list
+result = pb.import_contract({"fields": [{"name": "x", "type": "integer"}]})
+print(f"Detected: {result.source_format}")
+```
+
+For file-based imports, the extension is also used for detection (`.schema.json` maps to JSON
+Schema, `.resource.json` or `.datapackage.json` maps to Frictionless). Auto-detection is a
+convenience feature that works well for common cases. When working with ambiguous files or dict
+inputs that could match multiple formats, it is best to specify `format=` explicitly to avoid
+any possibility of misdetection.
+
+## Combining Imports with Extra Checks
+
+An imported schema gives you a baseline, but you can always add more Pointblank checks on top:
+
+```{python}
+imported = pb.import_contract(user_schema, format="json_schema")
+
+# Start from the import but add custom checks
+validation = (
+    imported
+    .to_validate(data=users, tbl_name="enriched_check")
+    .col_vals_regex(columns="email", pattern=r".*\.(com|io|org|net|co)$")
+    .rows_distinct(columns_subset="user_id")
+    .interrogate()
+)
+
+validation
+```
+
+This pattern works well when the external schema covers structural and type constraints, but your
+team has additional business rules that only make sense in the Pointblank context. The imported
+constraints form the foundation, and your additional `.col_vals_*()` or `.rows_*()` calls layer
+on top. Because `.to_validate()` returns a standard `Validate` object, you have full access to
+the entire Pointblank API for adding checks, setting thresholds, or attaching actions.
+
+## Migration from Other Tools
+
+A key use case for `import_contract()` is **migration**: bringing existing validation definitions
+from other tools into Pointblank without manual rewriting.
+
+### Coming from JSON Schema
+
+If your team uses JSON Schema for API validation and you want the same rules applied to DataFrames:
+
+```python
+# Your existing JSON Schema (maybe generated by your API framework)
+result = pb.import_contract("api/schemas/user.schema.json")
+
+# Now use it for DataFrame validation in your data pipeline
+validation = result.to_validate(data=raw_users_df).interrogate()
+```
+
+This approach is particularly powerful when your API team already maintains JSON Schema definitions
+for request/response validation. Those same schemas can now serve double duty: validating API
+payloads at the service boundary and validating the resulting DataFrames in your analytics pipeline.
+You get consistent enforcement across both layers without writing the rules twice.
+
+### Coming from Frictionless
+
+If you have data packages from open data sources or research datasets:
+
+```python
+# Import from an existing data package descriptor
+result = pb.import_contract("data/datapackage.json", resource="observations")
+
+# Validate the actual CSV data against the declared schema
+validation = result.to_validate(data=observations_df).interrogate()
+```
+
+Frictionless Data Packages are common in open data portals, government datasets, and academic
+research repositories. By importing their Table Schemas directly, you can validate downloaded data
+against its declared structure without needing to manually inspect the descriptor file and rewrite
+each constraint. This is especially valuable when working with unfamiliar datasets where the schema
+descriptor is your primary documentation of what the data should contain.
+
+### Generating a Starting Point
+
+Even if you don't plan to keep using the external format, importing is a great way to bootstrap
+a Pointblank contract:
+
+```python
+# Import from your existing schema
+imported = pb.import_contract("legacy_schema.json", format="json_schema")
+
+# Save as a YAML contract you'll maintain going forward
+contract = imported.to_contract(name="my_table", version="1.0.0")
+contract.to_yaml("contracts/my_table.yaml")
+```
+
+Now you have a Pointblank-native contract that you can extend and evolve independently of the
+original source. You can add new validation steps, adjust thresholds, or incorporate business rules
+that go beyond what the original schema format could express.
+
+## Conclusion
+
+The contract import/export system lets you bridge the gap between external schema definitions and
+Pointblank's validation engine. Rather than maintaining duplicate specifications across tools, you
+can keep your source of truth in whichever format suits your team and import it into Pointblank
+whenever you need runtime validation. The key points to remember:
+
+- Use `pb.import_contract()` to read external schemas and translate them into Pointblank checks
+- The `ContractImport` object gives you multiple output options: direct validation, reusable
+  contracts, generated Python code, or YAML
+- Check `.coverage` and `.warnings` to understand how completely the translation covered your
+  original schema
+- Use `pb.export_contract()` to write Pointblank contracts back to external formats for sharing
+  with other tools
+- Combine imports with additional Pointblank-specific checks for the most thorough validation
+  coverage
+
+Whether you are migrating from another validation tool, bootstrapping contracts from existing
+schemas, or maintaining interoperability with external systems, the adapter framework gives you a
+clean path between external specifications and Pointblank's validation engine. As new adapters are
+added in future releases, the same `import_contract()` interface will continue to work, so any code
+you write today will gain new format support automatically.

--- a/user_guide/10-contracts-and-pipelines/05-custom-adapters.qmd
+++ b/user_guide/10-contracts-and-pipelines/05-custom-adapters.qmd
@@ -1,0 +1,402 @@
+---
+title: Custom Adapters
+jupyter: python3
+html-table-processing: none
+---
+
+```{python}
+#| echo: false
+#| output: false
+import pointblank as pb
+pb.config(report_incl_footer_timings=False)
+```
+
+Pointblank's contract import/export system is designed to be extensible. If your organization uses
+a proprietary schema format, an internal data catalog, or any other schema definition tool that
+isn't covered by the built-in adapters, you can write a **custom adapter** and register it with
+the framework.
+
+Once registered, your custom adapter works seamlessly with `import_contract()` and
+`export_contract()`, the same API surface your team already uses for JSON Schema and Frictionless.
+
+## The Adapter Architecture
+
+Every adapter follows the same pattern:
+
+1. **Subclass** `ContractAdapter` and set a few class attributes
+2. **Implement** `detect()` (for auto-detection), `import_contract()`, and optionally
+   `export_contract()`
+3. **Register** the adapter with the `@register_adapter` decorator
+
+Here's a minimal example to illustrate the structure:
+
+```{python}
+from pointblank.adapters import ContractAdapter, ContractImport, MappedConstraint, register_adapter
+
+
+@register_adapter("my_format")
+class MyFormatAdapter(ContractAdapter):
+    """Adapter for My Company's internal schema format."""
+
+    format_name = "my_format"
+    file_extensions = [".myschema"]
+    supports_import = True
+    supports_export = False  # export not implemented yet
+
+    @staticmethod
+    def detect(source) -> bool:
+        """Return True if this adapter can handle the source."""
+        if isinstance(source, dict):
+            return "my_format_version" in source
+        return False
+
+    def import_contract(self, source, **kwargs) -> ContractImport:
+        """Parse the source and return a ContractImport."""
+        # Your parsing logic here
+        columns = [("id", "Int64"), ("value", "Float64")]
+        constraints = [
+            MappedConstraint(
+                method="col_vals_not_null",
+                kwargs={"columns": "id"},
+                source_description="id is required",
+            ),
+        ]
+        return ContractImport(
+            source_format="my_format",
+            columns=columns,
+            constraints=constraints,
+        )
+```
+
+After registration, it's immediately usable:
+
+```{python}
+# Now this works
+result = pb.import_contract({"my_format_version": "1.0", "fields": []}, format="my_format")
+print(result)
+```
+
+The adapter is now part of the Pointblank ecosystem. Any call to `import_contract()` with
+`format="my_format"` will route through this adapter, and the auto-detection system will call
+`detect()` when no format is specified.
+
+```{python}
+# And it shows up in the adapter list
+pb.list_adapters()
+```
+
+The `list_adapters()` output confirms your adapter is registered alongside the built-in ones,
+showing its supported file extensions and whether it handles import, export, or both.
+
+## The `ContractAdapter` Base Class
+
+Here are the class attributes and methods you can define:
+
+| Attribute | Type | Purpose |
+|---|---|---|
+| `format_name` | `str` | Short identifier (e.g., `"json_schema"`, `"my_format"`) |
+| `file_extensions` | `list[str]` | File extensions for auto-detection (e.g., `[".schema.json"]`) |
+| `supports_import` | `bool` | Whether `import_contract()` is implemented |
+| `supports_export` | `bool` | Whether `export_contract()` is implemented |
+
+| Method | Required? | Purpose |
+|---|---|---|
+| `detect(source)` | Recommended | Returns `True` if this adapter handles the given source |
+| `import_contract(source, **kwargs)` | If `supports_import` | Parses source, returns `ContractImport` |
+| `export_contract(obj, destination, **kwargs)` | If `supports_export` | Exports to the format |
+
+## Building an Import Adapter
+
+Let's build a more realistic adapter, one that reads a simple YAML-based schema format used
+internally at a hypothetical company:
+
+```yaml
+# company_schema.yaml
+version: "2.0"
+table: user_events
+columns:
+  - name: event_id
+    type: string
+    required: true
+    unique: true
+  - name: user_id
+    type: integer
+    required: true
+  - name: event_type
+    type: string
+    values: [click, view, purchase, signup]
+  - name: amount
+    type: float
+    min: 0
+```
+
+Here's the adapter that handles this format:
+
+```{python}
+import yaml
+from pointblank.adapters import ContractAdapter, ContractImport, MappedConstraint, register_adapter
+
+
+@register_adapter("company_schema")
+class CompanySchemaAdapter(ContractAdapter):
+    """Adapter for our company's internal YAML schema format."""
+
+    format_name = "company_schema"
+    file_extensions = [".company.yaml", ".company.yml"]
+    supports_import = True
+    supports_export = False
+
+    # Type mapping from our format to Pointblank dtypes
+    TYPE_MAP = {
+        "string": "String",
+        "integer": "Int64",
+        "float": "Float64",
+        "boolean": "Boolean",
+        "date": "Date",
+        "datetime": "Datetime",
+    }
+
+    @staticmethod
+    def detect(source) -> bool:
+        """Detect our format by looking for the 'version' + 'columns' keys."""
+        if isinstance(source, dict):
+            return "version" in source and "columns" in source and "table" in source
+        return False
+
+    def import_contract(self, source, **kwargs) -> ContractImport:
+        """Import from our company schema format."""
+        # Load from file or use dict directly
+        if isinstance(source, str):
+            from pathlib import Path
+
+            with open(Path(source)) as f:
+                doc = yaml.safe_load(f)
+        elif isinstance(source, dict):
+            doc = source
+        else:
+            raise TypeError(f"Expected str or dict, got {type(source).__name__}")
+
+        columns = []
+        constraints = []
+        warnings = []
+        total = 0
+
+        for col_def in doc.get("columns", []):
+            col_name = col_def["name"]
+            col_type = col_def.get("type", "string")
+            dtype = self.TYPE_MAP.get(col_type)
+            columns.append((col_name, dtype))
+
+            if col_def.get("required", False):
+                total += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_not_null",
+                        kwargs={"columns": col_name},
+                        source_description=f"{col_name} is required",
+                    )
+                )
+
+            if col_def.get("unique", False):
+                total += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="rows_distinct",
+                        kwargs={"columns_subset": col_name},
+                        source_description=f"{col_name} must be unique",
+                    )
+                )
+
+            if "values" in col_def:
+                total += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_in_set",
+                        kwargs={"columns": col_name, "set": col_def["values"]},
+                        source_description=f"{col_name} allowed values: {col_def['values']}",
+                    )
+                )
+
+            if "min" in col_def:
+                total += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_ge",
+                        kwargs={"columns": col_name, "value": col_def["min"]},
+                        source_description=f"{col_name} >= {col_def['min']}",
+                    )
+                )
+
+            if "max" in col_def:
+                total += 1
+                constraints.append(
+                    MappedConstraint(
+                        method="col_vals_le",
+                        kwargs={"columns": col_name, "value": col_def["max"]},
+                        source_description=f"{col_name} <= {col_def['max']}",
+                    )
+                )
+
+        coverage = 1.0 if total == 0 else (total - len(warnings)) / total
+
+        return ContractImport(
+            source_format="company_schema",
+            source_path=source if isinstance(source, str) else None,
+            source_version=doc.get("version"),
+            columns=columns,
+            constraints=constraints,
+            metadata={"table": doc.get("table")},
+            warnings=warnings,
+            coverage=coverage,
+        )
+```
+
+Now let's use it:
+
+```{python}
+import polars as pl
+
+# Simulate a company schema document
+company_schema = {
+    "version": "2.0",
+    "table": "user_events",
+    "columns": [
+        {"name": "event_id", "type": "string", "required": True, "unique": True},
+        {"name": "user_id", "type": "integer", "required": True},
+        {"name": "event_type", "type": "string", "values": ["click", "view", "purchase", "signup"]},
+        {"name": "amount", "type": "float", "min": 0},
+    ],
+}
+
+# Import using our custom adapter
+result = pb.import_contract(company_schema, format="company_schema")
+print(result.summary())
+```
+
+The summary shows four columns detected and five constraints mapped (two `required` fields, one
+`unique` field, one `values` check, and one `min` bound). All constraints were successfully
+translated, giving 100% coverage.
+
+```{python}
+# Validate some data
+events = pl.DataFrame(
+    {
+        "event_id": ["E001", "E002", "E003", "E004", "E005"],
+        "user_id": [101, 102, 101, 103, 104],
+        "event_type": ["click", "view", "purchase", "signup", "click"],
+        "amount": [0.0, 0.0, 49.99, 0.0, 0.0],
+    }
+)
+
+result.to_validate(data=events).interrogate()
+```
+
+The validation report shows each imported constraint as a separate step, just as if you had written
+the validation by hand. From the user's perspective, there is no difference between validation steps
+that came from a custom adapter and those written directly in Python.
+
+## The `MappedConstraint` Class
+
+Each constraint from the external format gets mapped to a `MappedConstraint`, which is a simple
+data container holding:
+
+- `method`: the Pointblank `Validate` method name (e.g., `"col_vals_gt"`)
+- `kwargs`: the keyword arguments to pass to that method
+- `source_description`: optional human-readable note about what this was in the source format
+
+```{python}
+# Creating constraints manually
+c1 = MappedConstraint(
+    method="col_vals_between",
+    kwargs={"columns": "temperature", "left": -40, "right": 60},
+    source_description="Temperature must be in physical range",
+)
+print(c1)
+```
+
+The `source_description` is stored for debugging and documentation but doesn't affect validation.
+When users call `.summary()` or inspect the `ContractImport` object, these descriptions help them
+understand the provenance of each validation step. This is especially useful when debugging why a
+particular check was generated or when comparing the import output against the original schema.
+
+## Handling Unmappable Constraints
+
+Not every constraint in every format has a clean Pointblank equivalent. When you encounter something
+that can't be translated, add it to the warnings list rather than silently dropping it:
+
+```python
+# In your import_contract() method:
+if "custom_check" in col_def:
+    total += 1
+    warnings.append(
+        f"Column '{col_name}': 'custom_check' has no Pointblank equivalent, skipped."
+    )
+```
+
+This follows Pointblank's design principle of **best-effort translation**: generate everything you
+can, be transparent about what was skipped, and never silently lose information. Users can then
+review the warnings list and decide whether to add manual validation steps for the missing
+constraints or whether the gap is acceptable for their use case.
+
+## Auto-Detection Tips
+
+The `detect()` method enables format auto-detection. Good detection should be:
+
+- **Fast**: don't load the entire file just to check if it's your format
+- **Specific**: avoid false positives that could conflict with other adapters
+- **Graceful**: return `False` (never raise) if the source isn't your format
+
+The detection system iterates through all registered adapters and calls `detect()` on each one.
+Because of this, your detection logic should be as lightweight as possible. Checking for the
+presence of a few distinctive keys in a dict is ideal. Avoid expensive operations like parsing
+large files or making network requests inside `detect()`.
+
+```python
+@staticmethod
+def detect(source) -> bool:
+    if isinstance(source, dict):
+        # Check for a distinctive key combination
+        return "my_format_version" in source and "tables" in source
+
+    if isinstance(source, str):
+        # Check file extension first (cheapest check)
+        return source.lower().endswith(".myformat.yaml")
+
+    return False
+```
+
+## Best Practices
+
+1. **Map as much as possible**: users expect high coverage. If a constraint is *close* to
+   something Pointblank supports, map it (possibly with reduced precision) rather than skipping it.
+
+2. **Use descriptive source_description**: this helps users understand what each generated
+   validation step corresponds to in their original schema.
+
+3. **Set coverage accurately**: track the total number of source constraints and how many were
+   successfully mapped. This gives users confidence in the import quality.
+
+4. **Handle both file paths and dicts**: users should be able to pass either a path string or
+   pre-loaded data. Most adapters check `isinstance(source, str)` for file paths and
+   `isinstance(source, dict)` for pre-parsed content.
+
+5. **Fail clearly on bad input**: raise `TypeError` for wrong source types, `FileNotFoundError`
+   for missing files, and `ValueError` for malformed content. Don't return partial results
+   silently.
+
+6. **Keep dependencies optional**: if your adapter needs a third-party library, check for it at
+   import time and give a clear installation hint if it's missing.
+
+## Conclusion
+
+Custom adapters let you extend Pointblank's import/export system to handle any schema format your
+organization uses. The plugin architecture is intentionally simple: subclass `ContractAdapter`,
+implement one or two methods, and register it with a decorator. From that point forward, your
+format participates in the same `import_contract()` and `export_contract()` workflow that the
+built-in adapters use.
+
+This extensibility means that Pointblank can serve as a universal validation layer regardless of
+where your data contracts originate. Whether your schemas live in a proprietary YAML format, an
+internal data catalog API, or a custom metadata store, a short adapter class is all you need to
+bring them into the Pointblank ecosystem and benefit from its validation reporting, threshold
+system, and pipeline integration.


### PR DESCRIPTION
This PR introduces a new contract import/export system that lets users import validation schemas from external formats (like JSON Schema, Frictionless Table Schema, etc.) and export Pointblank validations/contracts to those formats. It adds a modular adapter architecture, new API functions, and supporting documentation (i.e., new user guide pages).
