### PR TITLE
feat: add statistical drift measures

### DIFF
--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -791,6 +791,19 @@ def _compute_ks_statistic(
     return {"statistic": round(max_diff, 6), "p_value": round(p_value, 6)}
 
 
+def _extract_numeric_values(scan: DataScan, colname: str) -> list[float] | None:
+    """Extract non-null numeric values from a scan's raw data."""
+    if scan.nw_data is None:
+        return None
+
+    try:
+        col = scan.nw_data.get_column(colname)
+        vals = col.drop_nulls().to_list()
+        return [float(v) for v in vals if v is not None]
+    except Exception:
+        return None
+
+
 @dataclass
 class _ColumnDiff:
     colname: str

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -834,9 +834,7 @@ def _get_col_profile(scan: DataScan, colname: str) -> ColumnProfile:
 
 def _is_numeric_coltype(coltype: str) -> bool:
     coltype_lower = coltype.lower()
-    return any(
-        ind in coltype_lower for ind in ("int", "float", "double", "decimal", "numeric")
-    )
+    return any(ind in coltype_lower for ind in ("int", "float", "double", "decimal", "numeric"))
 
 
 @dataclass
@@ -1016,9 +1014,7 @@ class DataScanDiff:
                 if d.stat_diffs
             },
             "drift_scores": {
-                d.colname: d.drift_scores
-                for d in self.column_diffs
-                if d.drift_scores
+                d.colname: d.drift_scores for d in self.column_diffs if d.drift_scores
             },
         }
 
@@ -1137,9 +1133,7 @@ class DataScanDiff:
                 style=style.text(font=google_font("IBM Plex Mono"), size="11px"),
                 locations=loc.body(),
             )
-            .fmt_markdown(
-                columns=["stat_changes"] + (["drift"] if has_any_drift else [])
-            )
+            .fmt_markdown(columns=["stat_changes"] + (["drift"] if has_any_drift else []))
         )
 
         return gt_tbl

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -721,6 +721,32 @@ def _compute_psi_numeric(
     return psi
 
 
+def _compute_psi_categorical(
+    baseline_freqs: dict[str, int],
+    current_freqs: dict[str, int],
+) -> float | None:
+    """Compute PSI for categorical columns using frequency distributions."""
+    import math
+
+    all_keys = set(baseline_freqs) | set(current_freqs)
+    if not all_keys:
+        return None
+
+    total_base = sum(baseline_freqs.values())
+    total_cur = sum(current_freqs.values())
+    if total_base == 0 or total_cur == 0:
+        return None
+
+    eps = 1e-4
+    psi = 0.0
+    for key in all_keys:
+        p = max(baseline_freqs.get(key, 0) / total_base, eps)
+        q = max(current_freqs.get(key, 0) / total_cur, eps)
+        psi += (q - p) * math.log(q / p)
+
+    return psi
+
+
 @dataclass
 class _ColumnDiff:
     colname: str

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -747,6 +747,50 @@ def _compute_psi_categorical(
     return psi
 
 
+def _compute_ks_statistic(
+    baseline_vals: list[float],
+    current_vals: list[float],
+) -> dict[str, float] | None:
+    """Compute KS statistic and p-value for numeric columns."""
+    if len(baseline_vals) < 2 or len(current_vals) < 2:
+        return None
+
+    try:
+        from scipy.stats import ks_2samp
+
+        stat, p_value = ks_2samp(baseline_vals, current_vals)
+        return {"statistic": round(stat, 6), "p_value": round(p_value, 6)}
+    except ImportError:
+        pass
+
+    sorted_base = sorted(baseline_vals)
+    sorted_cur = sorted(current_vals)
+    all_vals = sorted(set(sorted_base + sorted_cur))
+
+    n_base = len(sorted_base)
+    n_cur = len(sorted_cur)
+    max_diff = 0.0
+
+    base_idx = 0
+    cur_idx = 0
+    for val in all_vals:
+        while base_idx < n_base and sorted_base[base_idx] <= val:
+            base_idx += 1
+        while cur_idx < n_cur and sorted_cur[cur_idx] <= val:
+            cur_idx += 1
+        diff = abs(base_idx / n_base - cur_idx / n_cur)
+        if diff > max_diff:
+            max_diff = diff
+
+    import math
+
+    n_eff = (n_base * n_cur) / (n_base + n_cur)
+    lam = (math.sqrt(n_eff) + 0.12 + 0.11 / math.sqrt(n_eff)) * max_diff
+    p_value = max(0.0, min(1.0, 2.0 * math.exp(-2.0 * lam * lam)))
+
+    return {"statistic": round(max_diff, 6), "p_value": round(p_value, 6)}
+
+
 @dataclass
 class _ColumnDiff:
     colname: str

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -846,6 +846,7 @@ class _ColumnDiff:
     coltype_current: str | None
     status: str
     stat_diffs: dict[str, tuple[Any, Any]]
+    drift_scores: dict[str, Any]
 
 
 class DataScanDiff:
@@ -897,6 +898,7 @@ class DataScanDiff:
                         coltype_current=cur_prof.coltype if cur_prof else None,
                         status="added",
                         stat_diffs={},
+                        drift_scores={},
                     )
                 )
                 continue
