### PR TITLE
Update retired Anthropic model ids in the skills docs

### DIFF
--- a/skills/draft-validation/SKILL.md
+++ b/skills/draft-validation/SKILL.md
@@ -36,7 +36,7 @@ import pointblank as pb
 # Draft a validation plan from data
 draft = pb.DraftValidation(
     data=df,
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
 )
 
 # View the generated code
@@ -76,7 +76,7 @@ Give data to an LLM and get back a validation plan:
 ```python
 draft = pb.DraftValidation(
     data=df,
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
     api_key=None,          # uses env var by default
     max_reprompts=1,       # retries on invalid code
 )
@@ -108,7 +108,7 @@ Modify an existing validation plan with natural language:
 edit = pb.EditValidation(
     validation=existing_validation,
     instruction="Add a check that order_id is unique and amount is positive",
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
 )
 
 # From Python code string
@@ -122,7 +122,7 @@ edit = pb.EditValidation(
 edit = pb.EditValidation(
     validation="validation.yaml",
     instruction="Add threshold warnings at 5%",
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
 )
 ```
 
@@ -149,7 +149,7 @@ You can supply data to the edit for context:
 edit = pb.EditValidation(
     validation=existing_validation,
     instruction="Add checks for the new columns",
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
     data=updated_df,
 )
 ```
@@ -161,14 +161,14 @@ Chat with an LLM about data validation:
 ```python
 # Browser-based chat (default)
 pb.assistant(
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
     data=df,
     tbl_name="orders",
 )
 
 # Terminal-based chat
 pb.assistant(
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
     data=df,
     display="terminal",
 )
@@ -187,7 +187,7 @@ All LLM features use the format `"provider:model_name"`:
 
 ```python
 # Anthropic
-model="anthropic:claude-sonnet-4-20250514"
+model="anthropic:claude-sonnet-4-6"
 model="anthropic:claude-haiku-4-5-20251001"
 
 # OpenAI
@@ -222,7 +222,7 @@ Or pass explicitly:
 ```python
 draft = pb.DraftValidation(
     data=df,
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
     api_key="sk-...",
 )
 ```

--- a/skills/draft-validation/references/providers-reference.md
+++ b/skills/draft-validation/references/providers-reference.md
@@ -9,9 +9,9 @@ Format: `"provider:model_name"`
 ### Anthropic
 
 ```python
-model="anthropic:claude-sonnet-4-20250514"
+model="anthropic:claude-sonnet-4-6"
 model="anthropic:claude-haiku-4-5-20251001"
-model="anthropic:claude-opus-4-20250514"
+model="anthropic:claude-opus-4-8"
 ```
 
 Environment variable: `ANTHROPIC_API_KEY`
@@ -85,7 +85,7 @@ export OPENAI_API_KEY="sk-..."
 ```python
 draft = pb.DraftValidation(
     data=df,
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
     api_key="sk-ant-...",
 )
 ```
@@ -97,7 +97,7 @@ For environments with custom certificates:
 ```python
 draft = pb.DraftValidation(
     data=df,
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
     verify_ssl=False,
 )
 ```

--- a/skills/pointblank/references/validation-methods.md
+++ b/skills/pointblank/references/validation-methods.md
@@ -144,7 +144,7 @@ compares against the reference column.
 ```python
 .prompt(
     prompt="Check if product names are appropriate",
-    model="anthropic:claude-sonnet-4-20250514",
+    model="anthropic:claude-sonnet-4-6",
     columns_subset=["product_name"],
     batch_size=1000,
     max_concurrent=3,


### PR DESCRIPTION
The Anthropic examples in the skills folder use two model ids that Anthropic retired on 15 June 2026, so anyone who copies them into `DraftValidation`, `EditValidation`, `assistant` or `prompt` is passing an id the API no longer serves.

| File | Old id | New id | Lines |
| --- | --- | --- | --- |
| `skills/draft-validation/SKILL.md` | `anthropic:claude-sonnet-4-20250514` | `anthropic:claude-sonnet-4-6` | 9 |
| `skills/draft-validation/references/providers-reference.md` | `anthropic:claude-sonnet-4-20250514` | `anthropic:claude-sonnet-4-6` | 3 |
| `skills/draft-validation/references/providers-reference.md` | `anthropic:claude-opus-4-20250514` | `anthropic:claude-opus-4-8` | 1 |
| `skills/pointblank/references/validation-methods.md` | `anthropic:claude-sonnet-4-20250514` | `anthropic:claude-sonnet-4-6` | 1 |

Retirement dates are on the Anthropic deprecations page: https://platform.claude.com/docs/en/about-claude/model-deprecations

The `anthropic:claude-haiku-4-5-20251001` lines sitting next to these are current, so they are untouched.

Three things I left alone on purpose.

Bedrock ids such as `bedrock:anthropic.claude-sonnet-4-20250514-v1:0` in `SKILL.md`, `providers-reference.md` and `user_guide/02-advanced-validation/04-draft-validation.qmd` keep their own availability schedule on the AWS side, and I did not want to guess at it for you.

`tests/test_prompt_method.py` passes old ids to mocked calls, where the string never reaches the API. Changing it would only add diff noise.

`_freeze/user-guide/advanced-validation/draft-validation/execute-results/html.json` is rendered output, so it belongs to whatever regenerates it.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not run pointblank against the API to reproduce a failure, the claim rests on the published retirement dates. If you would rather pick different replacement ids, or would rather not get this kind of contribution at all, tell me and I will not send another.
