### PR TITLE
fix: remove direct `mcp[cli]` dependency and bump `fastmcp` one

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,9 @@ generate = [
     "httpx>=0.28.0",
     "shiny>=1.3.0",
 ]
-mcp = ["mcp[cli]>=1.10.1", "fastmcp>=2.11.3", "pytest-asyncio>=1.0.0"]
+# NOTE: No direct dependency on the `mcp` SDK.
+# See: https://github.com/posit-dev/pointblank/issues/415
+mcp = ["fastmcp>=2.14.2", "pytest-asyncio>=1.0.0"]
 otel = [
     "opentelemetry-api>=1.22.0",
     "opentelemetry-sdk>=1.22.0",
@@ -120,8 +122,7 @@ dev = [
     "ruff==0.14.10",  # NOTE: must match rev in .pre-commit-config.yaml
     "shiny>=1.4.0",
     "openpyxl>=3.0.0",
-    "mcp[cli]>=1.10.1",
-    "fastmcp>=2.10.5",
+    "fastmcp>=2.14.2",
     "ty>=0.0.23",
     "mypy>=1.19.0",
     "tox-uv>=1.33.4",


### PR DESCRIPTION
# Summary

Removes direct `mcp[cli]` dependency and bump `fastmcp` one to `fastmcp>=2.14.2` which pins mcp internally

# Related GitHub Issues and PRs

- Ref: #415

# Checklist

- [x] I understand and agree to the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- [x] I have followed the [Style Guide for Python Code](https://peps.python.org/pep-0008/) as best as possible for the submitted code.
- [x] I have added **pytest** unit tests for any new functionality.