@@ -909,6 +911,7 @@ class DataScanDiff:
                         coltype_current=None,
                         status="removed",
                         stat_diffs={},
+                        drift_scores={},
                     )
                 )
                 continue
@@ -928,7 +931,31 @@ class DataScanDiff:
                 if base_val != cur_val:
                     stat_diffs[stat_name] = (base_val, cur_val)
 
+            drift_scores: dict[str, Any] = {}
+            if not type_changed:
+                coltype = cur_prof.coltype
+                if _is_numeric_coltype(coltype):
+                    base_vals = _extract_numeric_values(baseline, col_name)
+                    cur_vals = _extract_numeric_values(current, col_name)
+                    if base_vals is not None and cur_vals is not None:
+                        psi = _compute_psi_numeric(base_vals, cur_vals)
+                        if psi is not None and psi > 0.0:
+                            drift_scores["psi"] = round(psi, 6)
+                        ks = _compute_ks_statistic(base_vals, cur_vals)
+                        if ks is not None and ks["statistic"] > 0.0:
+                            drift_scores["ks_statistic"] = ks["statistic"]
+                            drift_scores["ks_p_value"] = ks["p_value"]
+                else:
+                    base_freqs = _extract_categorical_freqs(baseline, col_name)
+                    cur_freqs = _extract_categorical_freqs(current, col_name)
+                    if base_freqs is not None and cur_freqs is not None:
+                        psi = _compute_psi_categorical(base_freqs, cur_freqs)
+                        if psi is not None and psi > 0.0:
+                            drift_scores["psi"] = round(psi, 6)
+
             status = "type_changed" if type_changed else ("changed" if stat_diffs else "unchanged")
+            if drift_scores and status == "unchanged":
+                status = "changed"
             self.column_diffs.append(
                 _ColumnDiff(
                     colname=col_name,
@@ -936,6 +963,7 @@ class DataScanDiff:
                     coltype_current=cur_prof.coltype,
                     status=status,
                     stat_diffs=stat_diffs,
+                    drift_scores=drift_scores,
                 )
             )
 
@@ -946,7 +974,7 @@ class DataScanDiff:
             self.columns_added
             or self.columns_removed
             or self.columns_type_changed
-            or any(d.stat_diffs for d in self.column_diffs)
+            or any(d.stat_diffs or d.drift_scores for d in self.column_diffs)
         )
 
     @property
@@ -987,6 +1015,11 @@ class DataScanDiff:
                 for d in self.column_diffs
                 if d.stat_diffs
             },
+            "drift_scores": {
+                d.colname: d.drift_scores
+                for d in self.column_diffs
+                if d.drift_scores
+            },
         }
 
     def get_tabular_report(self) -> GT:
@@ -1001,28 +1034,43 @@ class DataScanDiff:
         import polars as pl
 
         rows: list[dict[str, Any]] = []
+        has_any_drift = any(d.drift_scores for d in self.column_diffs)
 
         for diff in self.column_diffs:
+            drift_str = ""
+            if diff.drift_scores:
+                drift_parts: list[str] = []
+                if "psi" in diff.drift_scores:
+                    drift_parts.append(f"PSI: {diff.drift_scores['psi']:.4f}")
+                if "ks_statistic" in diff.drift_scores:
+                    drift_parts.append(
+                        f"KS: {diff.drift_scores['ks_statistic']:.4f} "
+                        f"(p={diff.drift_scores['ks_p_value']:.4f})"
+                    )
+                drift_str = "<br>".join(drift_parts)
+
             if diff.status == "added":
-                rows.append(
-                    {
-                        "column": diff.colname,
-                        "status": "Added",
-                        "type_baseline": "",
-                        "type_current": diff.coltype_current or "",
-                        "stat_changes": "",
-                    }
-                )
+                row: dict[str, Any] = {
+                    "column": diff.colname,
+                    "status": "Added",
+                    "type_baseline": "",
+                    "type_current": diff.coltype_current or "",
+                    "stat_changes": "",
+                }
+                if has_any_drift:
+                    row["drift"] = ""
+                rows.append(row)
             elif diff.status == "removed":
-                rows.append(
-                    {
-                        "column": diff.colname,
-                        "status": "Removed",
-                        "type_baseline": diff.coltype_baseline or "",
-                        "type_current": "",
-                        "stat_changes": "",
-                    }
-                )
+                row = {
+                    "column": diff.colname,
+                    "status": "Removed",
+                    "type_baseline": diff.coltype_baseline or "",
+                    "type_current": "",
+                    "stat_changes": "",
+                }
+                if has_any_drift:
+                    row["drift"] = ""
+                rows.append(row)
             else:
                 status = "Type Changed" if diff.status == "type_changed" else "OK"
                 if diff.stat_diffs:
@@ -1038,26 +1086,28 @@ class DataScanDiff:
                     cv_str = _format_stat_value(cv)
                     change_parts.append(f"{stat_name}: {bv_str} -> {cv_str}")
 
-                rows.append(
-                    {
-                        "column": diff.colname,
-                        "status": status,
-                        "type_baseline": diff.coltype_baseline or "",
-                        "type_current": diff.coltype_current or "",
-                        "stat_changes": "; ".join(change_parts),
-                    }
-                )
+                row = {
+                    "column": diff.colname,
+                    "status": status,
+                    "type_baseline": diff.coltype_baseline or "",
+                    "type_current": diff.coltype_current or "",
+                    "stat_changes": "<br>".join(change_parts),
+                }
+                if has_any_drift:
+                    row["drift"] = drift_str
+                rows.append(row)
 
         if not rows:
-            rows.append(
-                {
-                    "column": "(no columns)",
-                    "status": "OK",
-                    "type_baseline": "",
-                    "type_current": "",
-                    "stat_changes": "",
-                }
-            )
+            row = {
+                "column": "(no columns)",
+                "status": "OK",
+                "type_baseline": "",
+                "type_current": "",
+                "stat_changes": "",
+            }
+            if has_any_drift:
+                row["drift"] = ""
+            rows.append(row)
 
         df = pl.DataFrame(rows)
 
@@ -1079,16 +1129,16 @@ class DataScanDiff:
                 type_baseline="Type (Baseline)",
                 type_current="Type (Current)",
                 stat_changes="Changed Statistics",
+                **({"drift": "Drift Scores"} if has_any_drift else {}),
             )
             .opt_table_font(font=google_font("IBM Plex Sans"))
             .opt_align_table_header(align="left")
             .tab_style(
-                style=style.text(font=google_font("IBM Plex Mono")),
+                style=style.text(font=google_font("IBM Plex Mono"), size="11px"),
                 locations=loc.body(),
             )
-            .tab_style(
-                style=style.text(size="11px"),
-                locations=loc.body(columns="stat_changes"),
+            .fmt_markdown(
+                columns=["stat_changes"] + (["drift"] if has_any_drift else [])
             )
         )
 

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -692,6 +692,35 @@ def _compute_psi_numeric(
     if len(edges) < 3:
         return None
 
+    def _bin_counts(vals: list[float], bin_edges: list[float]) -> list[int]:
+        counts = [0] * (len(bin_edges) - 1)
+        for v in vals:
+            for j in range(len(bin_edges) - 1):
+                if bin_edges[j] <= v < bin_edges[j + 1]:
+                    counts[j] += 1
+                    break
+            else:
+                counts[-1] += 1
+        return counts
+
+    base_counts = _bin_counts(baseline_vals, edges)
+    cur_counts = _bin_counts(current_vals, edges)
+
+    total_base = sum(base_counts)
+    total_cur = sum(cur_counts)
+    if total_base == 0 or total_cur == 0:
+        return None
+
+    eps = 1e-4
+    psi = 0.0
+    for bc, cc in zip(base_counts, cur_counts):
+        p = max(bc / total_base, eps)
+        q = max(cc / total_cur, eps)
+        psi += (q - p) * math.log(q / p)
+
+    return psi
+
+
 @dataclass
 class _ColumnDiff:
     colname: str

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -669,6 +669,29 @@ def _assign_type_from_coltype(prof: ColumnProfile) -> None:
             return
 
 
+def _compute_psi_numeric(
+    baseline_vals: list[float],
+    current_vals: list[float],
+    n_bins: int = 10,
+) -> float | None:
+    """Compute PSI for numeric columns using quantile-based binning."""
+    if len(baseline_vals) < n_bins or len(current_vals) < n_bins:
+        return None
+
+    import math
+
+    sorted_base = sorted(baseline_vals)
+    n = len(sorted_base)
+    edges = [sorted_base[0]]
+    for i in range(1, n_bins):
+        idx = int(i * n / n_bins)
+        edges.append(sorted_base[min(idx, n - 1)])
+    edges.append(sorted_base[-1] + 1e-10)
+
+    edges = list(dict.fromkeys(edges))
+    if len(edges) < 3:
+        return None
+
 @dataclass
 class _ColumnDiff:
     colname: str

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -825,6 +825,20 @@ def _extract_categorical_freqs(scan: DataScan, colname: str) -> dict[str, int] |
         return None
 
 
+def _get_col_profile(scan: DataScan, colname: str) -> ColumnProfile:
+    for p in scan.profile.column_profiles:
+        if p.colname == colname:
+            return p
+    raise KeyError(colname)
+
+
+def _is_numeric_coltype(coltype: str) -> bool:
+    coltype_lower = coltype.lower()
+    return any(
+        ind in coltype_lower for ind in ("int", "float", "double", "decimal", "numeric")
+    )
+
+
 @dataclass
 class _ColumnDiff:
     colname: str

--- a/pointblank/datascan.py
+++ b/pointblank/datascan.py
@@ -804,6 +804,27 @@ def _extract_numeric_values(scan: DataScan, colname: str) -> list[float] | None:
         return None
 
 
+def _extract_categorical_freqs(scan: DataScan, colname: str) -> dict[str, int] | None:
+    """Extract value frequency counts from a scan's raw data."""
+    if scan.nw_data is None:
+        stats = {s.name: s.val for s in _get_col_profile(scan, colname).statistics}
+        freqs = stats.get("freqs")
+        if isinstance(freqs, dict):
+            return freqs
+        return None
+
+    try:
+        col = scan.nw_data.get_column(colname).drop_nulls()
+        vals = col.to_list()
+        freqs: dict[str, int] = {}
+        for v in vals:
+            key = str(v)
+            freqs[key] = freqs.get(key, 0) + 1
+        return freqs
+    except Exception:
+        return None
+
+
 @dataclass
 class _ColumnDiff:
     colname: str

--- a/tests/test_drift_statistics.py
+++ b/tests/test_drift_statistics.py
@@ -247,7 +247,24 @@ def test_boolean_column_drift():
 
 def test_nulls_in_numeric_column():
     base = pl.DataFrame({"x": [1.0, 2.0, None, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0]})
-    cur = pl.DataFrame({"x": [100.0, None, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 1100.0, 1200.0]})
+    cur = pl.DataFrame(
+        {
+            "x": [
+                100.0,
+                None,
+                300.0,
+                400.0,
+                500.0,
+                600.0,
+                700.0,
+                800.0,
+                900.0,
+                1000.0,
+                1100.0,
+                1200.0,
+            ]
+        }
+    )
 
     diff = DataScan(data=cur).compare(DataScan(data=base))
     x_diff = next(d for d in diff.column_diffs if d.colname == "x")
@@ -352,16 +369,20 @@ def test_ks_overlapping_distributions():
 
 
 def test_mixed_column_types():
-    base = pl.DataFrame({
-        "num": list(range(20)),
-        "cat": ["a"] * 10 + ["b"] * 10,
-        "flag": [True] * 15 + [False] * 5,
-    })
-    cur = pl.DataFrame({
-        "num": list(range(50, 70)),
-        "cat": ["a"] * 5 + ["b"] * 10 + ["c"] * 5,
-        "flag": [True] * 10 + [False] * 10,
-    })
+    base = pl.DataFrame(
+        {
+            "num": list(range(20)),
+            "cat": ["a"] * 10 + ["b"] * 10,
+            "flag": [True] * 15 + [False] * 5,
+        }
+    )
+    cur = pl.DataFrame(
+        {
+            "num": list(range(50, 70)),
+            "cat": ["a"] * 5 + ["b"] * 10 + ["c"] * 5,
+            "flag": [True] * 10 + [False] * 10,
+        }
+    )
 
     diff = DataScan(data=cur).compare(DataScan(data=base))
 

--- a/tests/test_drift_statistics.py
+++ b/tests/test_drift_statistics.py
@@ -1,0 +1,377 @@
+import polars as pl
+import pytest
+
+from pointblank.datascan import (
+    DataScan,
+    DataScanDiff,
+    _compute_ks_statistic,
+    _compute_psi_categorical,
+    _compute_psi_numeric,
+)
+
+
+# ── PSI numeric ─────────────────────────────────────────────────────────────
+
+
+def test_psi_numeric_identical():
+    vals = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    psi = _compute_psi_numeric(vals, vals)
+    assert psi is not None
+    assert psi == pytest.approx(0.0, abs=1e-3)
+
+
+def test_psi_numeric_slight_shift():
+    base = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    cur = [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5]
+    psi = _compute_psi_numeric(base, cur)
+    assert psi is not None
+    assert psi < 0.25
+
+
+def test_psi_numeric_major_shift():
+    base = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    cur = [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0]
+    psi = _compute_psi_numeric(base, cur)
+    assert psi is not None
+    assert psi > 0.25
+
+
+def test_psi_numeric_too_few_values():
+    assert _compute_psi_numeric([1.0, 2.0], [3.0, 4.0]) is None
+
+
+def test_psi_numeric_empty():
+    assert _compute_psi_numeric([], []) is None
+
+
+# ── PSI categorical ─────────────────────────────────────────────────────────
+
+
+def test_psi_categorical_identical():
+    freqs = {"a": 50, "b": 30, "c": 20}
+    psi = _compute_psi_categorical(freqs, freqs)
+    assert psi is not None
+    assert psi == pytest.approx(0.0, abs=1e-6)
+
+
+def test_psi_categorical_shifted():
+    base = {"a": 50, "b": 30, "c": 20}
+    cur = {"a": 20, "b": 30, "c": 50}
+    psi = _compute_psi_categorical(base, cur)
+    assert psi is not None
+    assert psi > 0.0
+
+
+def test_psi_categorical_new_category():
+    base = {"a": 50, "b": 50}
+    cur = {"a": 40, "b": 40, "c": 20}
+    psi = _compute_psi_categorical(base, cur)
+    assert psi is not None
+    assert psi > 0.0
+
+
+def test_psi_categorical_empty():
+    assert _compute_psi_categorical({}, {}) is None
+
+
+# ── KS statistic ────────────────────────────────────────────────────────────
+
+
+def test_ks_identical():
+    vals = [1.0, 2.0, 3.0, 4.0, 5.0]
+    result = _compute_ks_statistic(vals, vals)
+    assert result is not None
+    assert result["statistic"] == 0.0
+    assert result["p_value"] == 1.0
+
+
+def test_ks_different_distributions():
+    base = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+    cur = [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0]
+    result = _compute_ks_statistic(base, cur)
+    assert result is not None
+    assert result["statistic"] == 1.0
+    assert result["p_value"] < 0.05
+
+
+def test_ks_too_few_values():
+    assert _compute_ks_statistic([1.0], [2.0]) is None
+
+
+# ── Integration: DataScanDiff with drift scores ─────────────────────────────
+
+
+def test_drift_scores_numeric_column():
+    base = pl.DataFrame({"x": list(range(100))})
+    cur = pl.DataFrame({"x": list(range(50, 150))})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    x_diff = next(d for d in diff.column_diffs if d.colname == "x")
+
+    assert "psi" in x_diff.drift_scores
+    assert "ks_statistic" in x_diff.drift_scores
+    assert "ks_p_value" in x_diff.drift_scores
+    assert x_diff.drift_scores["psi"] > 0.0
+
+
+def test_drift_scores_categorical_column():
+    base = pl.DataFrame({"cat": ["a"] * 50 + ["b"] * 30 + ["c"] * 20})
+    cur = pl.DataFrame({"cat": ["a"] * 20 + ["b"] * 30 + ["c"] * 50})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    cat_diff = next(d for d in diff.column_diffs if d.colname == "cat")
+
+    assert "psi" in cat_diff.drift_scores
+    assert "ks_statistic" not in cat_diff.drift_scores
+
+
+def test_drift_scores_identical_data():
+    df = pl.DataFrame({"x": list(range(20)), "y": ["a"] * 10 + ["b"] * 10})
+    scan = DataScan(data=df)
+    diff = scan.compare(scan)
+
+    for d in diff.column_diffs:
+        assert d.drift_scores == {}, f"{d.colname} has unexpected drift scores"
+    assert not diff.has_changes
+
+
+def test_drift_scores_no_raw_data():
+    df = pl.DataFrame({"x": list(range(20))})
+    scan = DataScan(data=df)
+    restored = DataScan.from_dict(scan.to_dict())
+
+    diff_data = DataScan(data=pl.DataFrame({"x": list(range(50, 70))}))
+    diff = diff_data.compare(restored)
+
+    x_diff = next(d for d in diff.column_diffs if d.colname == "x")
+    assert "ks_statistic" not in x_diff.drift_scores
+    assert "psi" not in x_diff.drift_scores
+
+
+def test_drift_scores_in_to_dict():
+    base = pl.DataFrame({"x": list(range(100))})
+    cur = pl.DataFrame({"x": list(range(50, 150))})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    d = diff.to_dict()
+
+    assert "drift_scores" in d
+    assert "x" in d["drift_scores"]
+    assert "psi" in d["drift_scores"]["x"]
+
+
+def test_drift_scores_in_tabular_report():
+    from great_tables import GT
+
+    base = pl.DataFrame({"x": list(range(100))})
+    cur = pl.DataFrame({"x": list(range(50, 150))})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    report = diff.get_tabular_report()
+    assert isinstance(report, GT)
+
+
+def test_drift_scores_not_in_report_when_absent():
+    from great_tables import GT
+
+    scan = DataScan.from_dict(
+        {
+            "metadata": {"row_count": 5, "columns": ["x"]},
+            "columns": [
+                {"colname": "x", "coltype": "Int64", "statistics": {}, "sample_data": []},
+            ],
+        }
+    )
+    diff = scan.compare(scan)
+    report = diff.get_tabular_report()
+    assert isinstance(report, GT)
+
+
+def test_drift_type_changed_no_scores():
+    base = pl.DataFrame({"x": [1, 2, 3]})
+    cur = pl.DataFrame({"x": ["a", "b", "c"]})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    x_diff = next(d for d in diff.column_diffs if d.colname == "x")
+    assert x_diff.status == "type_changed"
+    assert x_diff.drift_scores == {}
+
+
+def test_drift_added_removed_no_scores():
+    base = pl.DataFrame({"a": [1, 2]})
+    cur = pl.DataFrame({"b": [3, 4]})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    for d in diff.column_diffs:
+        assert d.drift_scores == {}
+
+
+# ── PSI interpretation thresholds ────────────────────────────────────────────
+
+
+def test_psi_no_drift_threshold():
+    """PSI < 0.1 indicates no significant drift."""
+    base = list(range(100))
+    cur = [x + 1 for x in base]
+    base_f = [float(x) for x in base]
+    cur_f = [float(x) for x in cur]
+    psi = _compute_psi_numeric(base_f, cur_f)
+    assert psi is not None
+    assert psi < 0.1
+
+
+def test_psi_major_drift_threshold():
+    """PSI > 0.25 indicates significant population shift."""
+    import random
+
+    random.seed(42)
+    base = [random.gauss(0, 1) for _ in range(200)]
+    cur = [random.gauss(5, 1) for _ in range(200)]
+    psi = _compute_psi_numeric(base, cur)
+    assert psi is not None
+    assert psi > 0.25
+
+
+def test_boolean_column_drift():
+    base = pl.DataFrame({"flag": [True] * 80 + [False] * 20})
+    cur = pl.DataFrame({"flag": [True] * 50 + [False] * 50})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    flag_diff = next(d for d in diff.column_diffs if d.colname == "flag")
+    assert "psi" in flag_diff.drift_scores
+    assert flag_diff.drift_scores["psi"] > 0.0
+
+
+# ── Edge cases ───────────────────────────────────────────────────────────────
+
+
+def test_nulls_in_numeric_column():
+    base = pl.DataFrame({"x": [1.0, 2.0, None, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0]})
+    cur = pl.DataFrame({"x": [100.0, None, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 1100.0, 1200.0]})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    x_diff = next(d for d in diff.column_diffs if d.colname == "x")
+    assert "psi" in x_diff.drift_scores
+    assert x_diff.drift_scores["psi"] > 0.0
+
+
+def test_nulls_in_categorical_column():
+    base = pl.DataFrame({"cat": ["a", "a", "b", None, "b", "a", "b", "a", "b", "a"]})
+    cur = pl.DataFrame({"cat": ["c", "c", "c", None, None, "c", "a", "a", "a", "a"]})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    cat_diff = next(d for d in diff.column_diffs if d.colname == "cat")
+    assert "psi" in cat_diff.drift_scores
+
+
+def test_all_null_column():
+    base = pl.DataFrame({"x": pl.Series([None, None, None], dtype=pl.Float64)})
+    cur = pl.DataFrame({"x": pl.Series([None, None, None], dtype=pl.Float64)})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    x_diff = next(d for d in diff.column_diffs if d.colname == "x")
+    assert x_diff.drift_scores == {}
+
+
+def test_constant_numeric_column():
+    base = pl.DataFrame({"x": [5.0] * 20})
+    cur = pl.DataFrame({"x": [5.0] * 20})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    x_diff = next(d for d in diff.column_diffs if d.colname == "x")
+    assert "psi" not in x_diff.drift_scores
+
+
+def test_single_category():
+    base = pl.DataFrame({"cat": ["a"] * 20})
+    cur = pl.DataFrame({"cat": ["a"] * 20})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    cat_diff = next(d for d in diff.column_diffs if d.colname == "cat")
+    assert cat_diff.drift_scores == {}
+
+
+def test_category_disappears():
+    base = {"a": 50, "b": 30, "c": 20}
+    cur = {"a": 80, "b": 20}
+    psi = _compute_psi_categorical(base, cur)
+    assert psi is not None
+    assert psi > 0.0
+
+
+def test_category_appears():
+    base = {"a": 80, "b": 20}
+    cur = {"a": 50, "b": 30, "c": 20}
+    psi = _compute_psi_categorical(base, cur)
+    assert psi is not None
+    assert psi > 0.0
+
+
+def test_asymmetric_sizes():
+    base = pl.DataFrame({"x": list(range(20))})
+    cur = pl.DataFrame({"x": list(range(1000))})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    x_diff = next(d for d in diff.column_diffs if d.colname == "x")
+    assert "psi" in x_diff.drift_scores
+    assert "ks_statistic" in x_diff.drift_scores
+
+
+def test_negative_and_zero_values():
+    base = pl.DataFrame({"x": [-10.0, -5.0, 0.0, 5.0, 10.0, -8.0, -3.0, 2.0, 7.0, 12.0]})
+    cur = pl.DataFrame({"x": [-100.0, -50.0, 0.0, 50.0, 100.0, -80.0, -30.0, 20.0, 70.0, 120.0]})
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+    x_diff = next(d for d in diff.column_diffs if d.colname == "x")
+    assert "psi" in x_diff.drift_scores
+    assert x_diff.drift_scores["psi"] > 0.0
+
+
+def test_psi_is_non_negative():
+    import random
+
+    random.seed(99)
+    for _ in range(10):
+        base = [random.gauss(0, 1) for _ in range(100)]
+        cur = [random.gauss(random.uniform(-2, 2), 1) for _ in range(100)]
+        psi = _compute_psi_numeric(base, cur)
+        if psi is not None:
+            assert psi >= 0.0, f"PSI should be non-negative, got {psi}"
+
+
+def test_ks_overlapping_distributions():
+    import random
+
+    random.seed(42)
+    base = [random.gauss(0, 1) for _ in range(100)]
+    cur = [random.gauss(0.5, 1) for _ in range(100)]
+    result = _compute_ks_statistic(base, cur)
+    assert result is not None
+    assert 0.0 < result["statistic"] < 1.0
+    assert 0.0 < result["p_value"] < 1.0
+
+
+def test_mixed_column_types():
+    base = pl.DataFrame({
+        "num": list(range(20)),
+        "cat": ["a"] * 10 + ["b"] * 10,
+        "flag": [True] * 15 + [False] * 5,
+    })
+    cur = pl.DataFrame({
+        "num": list(range(50, 70)),
+        "cat": ["a"] * 5 + ["b"] * 10 + ["c"] * 5,
+        "flag": [True] * 10 + [False] * 10,
+    })
+
+    diff = DataScan(data=cur).compare(DataScan(data=base))
+
+    num_diff = next(d for d in diff.column_diffs if d.colname == "num")
+    assert "psi" in num_diff.drift_scores
+    assert "ks_statistic" in num_diff.drift_scores
+
+    cat_diff = next(d for d in diff.column_diffs if d.colname == "cat")
+    assert "psi" in cat_diff.drift_scores
+    assert "ks_statistic" not in cat_diff.drift_scores
+
+    flag_diff = next(d for d in diff.column_diffs if d.colname == "flag")
+    assert "psi" in flag_diff.drift_scores

--- a/user_guide/05-data-inspection/02-col-summary-tbl.qmd
+++ b/user_guide/05-data-inspection/02-col-summary-tbl.qmd
@@ -190,8 +190,63 @@ with any statistics that shifted between the baseline and current profiles. This
 straightforward to spot when your data's shape or distribution has changed in ways that might affect
 downstream analyses or validation rules.
 
-A typical workflow is to save a baseline profile after your initial data quality checks pass, then
-compare new data against that baseline on each pipeline run:
+### Statistical Drift Measures
+
+When both the baseline and current `DataScan` objects have their original data attached (i.e., they
+haven't been loaded from disk), the comparison also computes formal drift statistics for each
+column:
+
+- **PSI (Population Stability Index)**: Measures how much a distribution has shifted. Computed for
+both numeric and categorical columns. Values below 0.1 indicate no meaningful drift, 0.1 to 0.25
+suggests moderate drift, and above 0.25 signals a significant population shift.
+- **KS (Kolmogorov-Smirnov) test**: For numeric columns only, this measures the maximum distance
+between two empirical CDFs and provides a p-value. A small p-value (e.g., below 0.05) indicates the
+two distributions are statistically different.
+
+These scores appear in the `drift_scores` field of the comparison dictionary and in the "Drift
+Scores" column of the generated report. Let's look at a more dramatic drift example to see them in
+action:
+
+```{python}
+# Baseline: normal revenue range
+revenue_v1 = pl.DataFrame({
+    "amount": [10.0, 25.0, 15.0, 30.0, 20.0, 12.0, 18.0, 22.0, 28.0, 35.0,
+               14.0, 26.0, 19.0, 31.0, 23.0, 11.0, 17.0, 29.0, 33.0, 21.0],
+    "category": (["electronics"] * 8 + ["clothing"] * 7 + ["food"] * 5),
+})
+
+# Current: large orders have appeared, category mix shifted
+revenue_v2 = pl.DataFrame({
+    "amount": [10.0, 25.0, 15.0, 30.0, 20.0, 150.0, 200.0, 175.0, 180.0, 160.0,
+               14.0, 26.0, 190.0, 170.0, 165.0, 11.0, 17.0, 155.0, 185.0, 195.0],
+    "category": (["electronics"] * 12 + ["clothing"] * 3 + ["food"] * 5),
+})
+
+baseline = pb.DataScan(data=revenue_v1, tbl_name="revenue_v1")
+current = pb.DataScan(data=revenue_v2, tbl_name="revenue_v2")
+
+diff = current.compare(baseline)
+diff.get_tabular_report()
+```
+
+The drift scores are also available programmatically through `to_dict()`:
+
+```{python}
+drift = diff.to_dict().get("drift_scores", {})
+for col_name, scores in drift.items():
+    print(f"{col_name}: {scores}")
+```
+
+When a `DataScan` is loaded from a saved JSON file (with no original data attached), drift scores
+cannot be computed. The comparison still reports schema changes and raw stat differences, but the
+`drift_scores` field will be empty. If you need drift scores in a persist-and-compare workflow,
+keep the original data available when calling `compare()`.
+
+### A Typical Workflow
+
+In practice, drift detection works best as a two-phase process. First, you establish a baseline
+profile once your data quality checks pass and save it to disk. Then, on each subsequent pipeline
+run, you load that baseline and compare it against a fresh scan of the incoming data.
 
 ```python
 # On the first run: establish the baseline
@@ -207,3 +262,24 @@ if diff.has_changes:
     print("Data drift detected!")
     print(diff.to_dict())
 ```
+
+The key thing to notice is that the baseline is loaded from a saved JSON file, so it won't have
+original data attached. This means drift scores (PSI and KS) won't be computed for the loaded
+baseline. If you need those scores, keep the baseline data accessible and create a fresh `DataScan`
+from it rather than loading from JSON.
+
+The `has_changes` property gives you a simple boolean for CI pipelines or alerting. So if anything
+shifted (schema or statistics) you can easily flag it. For more granular decisions, inspect
+`columns_added`, `columns_removed`, `columns_type_changed`, and the per-column `stat_diffs` and
+`drift_scores` in the object provided by `to_dict()`.
+
+## Conclusion
+
+The `col_summary_tbl()` function and the `DataScan` class give you two levels of access to
+column-level profiling. The function is a quick, visual summary you can drop into a notebook to
+understand a dataset at a glance. The class provides the same statistics in a structured form that
+you can save, load, and compare over time. When your data evolves, `compare()` catches schema drift
+(columns added, removed, or retyped) and statistical drift (shifts in means, quantiles, null rates,
+and frequency distributions), optionally backed by formal measures like PSI and the KS test.
+Together, these tools make it straightforward to move from initial data discovery to ongoing data
+quality monitoring.


### PR DESCRIPTION
This PR adds data drift detection capabilities to the `DataScanDiff` class. It introduces new methods for calculating drift metrics such as PSI (Population Stability Index) and the KS (Kolmogorov-Smirnov) statistic for both numeric and categorical columns. The drift results are included in the diff output and are displayed in the tabular report. This feature generally makes it easier to identify significant changes in data distributions between scans.